### PR TITLE
ci: Add auto-approve workflow for stuartshay PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,24 @@
+name: Auto Approve
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'stuartshay'
+    steps:
+      - name: Auto approve PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE'
+            });


### PR DESCRIPTION
Add GitHub Actions workflow that auto-approves PRs authored by stuartshay using github-actions[bot]. This enables branch protection with required reviews while allowing the solo maintainer to merge their own PRs.