### PR TITLE
feat: Add OpenTelemetry trace correlation with New Relic

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ make docker-run
 | `CORS_ORIGINS` | `*` | Allowed CORS origins |
 | `OTEL_SERVICE_NAME` | `otel-data-api` | OTel service name |
 | `NEW_RELIC_LICENSE_KEY` | — | New Relic license key (optional) |
+| `NEW_RELIC_APP_NAME` | `otel-data-api` | New Relic application name |
+| `NEW_RELIC_APPLICATION_LOGGING_ENABLED` | `true` | Enable NR log collection |
+| `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED` | `true` | Forward logs to NR |
+| `NEW_RELIC_LOG` | `stdout` | NR agent log destination |
+| `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED` | `true` | Enable distributed tracing |
 
 ## Database Schema
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.auth import configure_auth
 from app.config import Config
 from app.database import DatabaseService
+from app.middleware import SPAN_ID_HEADER, TRACE_ID_HEADER, TraceCorrelationMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,9 @@ def create_app(config: Config) -> FastAPI:
         lifespan=lifespan,
     )
 
+    # Trace correlation — injects X-Trace-Id / X-Span-Id response headers
+    app.add_middleware(TraceCorrelationMiddleware)
+
     # CORS
     if config.cors_origins:
         app.add_middleware(
@@ -50,6 +54,7 @@ def create_app(config: Config) -> FastAPI:
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
+            expose_headers=[TRACE_ID_HEADER, SPAN_ID_HEADER],
         )
 
     # Auth

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,0 +1,40 @@
+"""Middleware for trace correlation headers and request context."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Response header names for trace correlation
+TRACE_ID_HEADER = "X-Trace-Id"
+SPAN_ID_HEADER = "X-Span-Id"
+
+
+class TraceCorrelationMiddleware(BaseHTTPMiddleware):
+    """Inject New Relic trace/span IDs into response headers.
+
+    Enables distributed tracing correlation between services by exposing
+    trace context in HTTP response headers. When New Relic agent is not
+    active, the middleware is a no-op.
+    """
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        response = await call_next(request)
+        try:
+            import newrelic.agent  # pyright: ignore[reportMissingImports]
+
+            trace_id = newrelic.agent.current_trace_id()
+            span_id = newrelic.agent.current_span_id()
+            if trace_id:
+                response.headers[TRACE_ID_HEADER] = trace_id
+            if span_id:
+                response.headers[SPAN_ID_HEADER] = span_id
+        except Exception:  # noqa: BLE001
+            pass  # New Relic not available — skip silently
+        return response

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -134,7 +134,13 @@ queries, and optional AWS Cognito JWT authentication.
 
 ### Tasks
 
-- [ ] Add OpenTelemetry trace correlation (response headers, log injection)
+- [x] Add OpenTelemetry trace correlation (response headers, log injection)
+  - Added `TraceCorrelationMiddleware` injecting `X-Trace-Id` / `X-Span-Id`
+    response headers from New Relic agent trace context
+  - Enabled `NewRelicContextFormatter` for log-trace correlation (injects
+    `trace.id`, `span.id`, `entity.name` into log records)
+  - CORS `expose_headers` configured for frontend access to trace headers
+  - 3 unit tests covering NR-active, NR-absent, and graceful fallback
 - [ ] Add `/api/v1/locations` write endpoints (POST for ingesting data)
 - [ ] Add rate limiting middleware
 - [ ] Add response caching for expensive spatial queries

--- a/run.py
+++ b/run.py
@@ -24,7 +24,20 @@ if os.getenv("NEW_RELIC_LICENSE_KEY"):
 
         newrelic.agent.initialize()
         newrelic.agent.register_application(timeout=10)
-        logger.info("New Relic agent initialized")
+
+        # Enable log-trace correlation by replacing the root log formatter
+        # with NewRelicContextFormatter, which injects trace.id, span.id,
+        # and entity metadata into every log record.
+        from newrelic.agent import NewRelicContextFormatter  # pyright: ignore[reportMissingImports]
+
+        for handler in logging.root.handlers:
+            handler.setFormatter(
+                NewRelicContextFormatter(
+                    "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+                ),
+            )
+
+        logger.info("New Relic agent initialized with trace correlation")
     except Exception:
         logger.exception("New Relic agent failed to initialize — continuing without it")
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,42 @@
+"""Tests for trace correlation middleware."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_trace_headers_present_when_nr_active(client: AsyncClient):
+    """Response includes X-Trace-Id and X-Span-Id when New Relic is active."""
+    mock_nr = MagicMock()
+    mock_nr.current_trace_id.return_value = "trace-001"
+    mock_nr.current_span_id.return_value = "span-002"
+
+    mock_parent = MagicMock()
+    mock_parent.agent = mock_nr
+
+    with patch.dict("sys.modules", {"newrelic": mock_parent, "newrelic.agent": mock_nr}):
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers.get("X-Trace-Id") == "trace-001"
+    assert response.headers.get("X-Span-Id") == "span-002"
+
+
+@pytest.mark.asyncio
+async def test_trace_headers_absent_without_nr(client: AsyncClient):
+    """Response does NOT include trace headers when New Relic is not active."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert "X-Trace-Id" not in response.headers
+    assert "X-Span-Id" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_middleware_does_not_break_responses(client: AsyncClient):
+    """Middleware gracefully handles missing New Relic — requests still work."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"


### PR DESCRIPTION
## Summary

Implements OpenTelemetry trace correlation (response headers + log injection) using the New Relic Python agent. This enables distributed tracing visibility and log-trace correlation in the New Relic UI.

## Changes

### Trace Correlation Middleware (`app/middleware.py`)
- New `TraceCorrelationMiddleware` that injects `X-Trace-Id` and `X-Span-Id` response headers from the active New Relic transaction
- Graceful no-op when New Relic agent is not active (env-gated)

### Log-Trace Correlation (`run.py`)
- When New Relic is initialized, replaces the root log formatter with `NewRelicContextFormatter`
- Automatically injects `trace.id`, `span.id`, and `entity.name` into every log record
- Enables one-click log-to-trace navigation in New Relic UI

### CORS Configuration (`app/__init__.py`)
- Registered `TraceCorrelationMiddleware` in the app factory
- Added `X-Trace-Id` and `X-Span-Id` to CORS `expose_headers` for frontend access

### Tests (`tests/test_middleware.py`)
- 3 tests: NR-active (headers present), NR-absent (headers absent), graceful fallback

### Documentation
- Added New Relic env vars to README environment variables table
- Updated PROJECT_PLAN.md — marked trace correlation task as completed

## Testing

- All 39 tests pass
- All 18 pre-commit hooks pass (ruff, mypy, pyright, detect-secrets, etc.)

## Deployment Notes

After merge, the k8s-gitops ConfigMap and sealed secret need to be updated with New Relic env vars for the cluster deployment (separate PR).