### PR TITLE
feat: Add New Relic deployment marker to CI/CD pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -160,6 +160,48 @@ jobs:
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
         continue-on-error: true
 
+      - name: Record New Relic deployment marker
+        if: github.ref == 'refs/heads/master'
+        env:
+          NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+          NEW_RELIC_APP_GUID: ${{ secrets.NEW_RELIC_APP_GUID }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DESCRIPTION="${{ env.IMAGE_NAME }} v${VERSION}"
+
+          QUERY='mutation($version: String!, $entityGuid: EntityGuid!, $commit: String, $user: String, $description: String) {
+            changeTrackingCreateDeployment(deployment: {
+              version: $version
+              entityGuid: $entityGuid
+              commit: $commit
+              user: $user
+              description: $description
+            }) { deploymentId entityGuid }
+          }'
+
+          PAYLOAD=$(jq -n \
+            --arg query "$QUERY" \
+            --arg version "$VERSION" \
+            --arg entityGuid "$NEW_RELIC_APP_GUID" \
+            --arg commit "${{ github.sha }}" \
+            --arg user "${{ github.actor }}" \
+            --arg description "$DESCRIPTION" \
+            '{query: $query, variables: {version: $version, entityGuid: $entityGuid, commit: $commit, user: $user, description: $description}}')
+
+          RESPONSE=$(curl -s -X POST 'https://api.newrelic.com/graphql' \
+            -H 'Content-Type: application/json' \
+            -H "API-Key: ${NEW_RELIC_API_KEY}" \
+            -d "$PAYLOAD")
+
+          if echo "${RESPONSE}" | jq -e '.data.changeTrackingCreateDeployment.deploymentId' > /dev/null 2>&1; then
+            DEPLOY_ID=$(echo "${RESPONSE}" | jq -r '.data.changeTrackingCreateDeployment.deploymentId')
+            echo "✅ Deployment marker recorded: ${DEPLOY_ID}"
+          else
+            echo "⚠️ Failed to record deployment marker"
+            echo "${RESPONSE}"
+          fi
+        continue-on-error: true
+
       - name: Summary
         run: |
           echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a New Relic deployment marker step to the Docker build workflow. After each production Docker push, a deployment marker is recorded in New Relic via the NerdGraph `changeTrackingCreateDeployment` mutation.

## Changes

- Added "Record New Relic deployment marker" step to `docker.yml`
- Runs on master branch pushes only (after Docker push + k8s-gitops trigger)
- Uses `jq` to safely build the GraphQL payload (no escaping issues)
- Records version, commit SHA, actor, and image name
- `continue-on-error: true` — won't block the pipeline if NR is unreachable

## Required Secrets

| Secret | Description |
|--------|-------------|
| `NEW_RELIC_API_KEY` | NR User API Key (`NRAK-...`) |
| `NEW_RELIC_APP_GUID` | NR Entity GUID for otel-data-api |

## Phase 2 of Deployment Observability

Part of the 6-phase deployment observability plan. Enables deployment markers visible in NR APM → Deployments view.