### PR TITLE
docs: add README badges for CI, Docker Hub, and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # OTel Data API
 
+[![Lint](https://github.com/stuartshay/otel-data-api/actions/workflows/lint.yml/badge.svg)](https://github.com/stuartshay/otel-data-api/actions/workflows/lint.yml)
+[![Docker](https://github.com/stuartshay/otel-data-api/actions/workflows/docker.yml/badge.svg)](https://github.com/stuartshay/otel-data-api/actions/workflows/docker.yml)
+[![Publish Types](https://github.com/stuartshay/otel-data-api/actions/workflows/publish-types.yml/badge.svg)](https://github.com/stuartshay/otel-data-api/actions/workflows/publish-types.yml)
+[![Docker Hub](https://img.shields.io/badge/Docker%20Hub-stuartshay%2Fotel--data--api-blue?logo=docker)](https://hub.docker.com/repository/docker/stuartshay/otel-data-api)
+[![npm](https://img.shields.io/npm/v/@stuartshay/otel-data-types?logo=npm&label=otel-data-types)](https://www.npmjs.com/package/@stuartshay/otel-data-types)
+[![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-latest-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
+
 FastAPI microservice providing read/write access to the OwnTracks + Garmin
 location database with PostGIS spatial queries.
 


### PR DESCRIPTION
Add status badges to README matching the otel-worker pattern:

- **Lint** — GitHub Actions CI badge
- **Docker** — Docker build workflow badge
- **Publish Types** — npm types publish workflow badge
- **Docker Hub** — stuartshay/otel-data-api image link
- **npm** — @stuartshay/otel-data-types package badge
- **Python** — v3.12 version badge
- **FastAPI** — framework badge