### PR TITLE
docs: Add OpenAPI field descriptions and enhance Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,12 +185,20 @@ export SCRIPT_DB_TABLES
 
 db-test: ## Test database connection
 	@echo "$(YELLOW)Testing database connection...$(NC)"
+	@if [ ! -f .env ]; then \
+		echo "$(RED)✗ .env file not found. Run './setup.sh' to create it.$(NC)"; \
+		exit 1; \
+	fi
 	@set -a; . ./.env; set +a; \
 	. $(VENV_DIR)/bin/activate && \
 	python3 -c "$$SCRIPT_DB_TEST"
 
 db-tables: ## List database tables
 	@echo "$(YELLOW)Listing database tables...$(NC)"
+	@if [ ! -f .env ]; then \
+		echo "$(RED)✗ .env file not found. Run './setup.sh' to create it.$(NC)"; \
+		exit 1; \
+	fi
 	@set -a; . ./.env; set +a; \
 	. $(VENV_DIR)/bin/activate && \
 	python3 -c "$$SCRIPT_DB_TABLES"
@@ -212,6 +220,10 @@ dependencies: ## Check for outdated Python packages
 
 openapi: ## Generate OpenAPI schema to output directory
 	@echo "$(YELLOW)Generating OpenAPI schema...$(NC)"
+	@if [ ! -f .env ]; then \
+		echo "$(RED)✗ .env file not found. Run './setup.sh' to create it.$(NC)"; \
+		exit 1; \
+	fi
 	@mkdir -p output
 	@set -a; . ./.env; set +a; \
 	. $(VENV_DIR)/bin/activate && \


### PR DESCRIPTION
## Summary

Adds comprehensive OpenAPI documentation to all Pydantic models and FastAPI router parameters, and enhances the Makefile with new utility targets.

## OpenAPI Documentation (11 files)

### Model Fields (123 fields across 5 files)
- **`app/models/__init__.py`** — 8 fields: PaginatedResponse, ErrorResponse, HealthResponse
- **`app/models/locations.py`** — 20 fields: Location, LocationDetail, DeviceInfo, LocationCount
- **`app/models/garmin.py`** — 44 fields: GarminActivity, GarminTrackPoint, GarminChartPoint, SportInfo
- **`app/models/reference.py`** — 19 fields: ReferenceLocation, ReferenceLocationCreate, ReferenceLocationUpdate
- **`app/models/spatial.py`** — 32 fields: UnifiedGpsPoint, DailyActivitySummary, NearbyPoint, DistanceResult, WithinReferenceResult

### Router Parameters (19 params across 5 files)
- **`app/routers/locations.py`** — `limit`, `offset`, `order` descriptions + `location_id` Path
- **`app/routers/garmin.py`** — 6 params (limit/offset/order × 2 endpoints)
- **`app/routers/unified.py`** — 4 params (limit/offset/order + daily limit)
- **`app/routers/reference.py`** — 3 `location_id` Path params
- **`app/routers/spatial.py`** — 2 limit params

### Bug Fix
- Removed 12 duplicate unreachable `return LocationDetail(**data)` statements in `locations.py`

## Makefile & Config
- Fix `db-test` and `db-tables` targets (async def multiline handling)
- Add `make dependencies`, `make openapi` targets
- Add `output/` to `.gitignore`
- Optimize `renovate.json` configuration
- Add `kilometre`, `kilometres`, `MQTT`, `optimised` to cspell dictionary

## Validation
- ✅ All 19 pre-commit hooks pass
- ✅ All 45 tests pass
- ✅ OpenAPI spec regenerated and verified