### PR TITLE
fix: remove server_settings from asyncpg pool (PgBouncer incompatible)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,10 @@ def create_app(config: Config) -> FastAPI:
             app.state.db = db
             logger.info("Application started — database pool ready")
         except Exception:
-            logger.warning("Database initialization failed — starting without DB")
+            logger.warning(
+                "Database initialization failed \u2014 starting without DB",
+                exc_info=True,
+            )
             app.state.db = db
         yield
         # Shutdown

--- a/app/database.py
+++ b/app/database.py
@@ -46,7 +46,6 @@ class DatabaseService:
             min_size=self._config.db_pool_min,
             max_size=self._config.db_pool_max,
             command_timeout=self._config.db_connect_timeout,
-            server_settings={"statement_timeout": str(self._config.db_statement_timeout_ms)},
         )
         logger.info(
             "Database pool initialized",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -52,7 +52,7 @@ async def test_initialize_creates_pool(monkeypatch: pytest.MonkeyPatch, config):
     assert captured["min_size"] == config.db_pool_min
     assert captured["max_size"] == config.db_pool_max
     assert captured["command_timeout"] == config.db_connect_timeout
-    assert captured["server_settings"] == {"statement_timeout": str(config.db_statement_timeout_ms)}
+    assert "server_settings" not in captured
 
 
 def test_pool_property_requires_initialize(config):


### PR DESCRIPTION
## Problem

**Production outage**: otel-data-api v1.0.149 cannot connect to PostgreSQL via PgBouncer. Every pod startup logs:
```
Database initialization failed — starting without DB
```

All data endpoints return errors while `/health` and `/ready` probes continue passing, masking the failure.

## Root Cause

The `server_settings={"statement_timeout": "15000"}` parameter added in PR #53 is passed by asyncpg as a PostgreSQL **startup parameter** in the wire protocol. PgBouncer rejects unrecognized startup parameters:

```
ProtocolViolationError: unsupported startup parameter: statement_timeout
```

This prevented `asyncpg.create_pool()` from establishing any connections. Unlike `psql` which uses `SET statement_timeout` (a SQL command), asyncpg's `server_settings` sends parameters during connection negotiation — which PgBouncer does not support.

## Fix

- **Remove `server_settings`** from `asyncpg.create_pool()` — restores PgBouncer compatibility
- **Existing `command_timeout=10s`** already provides query-level timeout protection (client-side via asyncio)
- **Log actual exception** in lifespan startup for better diagnostics (`exc_info=True`)
- **Update test** to verify `server_settings` is not passed

## Testing

- All 88 tests pass
- Pre-commit checks pass
- Verified PgBouncer connection works without `server_settings`:
  ```python
  # FAILS:
  asyncpg.create_pool(..., server_settings={"statement_timeout": "15000"})
  # ProtocolViolationError: unsupported startup parameter: statement_timeout

  # WORKS:
  asyncpg.create_pool(...) # without server_settings
  ```