### PR TITLE
feat: Add repository_dispatch to otel-data-gateway on types publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -347,6 +347,7 @@ jobs:
           echo "version=${PKG_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Trigger otel-data-gateway types update
+        id: gateway_dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITOPS_PAT }}
@@ -357,6 +358,11 @@ jobs:
 
       - name: Summary
         run: |
+          if [ "${{ steps.gateway_dispatch.outcome }}" = "success" ]; then
+            DISPATCH_STATUS="✅"
+          else
+            DISPATCH_STATUS="❌ (${{ steps.gateway_dispatch.outcome }})"
+          fi
           {
             echo "## npm Package Published"
             echo ""
@@ -365,5 +371,5 @@ jobs:
             echo "| Package | \`@stuartshay/otel-data-types\` |"
             echo "| Version | \`${{ steps.types_version.outputs.version }}\` |"
             echo "| Run # | \`${{ github.run_number }}\` |"
-            echo "| Gateway Dispatch | ✅ |"
+            echo "| Gateway Dispatch | ${DISPATCH_STATUS} |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a `repository_dispatch` step to the `publish-types` job in `docker.yml` so that when `@stuartshay/otel-data-types` is published to npm (on schema changes), the otel-data-gateway repo is notified to update its dependency.

### Changes

- **`.github/workflows/docker.yml`**: Added `types_version` step to extract the published version, and a `repository_dispatch` step that sends `otel-data-types-release` event to `stuartshay/otel-data-gateway` with the version payload
- Updated the Summary step to include the gateway dispatch status

### Flow

```
otel-data-api master push
  → Docker build
  → Schema check (detects changes in index.d.ts/openapi.json)
  → Publish types to npm
  → NEW: Dispatch otel-data-types-release to otel-data-gateway
  → otel-data-gateway creates/updates PR to bump types version
```

### Companion PR

- stuartshay/otel-data-gateway — feat: Add automated types update workflow (handles the receiving side)