### PR TITLE
chore: Merge develop into master — dispatch fixes and template cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,8 @@
 ---
 name: Bug Report
 description: Report a bug in otel-data-api
-title: "bug: "
-labels: ["bug"]
+title: 'bug: '
+labels: ['bug']
 body:
   - type: markdown
     attributes:
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Affected Endpoint
       description: Which API endpoint is affected?
-      placeholder: "e.g., GET /api/v1/locations, POST /api/v1/reference-locations"
+      placeholder: 'e.g., GET /api/v1/locations, POST /api/v1/reference-locations'
     validations:
       required: true
 
@@ -72,7 +72,7 @@ body:
     attributes:
       label: Version
       description: API version from /health endpoint
-      placeholder: "e.g., 1.0.158"
+      placeholder: 'e.g., 1.0.158'
 
   - type: textarea
     id: logs


### PR DESCRIPTION
## Summary

Merge `develop` into `master` with the following changes:

### Changes

- **feat**: Add `repository_dispatch` to otel-data-gateway on types publish
- **fix**: Show actual dispatch outcome in publish-types summary
- **style**: Normalize YAML quotes in bug report template

### Notes

- Rebased onto latest `master` — no conflicts
- PR #58 review fix commit (`a69c73d`) was automatically dropped during rebase (already upstream via squash merge)
- Pre-commit checks pass on all commits