### PR TITLE
chore: enforce post-deploy AC checks and trigger gateway types update

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,23 @@ git fetch origin master && git rebase origin/master
 This is especially important after squash merges, which cause develop to
 diverge from master.
 
+### After Deployment (Required)
+
+⚠️ **ALWAYS verify linked issue acceptance criteria after cluster deployment**
+before considering work complete.
+
+1. Track the implementation issue linked to the code PR.
+2. Complete deployment via the corresponding deployment PR (for example in
+   `k8s-gitops`).
+3. Validate each acceptance-criteria checkbox against the deployed cluster
+   behavior (not only local tests/CI).
+4. Post verification evidence on the issue (commands, API responses, logs, or
+   screenshots as applicable).
+5. Only then mark the issue/project item as done.
+
+If an issue is auto-closed by merge keywords (`Closes #...`) before deployment
+validation is complete, reopen it until acceptance criteria are confirmed.
+
 ### Daily Workflow
 
 1. **ALWAYS** start from `develop` or create a feature branch

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -54,6 +54,22 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Get published version
+        id: types_version
+        run: |
+          PKG_VERSION=$(jq -r '.version' ${{ env.TYPES_PKG_DIR }}/package.json)
+          echo "version=${PKG_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger otel-data-gateway types update
+        id: gateway_dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITOPS_PAT }}
+          repository: stuartshay/otel-data-gateway
+          event-type: otel-data-types-release
+          client-payload: '{"version": "${{ steps.types_version.outputs.version }}"}'
+        continue-on-error: true
+
       - name: Attach OpenAPI spec to release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -64,13 +80,19 @@ jobs:
 
       - name: Summary
         run: |
+          if [ "${{ steps.gateway_dispatch.outcome }}" = "success" ]; then
+            DISPATCH_STATUS="✅"
+          else
+            DISPATCH_STATUS="❌ (${{ steps.gateway_dispatch.outcome }})"
+          fi
           {
             echo "## npm Package Published"
             echo ""
             echo "| Property | Value |"
             echo "|----------|-------|"
             echo "| Package | \`@stuartshay/otel-data-types\` |"
-            echo "| Version | \`${GITHUB_REF_NAME#v}\` |"
+            echo "| Version | \`${{ steps.types_version.outputs.version }}\` |"
             echo "| Release | \`${{ github.event.release.tag_name }}\` |"
             echo "| Spec | \`docs/openapi.json\` attached |"
+            echo "| Gateway Dispatch | ${DISPATCH_STATUS} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ All automation, assistants, and developers must follow
 - **Run dev**: `make dev`
 - **Test**: `make test`
 - **API Docs**: <http://localhost:8080/docs>
+- **Post-deploy check**: after cluster deploy, verify linked issue acceptance
+  criteria and record evidence before marking work complete
 
 ## Development Workflow
 
@@ -31,6 +33,8 @@ All automation, assistants, and developers must follow
 5. Run `make test`
 6. Commit and push to `develop` or `feature/*` branch
 7. Create PR to `master` when ready for production
+8. After deployment PR merges (for example in `k8s-gitops`), validate every
+   linked issue acceptance criterion in-cluster before closing/confirming done
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- add required post-deployment acceptance-criteria validation guidance
- ensure release-based types publishing dispatches `otel-data-types-release` to `otel-data-gateway`
- include dispatch status in workflow summary output

## Files Changed
- `.github/copilot-instructions.md`
- `.github/workflows/publish-types.yml`
- `AGENTS.md`

## Why
- prevent issues from being marked complete before in-cluster acceptance criteria are validated
- fix the workflow gap where npm package publish did not trigger the gateway auto-update PR path

## Validation
- pre-commit hooks passed during commit and push
- GitHub Actions workflow YAML lint passed locally via pre-commit
