### PR TITLE
docs: require downstream types PR verification after publish

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,21 @@ before considering work complete.
 If an issue is auto-closed by merge keywords (`Closes #...`) before deployment
 validation is complete, reopen it until acceptance criteria are confirmed.
 
+### After Types Publish (Required)
+
+⚠️ **ALWAYS verify the downstream dependency PR after publishing
+`@stuartshay/otel-data-types`.**
+
+1. Confirm `.github/workflows/publish-types.yml` completed successfully.
+2. Verify a new dependency-update PR is created in `otel-data-gateway` (title
+   pattern: `📦 Update @stuartshay/otel-data-types to vX.Y.Z`).
+3. Confirm the PR version bump matches the published npm version and CI checks
+   are green.
+4. Link that downstream PR in the originating issue/PR before marking work
+   complete.
+5. If no PR is created or checks fail, open/fix the workflow issue and rerun
+   until a valid PR exists.
+
 ### Daily Workflow
 
 1. **ALWAYS** start from `develop` or create a feature branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ All automation, assistants, and developers must follow
 - **API Docs**: <http://localhost:8080/docs>
 - **Post-deploy check**: after cluster deploy, verify linked issue acceptance
   criteria and record evidence before marking work complete
+- **Types release check**: after `publish-types.yml` publishes
+  `@stuartshay/otel-data-types`, verify the downstream update PR is created in
+  `otel-data-gateway`
 
 ## Development Workflow
 
@@ -35,6 +38,8 @@ All automation, assistants, and developers must follow
 7. Create PR to `master` when ready for production
 8. After deployment PR merges (for example in `k8s-gitops`), validate every
    linked issue acceptance criterion in-cluster before closing/confirming done
+9. If `packages/otel-data-types` changed, confirm the corresponding
+   `otel-data-gateway` dependency-update PR exists and is linked for follow-up
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary\n\nAdd explicit workflow requirements so post-publish validation includes downstream dependency PR checks for `@stuartshay/otel-data-types`.\n\n## Changes\n\n- update `AGENTS.md` quick reference + workflow steps with required downstream PR verification\n- add `After Types Publish (Required)` section to `.github/copilot-instructions.md`\n- document expected PR title pattern and required follow-up actions when PR is missing or failing\n\n## Why\n\nThis prevents publish/deploy completion from being marked done before confirming the auto-created `otel-data-gateway` update PR exists and passes checks.\n\n---\n\n**Closing — superseded by #66** which included all these changes plus additional release hygiene workflow documentation.