### PR TITLE
feat: Add release hygiene workflow and types dispatch docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,49 @@ before considering work complete.
 If an issue is auto-closed by merge keywords (`Closes #...`) before deployment
 validation is complete, reopen it until acceptance criteria are confirmed.
 
+### After Types Publish (Required)
+
+⚠️ **ALWAYS verify the downstream dependency PR after publishing
+`@stuartshay/otel-data-types`.**
+
+1. Confirm `.github/workflows/publish-types.yml` completed successfully.
+2. Verify a new dependency-update PR is created in `otel-data-gateway` (title
+   pattern: `📦 Update @stuartshay/otel-data-types to vX.Y.Z`).
+3. Confirm the PR version bump matches the published npm version and CI checks
+   are green.
+4. Link that downstream PR in the originating issue/PR before marking work
+   complete.
+5. If no PR is created or checks fail, open/fix the workflow issue and rerun
+   until a valid PR exists.
+
+### Release Hygiene Completion (Required)
+
+⚠️ **ALWAYS complete issue/project hygiene before setting work to Done.**
+
+1. If any earlier comment says validation is blocked, add a new superseding
+   comment after resolution that clearly states criteria are now satisfied.
+2. Ensure acceptance criteria are explicitly marked complete by either:
+   - updating issue checkboxes, or
+   - posting a final checklist comment that maps each criterion to pass/fail
+     evidence.
+3. Include links in the final comment to all lifecycle artifacts:
+   code PR, deployment PR, and (when applicable) downstream types PR.
+4. Only move the project item to `Done` after the final validation comment is
+   posted and blockers are resolved.
+5. Use `.github/skills/release-hygiene-check/SKILL.md` for this repeatable
+   workflow.
+
+Suggested final comment format:
+
+```text
+Final acceptance validation (YYYY-MM-DD):
+- Criterion 1: PASS — <evidence link/command output>
+- Criterion 2: PASS — <evidence link/command output>
+- Deployment PR: <link>
+- Types PR (if applicable): <link>
+- Prior blocker status: Resolved (<link to resolving PR/run>)
+```
+
 ### Daily Workflow
 
 1. **ALWAYS** start from `develop` or create a feature branch

--- a/.github/skills/release-hygiene-check/SKILL.md
+++ b/.github/skills/release-hygiene-check/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: release-hygiene-check
+description: Run a repeatable post-deploy hygiene check for otel-data-api. Validates issue acceptance criteria, resolves stale blocked status, and verifies downstream types PR lifecycle before marking work Done.
+---
+
+# Release Hygiene Check (otel-data-api)
+
+Use this skill whenever a code PR and deployment PR have merged, or when
+`@stuartshay/otel-data-types` was published.
+
+## Required Outputs
+
+- Final acceptance-validation comment on the linked issue
+- Evidence links for each acceptance criterion
+- Confirmation that stale "blocked" validation state is superseded
+- Types downstream PR status (if package publish occurred)
+- Project item moved to `Done` only after all items above are complete
+
+## Workflow
+
+### 1. Collect Linked Artifacts
+
+Identify and record:
+
+- Implementation issue (`otel-data-api`)
+- Code PR (`otel-data-api`)
+- Deployment PR (`k8s-gitops`)
+- Types dependency PR (`otel-data-gateway`, if applicable)
+
+Suggested commands:
+
+```bash
+gh issue view <issue_number> --repo stuartshay/otel-data-api \
+  --json number,title,state,body,comments,projectItems
+gh pr view <pr_number> --repo stuartshay/otel-data-api \
+  --json number,title,state,mergedAt,url
+gh pr view <pr_number> --repo stuartshay/k8s-gitops \
+  --json number,title,state,mergedAt,url
+```
+
+### 2. Validate Deployed Behavior
+
+Validate against the live cluster, not only local CI:
+
+```bash
+curl -s https://api.lab.informationcart.com/health
+curl -s https://api.lab.informationcart.com/openapi.json | jq '.info.version'
+```
+
+Add endpoint-specific checks required by the issue acceptance criteria.
+
+### 3. Validate Each Acceptance Criterion
+
+Create a criterion-by-criterion mapping from issue text to evidence:
+
+- `PASS`: criterion is satisfied in deployed environment
+- `FAIL`: criterion not met; open follow-up and do not move to `Done`
+
+If issue body checkboxes are not updated, post a final checklist comment with
+all criteria statuses.
+
+### 4. Validate Types Downstream PR (When Applicable)
+
+If API changes published `@stuartshay/otel-data-types`:
+
+```bash
+gh pr list --repo stuartshay/otel-data-gateway --state all \
+  --search "Update @stuartshay/otel-data-types in:title" --limit 5
+```
+
+Confirm:
+
+- Bumped version matches npm publish version
+- Required checks passed
+- Merge status is recorded or blocker is documented
+
+### 5. Post Final Superseding Comment
+
+If earlier comments reported blocked validation, post a new final comment that
+supersedes that state and links the resolving PR/run.
+
+Template:
+
+```text
+Final acceptance validation (YYYY-MM-DD):
+- Criterion 1: PASS — <evidence link/command output>
+- Criterion 2: PASS — <evidence link/command output>
+- Deployment PR: <link>
+- Types PR (if applicable): <link>
+- Prior blocker status: Resolved (<link>)
+```
+
+### 6. Project Board Hygiene
+
+Move the project item to `Done` only after Step 5 is posted and all criteria
+pass.
+
+## Completion Checklist
+
+- [ ] Acceptance criteria validated in deployed environment
+- [ ] Final validation comment posted with evidence links
+- [ ] Prior blocked status explicitly superseded
+- [ ] Types downstream PR validated (if applicable)
+- [ ] Project item status updated after evidence is posted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,14 @@ All automation, assistants, and developers must follow
 - **API Docs**: <http://localhost:8080/docs>
 - **Post-deploy check**: after cluster deploy, verify linked issue acceptance
   criteria and record evidence before marking work complete
+- **Types release check**: after `publish-types.yml` publishes
+  `@stuartshay/otel-data-types`, verify the downstream update PR is created in
+  `otel-data-gateway`
+- **Issue closure hygiene**: if any prior validation comment reported a blocker,
+  add a final superseding validation comment after resolution before marking
+  done
+- **Release hygiene skill**:
+  `.github/skills/release-hygiene-check/SKILL.md`
 
 ## Development Workflow
 
@@ -35,6 +43,10 @@ All automation, assistants, and developers must follow
 7. Create PR to `master` when ready for production
 8. After deployment PR merges (for example in `k8s-gitops`), validate every
    linked issue acceptance criterion in-cluster before closing/confirming done
+9. If `packages/otel-data-types` changed, confirm the corresponding
+   `otel-data-gateway` dependency-update PR exists and is linked for follow-up
+10. If validation was previously blocked, post a final resolution comment with
+    evidence and links before moving the project item to Done
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

Adds release hygiene workflow documentation and types dispatch improvements.

### Changes

**Release Hygiene Workflow**
- New `.github/skills/release-hygiene-check/SKILL.md` — reusable 6-step workflow for post-deploy acceptance validation
- Updated `copilot-instructions.md` with:
  - "After Types Publish" section (5 steps for verifying downstream dependency PR)
  - "Release Hygiene Completion" section (5 rules with suggested final comment template)
- Updated `AGENTS.md` with types release check, issue closure hygiene, and release hygiene skill references

**Types Dispatch Improvements** (from earlier commits on this branch)
- `publish-types.yml`: Added `repository_dispatch` to `otel-data-gateway` when `@stuartshay/otel-data-types` is published
- Fixed dispatch outcome reporting in publish summary

Closes #65