### PR TITLE
docs: add PR template and issue closure policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,8 +85,17 @@ before considering work complete.
    screenshots as applicable).
 5. Only then mark the issue/project item as done.
 
-If an issue is auto-closed by merge keywords (`Closes #...`) before deployment
-validation is complete, reopen it until acceptance criteria are confirmed.
+### Issue Closure Policy
+
+⚠️ **Do NOT use `Closes #` or `Fixes #` in PR descriptions.** Issues must
+remain open until post-deploy acceptance criteria are validated on the cluster.
+
+1. After the PR merges, wait for Docker build and k8s-gitops deployment.
+2. Validate each acceptance criterion against the live cluster.
+3. Post a final validation comment on the issue with evidence.
+4. Close the issue manually only after all criteria pass.
+5. If any criterion cannot be validated, document the reason on the issue
+   instead of closing it.
 
 ### After Types Publish (Required)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,59 @@
+## Summary
+
+Refs #<!-- issue number — do NOT use "Closes" or "Fixes" (see below) -->
+
+Describe the change and why it's needed.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change fixing an issue)
+- [ ] New feature / endpoint (non-breaking)
+- [ ] Breaking change (existing behavior altered)
+- [ ] Database migration required
+- [ ] CI/CD pipeline change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] Read `README.md` and relevant docs
+- [ ] No secrets or credentials committed
+- [ ] Environment variables used for configuration (not hardcoded)
+- [ ] Ran `pre-commit run -a` locally (hooks passing)
+- [ ] Ran `make test` (tests passing, coverage ≥ 85%)
+- [ ] Ran `make lint` (no lint errors)
+
+## Deployment
+
+- [ ] Does this need [k8s-gitops](https://github.com/stuartshay/k8s-gitops)
+      manifest changes?
+- [ ] Does this need
+      [database migrations](https://github.com/stuartshay/homelab-database-migrations)?
+- [ ] Does this publish `@stuartshay/otel-data-types`?
+
+## Testing
+
+```bash
+# Commands used to validate changes
+make test
+make lint
+pre-commit run -a
+```
+
+## Post-Merge Validation
+
+⚠️ **Do NOT use `Closes #` or `Fixes #` in this PR.** Issues must remain open
+until post-deploy acceptance criteria are validated on the cluster.
+
+After this PR merges:
+
+- [ ] Docker image built and pushed (CI)
+- [ ] k8s-gitops deployment PR created and merged
+- [ ] Argo CD synced to cluster
+- [ ] Acceptance criteria validated against deployed behavior
+- [ ] Final validation comment posted on the linked issue
+- [ ] Issue closed manually after all criteria confirmed
+- [ ] If any criterion cannot be validated, reason documented on the issue
+
+## Notes
+
+Any additional context, screenshots, or log output.


### PR DESCRIPTION
## Summary

Refs cross-repo workflow refinement

Adds a standardized PR template and updates copilot-instructions to enforce manual issue closure after post-deploy acceptance criteria validation.

## Changes

- **New**: `.github/pull_request_template.md` — PR template with `Refs #` (not `Closes #`), post-merge validation checklist
- **Updated**: `.github/copilot-instructions.md` — Added Issue Closure Policy section replacing auto-close workaround language

## Motivation

Issues should not be auto-closed on merge. They must remain open until:
1. PR merges and deploys to the cluster
2. Each acceptance criterion is validated against live behavior
3. Final validation comment is posted with evidence
4. Issue is closed manually

This aligns the workflow across all repos in the homelab ecosystem.