### PR TITLE
feat: add GET /api/v1/locations/date-range endpoint

### DIFF
--- a/app/models/locations.py
+++ b/app/models/locations.py
@@ -119,3 +119,21 @@ class LocationCount(BaseModel):
     device_id: str | None = Field(default=None, description="Device ID filter applied, if any")
 
     model_config = {"json_schema_extra": {"examples": [{"count": 45883, "date": None, "device_id": "iphone_stuart"}]}}
+
+
+class LocationDateRange(BaseModel):
+    """Earliest and latest location timestamps in the database."""
+
+    min_date: datetime = Field(description="Timestamp of the earliest location record")
+    max_date: datetime = Field(description="Timestamp of the latest location record")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "min_date": "2025-12-27T08:44:52+00:00",
+                    "max_date": "2026-04-06T20:00:00+00:00",
+                }
+            ]
+        }
+    }

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from app.models import PaginatedResponse
 from app.models.geocoding import GeocodedAddress
-from app.models.locations import DeviceInfo, Location, LocationCount, LocationDetail
+from app.models.locations import DeviceInfo, Location, LocationCount, LocationDateRange, LocationDetail
 
 router = APIRouter(prefix="/api/v1/locations", tags=["Locations"])
 
@@ -111,6 +111,16 @@ async def list_devices(request: Request) -> list[DeviceInfo]:
     db = request.app.state.db
     rows = await db.fetch("SELECT DISTINCT device_id FROM public.locations ORDER BY device_id")
     return [DeviceInfo(device_id=row["device_id"]) for row in rows]
+
+
+@router.get("/date-range", response_model=LocationDateRange)
+async def location_date_range(request: Request) -> LocationDateRange:
+    """Get the earliest and latest location timestamps."""
+    db = request.app.state.db
+    row = await db.fetchrow("SELECT MIN(timestamp) AS min_date, MAX(timestamp) AS max_date FROM public.locations")
+    if not row or row["min_date"] is None:
+        raise HTTPException(status_code=404, detail="No location data found")
+    return LocationDateRange(min_date=row["min_date"], max_date=row["max_date"])
 
 
 @router.get("/count", response_model=LocationCount)

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -150,6 +150,10 @@ async def test_date_range_returns_min_max(client: AsyncClient, mock_db):
     assert "max_date" in data
     assert "2025-12-27" in data["min_date"]
     assert "2026-04-06" in data["max_date"]
+    query = mock_db.fetchrow.await_args.args[0]
+    assert "MIN(timestamp)" in query
+    assert "MAX(timestamp)" in query
+    assert "FROM public.locations" in query
 
 
 @pytest.mark.asyncio
@@ -160,3 +164,7 @@ async def test_date_range_empty_database(client: AsyncClient, mock_db):
 
     assert response.status_code == 404
     assert response.json() == {"detail": "No location data found"}
+    query = mock_db.fetchrow.await_args.args[0]
+    assert "MIN(timestamp)" in query
+    assert "MAX(timestamp)" in query
+    assert "FROM public.locations" in query

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -133,3 +133,30 @@ async def test_get_location_not_found(client: AsyncClient, mock_db):
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Location not found"}
+
+
+@pytest.mark.asyncio
+async def test_date_range_returns_min_max(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {
+        "min_date": "2025-12-27T08:44:52+00:00",
+        "max_date": "2026-04-06T20:00:00+00:00",
+    }
+
+    response = await client.get("/api/v1/locations/date-range")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "min_date" in data
+    assert "max_date" in data
+    assert "2025-12-27" in data["min_date"]
+    assert "2026-04-06" in data["max_date"]
+
+
+@pytest.mark.asyncio
+async def test_date_range_empty_database(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {"min_date": None, "max_date": None}
+
+    response = await client.get("/api/v1/locations/date-range")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No location data found"}


### PR DESCRIPTION
Add endpoint that returns the earliest and latest timestamps from the locations table, enabling dynamic calendar date bounds in the UI instead of hardcoded values.

## Changes
- Add `LocationDateRange` Pydantic model (`app/models/locations.py`)
- Add `GET /api/v1/locations/date-range` route (`app/routers/locations.py`)
- Add tests for happy path and empty database (`tests/test_locations.py`)

## Related PRs
- otel-data-gateway: `feature/locations-date-range` (GraphQL layer)
- otel-data-ui PR #55 (consumes the query)