### PR TITLE
feat: Add Garmin date-range endpoint

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -160,6 +160,24 @@ class SportInfo(BaseModel):
     model_config = {"json_schema_extra": {"examples": [{"sport": "cycling", "activity_count": 20}]}}
 
 
+class GarminDateRange(BaseModel):
+    """Earliest and latest Garmin activity timestamps in the database."""
+
+    min_date: datetime = Field(description="Timestamp of the earliest Garmin activity")
+    max_date: datetime = Field(description="Timestamp of the latest Garmin activity")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "min_date": "2025-11-08T18:21:13+00:00",
+                    "max_date": "2026-04-06T20:00:00+00:00",
+                }
+            ]
+        }
+    }
+
+
 class GarminSyncResponse(BaseModel):
     """Response payload for Garmin on-demand sync trigger requests."""
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -13,7 +13,14 @@ from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import ValidationError
 
 from app.models import PaginatedResponse
-from app.models.garmin import GarminActivity, GarminChartPoint, GarminSyncResponse, GarminTrackPoint, SportInfo
+from app.models.garmin import (
+    GarminActivity,
+    GarminChartPoint,
+    GarminDateRange,
+    GarminSyncResponse,
+    GarminTrackPoint,
+    SportInfo,
+)
 
 router = APIRouter(prefix="/api/v1/garmin", tags=["Garmin"])
 logger = structlog.get_logger(__name__)
@@ -127,6 +134,18 @@ async def trigger_sync(
         status="error",
         message=f"Unexpected response from Garmin sync service: {upstream_response.status_code}",
     )
+
+
+@router.get("/date-range", response_model=GarminDateRange)
+async def garmin_date_range(request: Request) -> GarminDateRange:
+    """Get the earliest and latest Garmin activity timestamps."""
+    db = request.app.state.db
+    row = await db.fetchrow(
+        "SELECT MIN(start_time) AS min_date, MAX(start_time) AS max_date FROM public.garmin_activities"
+    )
+    if not row or row["min_date"] is None:
+        raise HTTPException(status_code=404, detail="No Garmin activity data found")
+    return GarminDateRange(min_date=row["min_date"], max_date=row["max_date"])
 
 
 @router.get("/activities", response_model=PaginatedResponse[GarminActivity])

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -555,3 +555,38 @@ async def test_trigger_sync_forwards_provided_sync_id(client: AsyncClient, monke
 
     assert response.status_code == 202
     assert captured["headers"]["X-Garmin-Sync-Id"] == provided_id
+
+
+@pytest.mark.asyncio
+async def test_garmin_date_range_returns_min_max(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {
+        "min_date": "2025-11-08T18:21:13+00:00",
+        "max_date": "2026-04-06T20:00:00+00:00",
+    }
+
+    response = await client.get("/api/v1/garmin/date-range")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "min_date" in data
+    assert "max_date" in data
+    assert "2025-11-08" in data["min_date"]
+    assert "2026-04-06" in data["max_date"]
+    query = mock_db.fetchrow.await_args.args[0]
+    assert "MIN(start_time)" in query
+    assert "MAX(start_time)" in query
+    assert "FROM public.garmin_activities" in query
+
+
+@pytest.mark.asyncio
+async def test_garmin_date_range_empty_database(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {"min_date": None, "max_date": None}
+
+    response = await client.get("/api/v1/garmin/date-range")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No Garmin activity data found"}
+    query = mock_db.fetchrow.await_args.args[0]
+    assert "MIN(start_time)" in query
+    assert "MAX(start_time)" in query
+    assert "FROM public.garmin_activities" in query


### PR DESCRIPTION
## Summary

Add `GET /api/v1/garmin/date-range` endpoint that returns the min/max `start_time` from the `garmin_activities` table, enabling calendar date bounds in the UI's Garmin Activities page.

## Changes

- **`app/models/garmin.py`** — Add `GarminDateRange` Pydantic model with `min_date`/`max_date` datetime fields
- **`app/routers/garmin.py`** — Add `/date-range` endpoint querying `MIN(start_time)` / `MAX(start_time)` from `public.garmin_activities`
- **`tests/test_garmin.py`** — Add tests for populated and empty database scenarios

## Context

This mirrors the existing `GET /api/v1/locations/date-range` endpoint (#83) but for Garmin activity data. The gateway and UI repos have corresponding PRs to consume this endpoint.