### PR TITLE
chore: Update Python dependencies and add Renovate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![npm](https://img.shields.io/npm/v/@stuartshay/otel-data-types?logo=npm&label=otel-data-types)](https://www.npmjs.com/package/@stuartshay/otel-data-types)
 [![Python](https://img.shields.io/badge/Python-3.14-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-latest-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
+[![Renovate](https://img.shields.io/badge/Renovate-enabled-brightgreen?logo=renovatebot)](https://developer.mend.io/github/stuartshay/otel-data-api)
 
 FastAPI microservice providing read/write access to the OwnTracks + Garmin
 location database with PostGIS spatial queries.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 # Core Framework
 # =============================================================================
-fastapi==0.135.1
-uvicorn[standard]==0.41.0
+fastapi==0.135.3
+uvicorn[standard]==0.44.0
 pydantic==2.12.5
 pydantic-settings==2.13.1
 
@@ -20,23 +20,23 @@ httpx==0.28.1
 # =============================================================================
 # OpenTelemetry
 # =============================================================================
-opentelemetry-api==1.40.0
-opentelemetry-sdk==1.40.0
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
-opentelemetry-instrumentation-asyncpg==0.61b0
-opentelemetry-instrumentation-fastapi==0.61b0
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-api==1.41.0
+opentelemetry-sdk==1.41.0
+opentelemetry-exporter-otlp-proto-grpc==1.41.0
+opentelemetry-instrumentation-asyncpg==0.62b0
+opentelemetry-instrumentation-fastapi==0.62b0
+opentelemetry-instrumentation-httpx==0.62b0
 
 # =============================================================================
 # Monitoring
 # =============================================================================
-newrelic==12.0.0
+newrelic==12.1.0
 
 # =============================================================================
 # Structured Logging
 # =============================================================================
-structlog==25.1.0
-rich==14.0.0
+structlog==25.5.0
+rich==15.0.0
 
 # =============================================================================
 # Utilities


### PR DESCRIPTION
## Summary

Update direct Python dependencies to latest versions and add Renovate badge to README.

## Changes

### Dependency Updates (`requirements.txt`)
- **fastapi**: 0.135.1 → 0.135.3
- **uvicorn**: 0.41.0 → 0.44.0
- **opentelemetry-api/sdk/exporter-otlp-proto-grpc**: 1.40.0 → 1.41.0
- **opentelemetry-instrumentation-asyncpg/fastapi/httpx**: 0.61b0 → 0.62b0
- **newrelic**: 12.0.0 → 12.1.0
- **structlog**: 25.1.0 → 25.5.0
- **rich**: 14.0.0 → 15.0.0

### README
- Add Renovate shield badge linking to https://developer.mend.io/github/stuartshay/otel-data-api

## Validation
- All 128 tests pass
- All 19 pre-commit hooks pass
- No breaking changes