### PR TITLE
feat(garmin): add activity-totals aggregation endpoint

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -217,10 +217,10 @@ class GarminActivityTotal(BaseModel):
     period_start: date_type = Field(description="UTC start date of the period bucket (week/month/year)")
     activity_count: int = Field(description="Number of activities recorded in the period")
     total_distance_km: float | None = Field(default=None, description="Sum of distance in kilometres")
-    total_duration_seconds: float | None = Field(
+    total_duration_seconds: int | None = Field(
         default=None, description="Sum of active duration in seconds (excludes pauses)"
     )
-    total_ascent_m: float | None = Field(default=None, description="Sum of elevation gain in meters")
+    total_ascent_m: int | None = Field(default=None, description="Sum of elevation gain in meters")
     total_calories: int | None = Field(default=None, description="Sum of calories burned")
 
     model_config = {

--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date as date_type
 from datetime import datetime
 
 from pydantic import BaseModel, Field
@@ -207,4 +208,32 @@ class GarminSyncResponse(BaseModel):
                 },
             ]
         },
+    }
+
+
+class GarminActivityTotal(BaseModel):
+    """Aggregated Garmin activity totals for a single time bucket (week/month/year)."""
+
+    period_start: date_type = Field(description="UTC start date of the period bucket (week/month/year)")
+    activity_count: int = Field(description="Number of activities recorded in the period")
+    total_distance_km: float | None = Field(default=None, description="Sum of distance in kilometres")
+    total_duration_seconds: float | None = Field(
+        default=None, description="Sum of active duration in seconds (excludes pauses)"
+    )
+    total_ascent_m: float | None = Field(default=None, description="Sum of elevation gain in meters")
+    total_calories: int | None = Field(default=None, description="Sum of calories burned")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "period_start": "2025-05-01",
+                    "activity_count": 12,
+                    "total_distance_km": 632.4,
+                    "total_duration_seconds": 90123,
+                    "total_ascent_m": 4521,
+                    "total_calories": 18234,
+                }
+            ]
+        }
     }

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -252,9 +252,11 @@ async def list_activity_totals(
     """
     db = request.app.state.db
 
+    # Period is the first positional parameter so the entire query stays
+    # parameterized (no string interpolation of user-controlled values into SQL).
+    params: list = [period]
     conditions: list[str] = []
-    params: list = []
-    idx = 1
+    idx = 2
 
     if sport:
         conditions.append(f"sport = ${idx}")
@@ -274,14 +276,14 @@ async def list_activity_totals(
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
     query = (
-        f"SELECT DATE_TRUNC('{period}', start_time)::date AS period_start, "
-        f"COUNT(*) AS activity_count, "
-        f"SUM(distance_km) AS total_distance_km, "
-        f"SUM(duration_seconds) AS total_duration_seconds, "
-        f"SUM(total_ascent_m) AS total_ascent_m, "
-        f"SUM(calories) AS total_calories "
+        "SELECT DATE_TRUNC($1::text, start_time)::date AS period_start, "
+        "COUNT(*) AS activity_count, "
+        "SUM(distance_km) AS total_distance_km, "
+        "SUM(duration_seconds) AS total_duration_seconds, "
+        "SUM(total_ascent_m) AS total_ascent_m, "
+        "SUM(calories) AS total_calories "
         f"FROM public.garmin_activities {where} "
-        f"GROUP BY period_start ORDER BY period_start ASC"
+        "GROUP BY period_start ORDER BY period_start ASC"
     )
 
     rows = await db.fetch(query, *params)

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from app.models import PaginatedResponse
 from app.models.garmin import (
     GarminActivity,
+    GarminActivityTotal,
     GarminChartPoint,
     GarminDateRange,
     GarminSyncResponse,
@@ -227,6 +228,64 @@ async def list_sports(request: Request) -> list[SportInfo]:
         "GROUP BY sport ORDER BY activity_count DESC"
     )
     return [SportInfo(**dict(row)) for row in rows]
+
+
+@router.get(
+    "/activity-totals",
+    response_model=list[GarminActivityTotal],
+    responses={422: {"description": "Invalid query parameter"}},
+)
+async def list_activity_totals(
+    request: Request,
+    period: Literal["week", "month", "year"] = Query(
+        ..., description="Time bucket for aggregation: week, month, or year"
+    ),
+    sport: str | None = Query(None, description="Filter to a single sport (e.g. cycling)"),
+    date_from: str | None = Query(None, description="Inclusive lower bound on start_time (YYYY-MM-DD, UTC)"),
+    date_to: str | None = Query(None, description="Inclusive upper bound on start_time (YYYY-MM-DD, UTC)"),
+) -> list[GarminActivityTotal]:
+    """Aggregate Garmin activities into period totals (week / month / year).
+
+    Buckets are computed via ``DATE_TRUNC(period, start_time)`` and ordered by
+    ``period_start`` ascending. Each row contains activity count plus sum of
+    distance, duration, ascent, and calories. Empty result returns ``[]``.
+    """
+    db = request.app.state.db
+
+    conditions: list[str] = []
+    params: list = []
+    idx = 1
+
+    if sport:
+        conditions.append(f"sport = ${idx}")
+        params.append(sport)
+        idx += 1
+
+    if date_from:
+        conditions.append(f"start_time >= ${idx}::date")
+        params.append(_parse_date(date_from))
+        idx += 1
+
+    if date_to:
+        conditions.append(f"start_time < (${idx}::date + INTERVAL '1 day')")
+        params.append(_parse_date(date_to))
+        idx += 1
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    query = (
+        f"SELECT DATE_TRUNC('{period}', start_time)::date AS period_start, "
+        f"COUNT(*) AS activity_count, "
+        f"SUM(distance_km) AS total_distance_km, "
+        f"SUM(duration_seconds) AS total_duration_seconds, "
+        f"SUM(total_ascent_m) AS total_ascent_m, "
+        f"SUM(calories) AS total_calories "
+        f"FROM public.garmin_activities {where} "
+        f"GROUP BY period_start ORDER BY period_start ASC"
+    )
+
+    rows = await db.fetch(query, *params)
+    return [GarminActivityTotal(**dict(row)) for row in rows]
 
 
 @router.get(

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -120,10 +120,11 @@ async def test_activity_totals_empty(client: AsyncClient, mock_db):
 
     assert response.status_code == 200
     assert response.json() == []
-    query, *_params = mock_db.fetch.await_args.args
-    assert "DATE_TRUNC('month', start_time)" in query
+    query, *params = mock_db.fetch.await_args.args
+    assert "DATE_TRUNC($1::text, start_time)" in query
     assert "GROUP BY period_start" in query
     assert "ORDER BY period_start ASC" in query
+    assert params == ["month"]
 
 
 @pytest.mark.asyncio
@@ -156,8 +157,9 @@ async def test_activity_totals_returns_rows(client: AsyncClient, mock_db, period
     assert body[0]["period_start"] == "2025-05-01"
     assert body[0]["activity_count"] == 12
     assert body[0]["total_distance_km"] == 632.4
-    query, *_params = mock_db.fetch.await_args.args
-    assert f"DATE_TRUNC('{period}', start_time)" in query
+    query, *params = mock_db.fetch.await_args.args
+    assert "DATE_TRUNC($1::text, start_time)" in query
+    assert params[0] == period
 
 
 @pytest.mark.asyncio
@@ -192,10 +194,11 @@ async def test_activity_totals_with_filters(client: AsyncClient, mock_db):
 
     assert response.status_code == 200
     query, *params = mock_db.fetch.await_args.args
-    assert "sport = $1" in query
-    assert "start_time >= $2::date" in query
-    assert "start_time < ($3::date + INTERVAL '1 day')" in query
-    assert params == ["cycling", date(2025, 5, 1), date(2025, 12, 31)]
+    assert "DATE_TRUNC($1::text, start_time)" in query
+    assert "sport = $2" in query
+    assert "start_time >= $3::date" in query
+    assert "start_time < ($4::date + INTERVAL '1 day')" in query
+    assert params == ["week", "cycling", date(2025, 5, 1), date(2025, 12, 31)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -113,6 +113,92 @@ async def test_get_sports(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_activity_totals_empty(client: AsyncClient, mock_db):
+    mock_db.fetch.return_value = []
+
+    response = await client.get("/api/v1/garmin/activity-totals?period=month")
+
+    assert response.status_code == 200
+    assert response.json() == []
+    query, *_params = mock_db.fetch.await_args.args
+    assert "DATE_TRUNC('month', start_time)" in query
+    assert "GROUP BY period_start" in query
+    assert "ORDER BY period_start ASC" in query
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("period", ["week", "month", "year"])
+async def test_activity_totals_returns_rows(client: AsyncClient, mock_db, period):
+    mock_db.fetch.return_value = [
+        {
+            "period_start": date(2025, 5, 1),
+            "activity_count": 12,
+            "total_distance_km": 632.4,
+            "total_duration_seconds": 90123.0,
+            "total_ascent_m": 4521.0,
+            "total_calories": 18234,
+        },
+        {
+            "period_start": date(2025, 6, 1),
+            "activity_count": 9,
+            "total_distance_km": 410.5,
+            "total_duration_seconds": 60000.0,
+            "total_ascent_m": 2300.0,
+            "total_calories": 12000,
+        },
+    ]
+
+    response = await client.get(f"/api/v1/garmin/activity-totals?period={period}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    assert body[0]["period_start"] == "2025-05-01"
+    assert body[0]["activity_count"] == 12
+    assert body[0]["total_distance_km"] == 632.4
+    query, *_params = mock_db.fetch.await_args.args
+    assert f"DATE_TRUNC('{period}', start_time)" in query
+
+
+@pytest.mark.asyncio
+async def test_activity_totals_invalid_period(client: AsyncClient, mock_db):
+    response = await client.get("/api/v1/garmin/activity-totals?period=decade")
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_activity_totals_missing_period(client: AsyncClient, mock_db):
+    response = await client.get("/api/v1/garmin/activity-totals")
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_activity_totals_invalid_date(client: AsyncClient, mock_db):
+    response = await client.get("/api/v1/garmin/activity-totals?period=month&date_from=not-a-date")
+
+    assert response.status_code == 422
+    assert "Invalid date format" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_activity_totals_with_filters(client: AsyncClient, mock_db):
+    mock_db.fetch.return_value = []
+
+    response = await client.get(
+        "/api/v1/garmin/activity-totals?period=week&sport=cycling&date_from=2025-05-01&date_to=2025-12-31"
+    )
+
+    assert response.status_code == 200
+    query, *params = mock_db.fetch.await_args.args
+    assert "sport = $1" in query
+    assert "start_time >= $2::date" in query
+    assert "start_time < ($3::date + INTERVAL '1 day')" in query
+    assert params == ["cycling", date(2025, 5, 1), date(2025, 12, 31)]
+
+
+@pytest.mark.asyncio
 async def test_get_activity_success(client: AsyncClient, mock_db):
     mock_db.fetchrow.return_value = _activity_row()
 


### PR DESCRIPTION
Refs #96

## Summary

Adds a new aggregation endpoint:

- GET /api/v1/garmin/activity-totals?period={week|month|year}
- Optional filters: sport, date_from, date_to
- Returns activity_count + sum of distance_km, duration_seconds, total_ascent_m, calories per period bucket
- Buckets via DATE_TRUNC(period, start_time)
- Ordered by period_start ASC; empty result returns []

This powers the new Garmin Activity Totals dashboard widget (mirroring the Garmin Connect mobile UI mockup).

## Test plan

- 8 new pytest cases (empty, week/month/year params, invalid period 422, missing period 422, invalid date 422, sport+date filter SQL/params).
- Full suite: 138 tests pass; coverage 95.89%.
- `pre-commit run --all-files` passes.

## Follow-ups (not in this PR)

- otel-data-gateway: add GraphQL query garminActivityTotals and republish @stuartshay/otel-data-types.
- otel-data-ui: add GarminActivityTotals dashboard widget below GarminActivityHeatmap.