### PR TITLE
[codex] fix renovate config validation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,6 @@
   "enabledManagers": [
     "pip_requirements",
     "dockerfile",
-    "regex",
     "pre-commit",
     "github-actions"
   ],
@@ -51,7 +50,10 @@
     {
       "description": "Group OpenTelemetry core packages (excluding instrumentation)",
       "matchPackageNames": [
-        "/^opentelemetry(?!-instrumentation)/"
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "/^opentelemetry-exporter-/",
+        "/^opentelemetry-proto/"
       ],
       "groupName": "opentelemetry-core",
       "groupSlug": "opentelemetry-core"
@@ -167,8 +169,8 @@
     },
     {
       "description": "Automerge minor and patch updates (excludes Docker; handled by its own rule)",
+      "matchManagers": ["pip_requirements", "pre-commit", "github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludeDatasources": ["docker"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary
- Remove the unused legacy `regex` manager from `enabledManagers` so Renovate no longer needs to migrate it to `custom.regex`.
- Replace the unsupported OpenTelemetry negative-lookahead package regex with explicit valid match patterns.
- Replace invalid `excludeDatasources` usage with a non-Docker `matchManagers` list for the broad automerge rule.

## Root Cause
Renovate 43 rejects this repository config because `packageRules[15].excludeDatasources` is not a valid option and the RE2-based regex validation rejects the negative lookahead in the OpenTelemetry package rule. It also flags the legacy `regex` manager name as requiring config migration.

## Validation
- `npx --yes --package renovate renovate-config-validator --no-global --strict renovate.json`
- `pre-commit run -a`
- `make test` (140 passed)