### PR TITLE
[codex] roll up remaining dependency updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         exclude: package.lock.json
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: v2.0.0
     hooks:
       - id: mypy
         additional_dependencies:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,12 +20,12 @@ httpx==0.28.1
 # =============================================================================
 # OpenTelemetry
 # =============================================================================
-opentelemetry-api==1.41.0
-opentelemetry-sdk==1.41.0
-opentelemetry-exporter-otlp-proto-grpc==1.41.0
-opentelemetry-instrumentation-asyncpg==0.62b0
-opentelemetry-instrumentation-fastapi==0.62b0
-opentelemetry-instrumentation-httpx==0.62b0
+opentelemetry-api==1.41.1
+opentelemetry-sdk==1.41.1
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+opentelemetry-instrumentation-asyncpg==0.62b1
+opentelemetry-instrumentation-fastapi==0.62b1
+opentelemetry-instrumentation-httpx==0.62b1
 
 # =============================================================================
 # Monitoring


### PR DESCRIPTION
## Summary
- Roll up the remaining dependency updates from Renovate PRs #102, #103, and #105 into one branch.
- Update OpenTelemetry core packages from `1.41.0` to `1.41.1` and instrumentation packages from `0.62b0` to `0.62b1` together.
- Update the `pre-commit/mirrors-mypy` hook from `v1.20.2` to `v2.0.0`.

## Root Cause
The individual OpenTelemetry Renovate PRs fail independently because core `1.41.1` requires `opentelemetry-semantic-conventions==0.62b1`, while instrumentation `0.62b0` still requires `0.62b0`. The inverse is true for the instrumentation-only update. Updating both groups together resolves the dependency conflict.

PR #101 for FastAPI/Uvicorn merged separately while this rollup was being prepared, so this branch has been rebased onto that update and no longer carries it.

## Validation
- `python -m pip install --dry-run -r requirements.txt` under Python 3.14
- `venv/bin/pip install -r requirements.txt`
- `venv/bin/pip check`
- `pre-commit run -a`
- `make test` (140 passed)
- `make docker-build`