### PR TITLE
feat(geocoding): add Garmin activity reverse-geocoding pipeline

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from app.models.geocoding import GeocodedAddressSummary
+
 
 class GarminActivity(BaseModel):
     """Summary of a Garmin Connect activity parsed from a FIT file."""
@@ -95,6 +97,11 @@ class GarminTrackPoint(BaseModel):
     cadence: int | None = Field(default=None, description="Pedal/step cadence in RPM")
     temperature_c: int | None = Field(default=None, description="Ambient temperature in degrees C")
     created_at: datetime | None = Field(default=None, description="UTC timestamp when the record was inserted")
+    address: GeocodedAddressSummary | None = Field(
+        default=None,
+        description="Reverse-geocoded address for this track point (Garmin pipeline). "
+        "Only populated for waypoints that have been geocoded.",
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -112,6 +119,7 @@ class GarminTrackPoint(BaseModel):
                     "cadence": 80,
                     "temperature_c": 18,
                     "created_at": "2026-02-09T23:56:37Z",
+                    "address": None,
                 }
             ]
         }

--- a/app/models/geocoding.py
+++ b/app/models/geocoding.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+WaypointKind = Literal["start", "end", "waypoint"]
 
 
 class GeocodedAddress(BaseModel):
@@ -53,6 +56,10 @@ class GeocodingStatus(BaseModel):
     no_coverage: int = Field(description="Number of locations outside Pelias coverage area")
     errors: int = Field(description="Number of locations that failed geocoding")
     coverage_percent: float = Field(description="Percentage of locations with a geocoded address")
+    by_source: GeocodingStatusBySource | None = Field(
+        default=None,
+        description="Per-source breakdown of geocoding coverage (owntracks, garmin)",
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -69,6 +76,32 @@ class GeocodingStatus(BaseModel):
             ]
         }
     }
+
+
+class GeocodingSourceStatus(BaseModel):
+    """Coverage statistics for a single geocoding source (owntracks or garmin)."""
+
+    success: int = Field(description="Number of successfully geocoded records for this source")
+    pending: int = Field(default=0, description="Number of records awaiting geocoding for this source")
+    no_coverage: int = Field(description="Number of records outside Pelias coverage area")
+    errors: int = Field(description="Number of records that failed geocoding")
+    total: int = Field(description="Total number of geocoded_addresses rows for this source")
+
+
+class GeocodingStatusBySource(BaseModel):
+    """Per-source breakdown of geocoding coverage."""
+
+    owntracks: GeocodingSourceStatus = Field(description="Coverage stats for OwnTracks rows")
+    garmin: GeocodingSourceStatus = Field(description="Coverage stats for Garmin rows")
+    garmin_activities_total: int = Field(
+        description="Total number of Garmin activities (denominator for activity-level coverage)"
+    )
+    garmin_activities_geocoded: int = Field(
+        description="Number of Garmin activities that have at least one address row"
+    )
+    garmin_coverage_percent: float = Field(
+        description="Percentage of Garmin activities with at least one geocoded address"
+    )
 
 
 class GeocodingTriggerResponse(BaseModel):
@@ -89,3 +122,36 @@ class GeocodingTriggerResponse(BaseModel):
             ]
         }
     }
+
+
+class GarminActivityAddress(BaseModel):
+    """Reverse-geocoded address attached to a Garmin activity waypoint."""
+
+    track_point_id: int = Field(description="garmin_track_points.id this address was geocoded from")
+    activity_id: str = Field(description="Parent Garmin activity identifier")
+    waypoint_kind: WaypointKind = Field(description="Role of this waypoint: start, end, or mid-route waypoint")
+    timestamp: datetime = Field(description="UTC timestamp of the track point this address was derived from")
+    latitude: float = Field(description="GPS latitude in decimal degrees (WGS 84)")
+    longitude: float = Field(description="GPS longitude in decimal degrees (WGS 84)")
+    display_address: str | None = Field(default=None, description="Full formatted address label from Pelias")
+    street: str | None = Field(default=None, description="Street name")
+    housenumber: str | None = Field(default=None, description="House or building number")
+    neighbourhood: str | None = Field(default=None, description="Neighbourhood name")
+    locality: str | None = Field(default=None, description="City or town")
+    region: str | None = Field(default=None, description="State or province")
+    country: str | None = Field(default=None, description="Country name")
+    postalcode: str | None = Field(default=None, description="Postal or ZIP code")
+    confidence: float | None = Field(default=None, description="Pelias confidence score (0-1)")
+    status: str = Field(description="Geocoding status: success, no_coverage, error, pending")
+    geocoded_at: datetime | None = Field(default=None, description="UTC timestamp when geocoding was performed")
+
+
+class GeocodedAddressSummary(BaseModel):
+    """Compact address summary embedded in track-point payloads."""
+
+    display_address: str | None = Field(default=None, description="Full formatted address label from Pelias")
+    locality: str | None = Field(default=None, description="City or town")
+    region: str | None = Field(default=None, description="State or province")
+    country: str | None = Field(default=None, description="Country name")
+    waypoint_kind: WaypointKind | None = Field(default=None, description="Role of this waypoint (Garmin only)")
+    status: str = Field(description="Geocoding status: success, no_coverage, error, pending")

--- a/app/models/geocoding.py
+++ b/app/models/geocoding.py
@@ -56,8 +56,7 @@ class GeocodingStatus(BaseModel):
     no_coverage: int = Field(description="Number of locations outside Pelias coverage area")
     errors: int = Field(description="Number of locations that failed geocoding")
     coverage_percent: float = Field(description="Percentage of locations with a geocoded address")
-    by_source: GeocodingStatusBySource | None = Field(
-        default=None,
+    by_source: GeocodingStatusBySource = Field(
         description="Per-source breakdown of geocoding coverage (owntracks, garmin)",
     )
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from datetime import date
-from typing import Literal
+from typing import Any, Literal
 
 import fastapi
 import httpx
@@ -22,6 +23,7 @@ from app.models.garmin import (
     GarminTrackPoint,
     SportInfo,
 )
+from app.models.geocoding import GarminActivityAddress, GeocodedAddressSummary
 
 router = APIRouter(prefix="/api/v1/garmin", tags=["Garmin"])
 logger = structlog.get_logger(__name__)
@@ -391,28 +393,39 @@ async def list_track_points(
             "    ON gtp.longitude = sc.lng AND gtp.latitude = sc.lat "
             "  WHERE gtp.activity_id = $1"
             ") "
-            "SELECT id, activity_id, latitude, longitude, "
-            "timestamp, altitude, distance_from_start_km, speed_kmh, "
-            "heart_rate, cadence, temperature_c, created_at "
-            "FROM matched WHERE rn = 1 "
-            f"ORDER BY timestamp {order}",
+            "SELECT m.id, m.activity_id, m.latitude, m.longitude, "
+            "m.timestamp, m.altitude, m.distance_from_start_km, m.speed_kmh, "
+            "m.heart_rate, m.cadence, m.temperature_c, m.created_at, "
+            "ga.display_address, ga.locality, ga.region, ga.country, "
+            "ga.waypoint_kind, ga.status AS address_status "
+            "FROM matched m "
+            "LEFT JOIN public.geocoded_addresses ga "
+            "  ON ga.garmin_track_point_id = m.id AND ga.source = 'garmin' "
+            "WHERE m.rn = 1 "
+            f"ORDER BY m.timestamp {order}",
             activity_id,
             simplify,
         )
-        items = [GarminTrackPoint(**dict(row)) for row in rows]
+        items = [_row_to_track_point(row) for row in rows]
         return PaginatedResponse(items=items, total=total, limit=len(items), offset=0)
 
     rows = await db.fetch(
-        "SELECT id, activity_id, latitude, longitude, timestamp, altitude, "
-        "distance_from_start_km, speed_kmh, heart_rate, cadence, temperature_c, "
-        f"created_at FROM public.garmin_track_points WHERE activity_id = $1 ORDER BY {sort} {order} "
+        "SELECT gtp.id, gtp.activity_id, gtp.latitude, gtp.longitude, gtp.timestamp, "
+        "gtp.altitude, gtp.distance_from_start_km, gtp.speed_kmh, gtp.heart_rate, "
+        "gtp.cadence, gtp.temperature_c, gtp.created_at, "
+        "ga.display_address, ga.locality, ga.region, ga.country, "
+        "ga.waypoint_kind, ga.status AS address_status "
+        "FROM public.garmin_track_points gtp "
+        "LEFT JOIN public.geocoded_addresses ga "
+        "  ON ga.garmin_track_point_id = gtp.id AND ga.source = 'garmin' "
+        f"WHERE gtp.activity_id = $1 ORDER BY gtp.{sort} {order} "
         f"LIMIT $2 OFFSET $3",
         activity_id,
         limit,
         offset,
     )
 
-    items = [GarminTrackPoint(**dict(row)) for row in rows]
+    items = [_row_to_track_point(row) for row in rows]
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
@@ -445,3 +458,62 @@ async def get_chart_data(
     )
 
     return [GarminChartPoint(**dict(row)) for row in rows]
+
+
+def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:
+    """Build a GarminTrackPoint, attaching the joined address summary when present."""
+    data: dict[str, Any] = dict(row)
+    address_status = data.pop("address_status", None)
+    display_address = data.pop("display_address", None)
+    locality = data.pop("locality", None)
+    region = data.pop("region", None)
+    country = data.pop("country", None)
+    waypoint_kind = data.pop("waypoint_kind", None)
+    address: GeocodedAddressSummary | None = None
+    if address_status is not None:
+        address = GeocodedAddressSummary(
+            display_address=display_address,
+            locality=locality,
+            region=region,
+            country=country,
+            waypoint_kind=waypoint_kind,
+            status=address_status,
+        )
+    return GarminTrackPoint(**data, address=address)
+
+
+@router.get(
+    "/activities/{activity_id}/addresses",
+    response_model=list[GarminActivityAddress],
+    responses={404: {"description": "Activity not found"}},
+)
+async def list_activity_addresses(
+    request: Request,
+    activity_id: str = fastapi.Path(description="Garmin activity ID", examples=["20932993811"]),
+) -> list[GarminActivityAddress]:
+    """Return all reverse-geocoded addresses for a Garmin activity, in timestamp order.
+
+    Includes start, end, and mid-route waypoints as persisted by the Garmin
+    geocoding pipeline.
+    """
+    db = request.app.state.db
+
+    exists = await db.fetchval("SELECT 1 FROM public.garmin_activities WHERE activity_id = $1", activity_id)
+    if not exists:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    rows = await db.fetch(
+        "SELECT ga.garmin_track_point_id AS track_point_id, "
+        "ga.garmin_activity_id AS activity_id, ga.waypoint_kind, "
+        "gtp.timestamp, gtp.latitude, gtp.longitude, "
+        "ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
+        "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "
+        "ga.status, ga.geocoded_at "
+        "FROM public.geocoded_addresses ga "
+        "INNER JOIN public.garmin_track_points gtp ON gtp.id = ga.garmin_track_point_id "
+        "WHERE ga.source = 'garmin' AND ga.garmin_activity_id = $1 "
+        "ORDER BY gtp.timestamp ASC",
+        activity_id,
+    )
+
+    return [GarminActivityAddress(**dict(row)) for row in rows]

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -512,7 +512,9 @@ async def list_activity_addresses(
         "FROM public.geocoded_addresses ga "
         "INNER JOIN public.garmin_track_points gtp ON gtp.id = ga.garmin_track_point_id "
         "WHERE ga.source = 'garmin' AND ga.garmin_activity_id = $1 "
-        "ORDER BY gtp.timestamp ASC",
+        "ORDER BY CASE ga.waypoint_kind "
+        "WHEN 'start' THEN 0 WHEN 'waypoint' THEN 1 WHEN 'end' THEN 2 ELSE 3 END, "
+        "gtp.timestamp ASC",
         activity_id,
     )
 

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -395,6 +395,17 @@ async def _process_garmin_waypoint(
         )
     except TimeoutError:
         logger.warning("Database timeout for garmin track point %d, skipping", track_point_id)
+        # Persist an error status row so this waypoint can be retried with
+        # retry_failed=True; otherwise the activity selection query would
+        # consider this activity "done" once any other waypoint succeeds.
+        try:
+            await _upsert_garmin_status(db, track_point_id, activity_id, waypoint_kind, status="error")
+        except Exception:
+            logger.warning(
+                "Failed to upsert error status after timeout for garmin track point %d",
+                track_point_id,
+                exc_info=True,
+            )
         return 0, 0
     except Exception:
         logger.warning("Unexpected error processing garmin track point %d", track_point_id, exc_info=True)

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -1,4 +1,4 @@
-"""Geocoding management endpoints for reverse-geocoding OwnTracks locations."""
+"""Geocoding management endpoints for reverse-geocoding OwnTracks + Garmin records."""
 
 from __future__ import annotations
 
@@ -11,7 +11,12 @@ import structlog
 from fastapi import APIRouter, Depends, Query, Request
 
 from app.auth import require_auth
-from app.models.geocoding import GeocodingStatus, GeocodingTriggerResponse
+from app.models.geocoding import (
+    GeocodingSourceStatus,
+    GeocodingStatus,
+    GeocodingStatusBySource,
+    GeocodingTriggerResponse,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -20,30 +25,88 @@ internal_router = APIRouter(prefix="/internal/geocoding", tags=["Internal"])
 
 PELIAS_REVERSE_PATH = "/v1/reverse"
 MAX_GEOCODE_CONCURRENCY = 5
+DEFAULT_GARMIN_WAYPOINT_SPACING_KM = 1.0
+
+_OT_CONFLICT = "ON CONFLICT (location_id) WHERE source = 'owntracks'"
+_GARMIN_CONFLICT = "ON CONFLICT (garmin_track_point_id) WHERE source = 'garmin'"
 
 
 @router.get("/status", response_model=GeocodingStatus)
 async def geocoding_status(request: Request) -> GeocodingStatus:
-    """Get geocoding coverage statistics."""
+    """Get geocoding coverage statistics for both OwnTracks and Garmin sources."""
     db = request.app.state.db
 
     total = await db.fetchval("SELECT COUNT(*) FROM public.locations")
-    geocoded = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses")
-    success = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses WHERE status = 'success'")
-    pending = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses WHERE status = 'pending'")
-    no_coverage = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses WHERE status = 'no_coverage'")
-    errors = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses WHERE status = 'error'")
+    geocoded = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks'")
+    ot_success = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'success'"
+    )
+    ot_pending = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'pending'"
+    )
+    ot_no_coverage = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'no_coverage'"
+    )
+    ot_errors = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'error'"
+    )
     coverage_percent = round((geocoded / total * 100), 2) if total > 0 else 0.0
+
+    g_success = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'success'"
+    )
+    g_pending = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'pending'"
+    )
+    g_no_coverage = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'no_coverage'"
+    )
+    g_errors = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'error'"
+    )
+    g_total_rows = (g_success or 0) + (g_pending or 0) + (g_no_coverage or 0) + (g_errors or 0)
+
+    activities_total = await db.fetchval("SELECT COUNT(*) FROM public.garmin_activities")
+    activities_geocoded = await db.fetchval(
+        "SELECT COUNT(DISTINCT garmin_activity_id) FROM public.geocoded_addresses WHERE source = 'garmin'"
+    )
+    garmin_coverage_percent = round((activities_geocoded / activities_total * 100), 2) if activities_total else 0.0
+
+    by_source = GeocodingStatusBySource(
+        owntracks=GeocodingSourceStatus(
+            success=ot_success or 0,
+            pending=ot_pending or 0,
+            no_coverage=ot_no_coverage or 0,
+            errors=ot_errors or 0,
+            total=geocoded or 0,
+        ),
+        garmin=GeocodingSourceStatus(
+            success=g_success or 0,
+            pending=g_pending or 0,
+            no_coverage=g_no_coverage or 0,
+            errors=g_errors or 0,
+            total=g_total_rows,
+        ),
+        garmin_activities_total=activities_total or 0,
+        garmin_activities_geocoded=activities_geocoded or 0,
+        garmin_coverage_percent=garmin_coverage_percent,
+    )
 
     return GeocodingStatus(
         total_locations=total,
         geocoded=geocoded,
-        success=success,
-        pending=pending,
-        no_coverage=no_coverage,
-        errors=errors,
+        success=ot_success,
+        pending=ot_pending,
+        no_coverage=ot_no_coverage,
+        errors=ot_errors,
         coverage_percent=coverage_percent,
+        by_source=by_source,
     )
+
+
+# ---------------------------------------------------------------------------
+# OwnTracks trigger
+# ---------------------------------------------------------------------------
 
 
 @router.post("/trigger", response_model=GeocodingTriggerResponse)
@@ -53,12 +116,7 @@ async def trigger_geocoding(
     retry_failed: bool = Query(False, description="Re-process records with status no_coverage"),
     _user: dict = Depends(require_auth),
 ) -> GeocodingTriggerResponse:
-    """Trigger batch reverse-geocoding of un-geocoded location records (auth required).
-
-    Fetches the next batch of locations without a geocoded address and calls
-    the Pelias reverse-geocoder for each one.  Duplicate nearby coordinates
-    (within 50 m) that already have a geocoded address are skipped.
-    """
+    """Trigger batch reverse-geocoding of OwnTracks location records (auth required)."""
     return await _trigger_geocoding_impl(request, batch_size, retry_failed)
 
 
@@ -68,11 +126,7 @@ async def internal_trigger_geocoding(
     batch_size: int = Query(100, ge=1, le=1000, description="Number of locations to geocode in this batch"),
     retry_failed: bool = Query(False, description="Re-process records with status no_coverage"),
 ) -> GeocodingTriggerResponse:
-    """Trigger batch reverse-geocoding (internal, no auth).
-
-    Identical to the public trigger endpoint but intended for in-cluster
-    callers such as the geocoding-backfill agent.
-    """
+    """Trigger batch OwnTracks reverse-geocoding (internal, no auth)."""
     return await _trigger_geocoding_impl(request, batch_size, retry_failed)
 
 
@@ -81,7 +135,6 @@ async def _trigger_geocoding_impl(
     batch_size: int,
     retry_failed: bool,
 ) -> GeocodingTriggerResponse:
-    """Shared batch reverse-geocoding logic used by both public and internal endpoints."""
     db = request.app.state.db
     config = request.app.state.config
     pelias_base_url = config.pelias_base_url
@@ -92,7 +145,7 @@ async def _trigger_geocoding_impl(
             "SELECT l.id, l.latitude, l.longitude "
             "FROM public.locations l "
             "INNER JOIN public.geocoded_addresses ga ON ga.location_id = l.id "
-            "WHERE ga.status = 'no_coverage' "
+            "WHERE ga.source = 'owntracks' AND ga.status = 'no_coverage' "
             "ORDER BY l.id LIMIT $1",
             batch_size,
         )
@@ -100,7 +153,8 @@ async def _trigger_geocoding_impl(
         rows = await db.fetch(
             "SELECT l.id, l.latitude, l.longitude "
             "FROM public.locations l "
-            "LEFT JOIN public.geocoded_addresses ga ON ga.location_id = l.id "
+            "LEFT JOIN public.geocoded_addresses ga "
+            "  ON ga.location_id = l.id AND ga.source = 'owntracks' "
             "WHERE ga.id IS NULL "
             "ORDER BY l.id LIMIT $1",
             batch_size,
@@ -110,10 +164,7 @@ async def _trigger_geocoding_impl(
     skipped_dedup = 0
     sem = asyncio.Semaphore(MAX_GEOCODE_CONCURRENCY)
 
-    async def _geocode_one(
-        client: httpx.AsyncClient,
-        row: dict[str, Any],
-    ) -> tuple[int, int]:
+    async def _geocode_one(client: httpx.AsyncClient, row: dict[str, Any]) -> tuple[int, int]:
         async with sem:
             return await _process_location(db, client, pelias_base_url, row)
 
@@ -125,7 +176,8 @@ async def _trigger_geocoding_impl(
 
     remaining = await db.fetchval(
         "SELECT COUNT(*) FROM public.locations l "
-        "LEFT JOIN public.geocoded_addresses ga ON ga.location_id = l.id "
+        "LEFT JOIN public.geocoded_addresses ga "
+        "  ON ga.location_id = l.id AND ga.source = 'owntracks' "
         "WHERE ga.id IS NULL"
     )
 
@@ -138,10 +190,7 @@ async def _process_location(
     pelias_base_url: str,
     row: dict[str, Any],
 ) -> tuple[int, int]:
-    """Process a single location for reverse geocoding.
-
-    Returns ``(processed, skipped_dedup)`` counts.
-    """
+    """Process a single OwnTracks location for reverse geocoding."""
     location_id = row["id"]
     lat = row["latitude"]
     lon = row["longitude"]
@@ -154,7 +203,7 @@ async def _process_location(
     except Exception:
         logger.warning("Unexpected error processing location %d", location_id, exc_info=True)
         try:
-            await _upsert_geocoded(db, location_id, status="error")
+            await _upsert_owntracks_status(db, location_id, status="error")
         except Exception:
             logger.warning("Failed to upsert error status for location %d", location_id, exc_info=True)
         return 0, 0
@@ -168,86 +217,322 @@ async def _process_location_inner(
     lat: float,
     lon: float,
 ) -> tuple[int, int]:
-    """Core logic for processing a single location (may raise on timeout)."""
-    # Proximity dedup: fetch the nearest geocoded neighbour within 50 m
-    # in a single query (combines the EXISTS check and address fetch).
-    # Uses the pre-computed l.geog column with a GIST index.
+    """OwnTracks geocoding: proximity dedup -> Pelias -> upsert."""
+    neighbour = await _find_nearby_address(db, lat, lon)
+    if neighbour:
+        await _persist_owntracks_from_neighbour(db, location_id, neighbour)
+        return 0, 1
+
+    pelias_data = await _call_pelias(client, pelias_base_url, lat, lon)
+    if pelias_data is None:
+        await _upsert_owntracks_status(db, location_id, status="error")
+        return 1, 0
+
+    features = pelias_data.get("features", [])
+    if not features:
+        await _upsert_owntracks_status(db, location_id, status="no_coverage")
+        return 1, 0
+
+    props = features[0].get("properties", {})
+    await _persist_owntracks_from_pelias(db, location_id, props, pelias_data)
+    return 1, 0
+
+
+# ---------------------------------------------------------------------------
+# Garmin trigger
+# ---------------------------------------------------------------------------
+
+
+@internal_router.post("/trigger/garmin", response_model=GeocodingTriggerResponse)
+async def internal_trigger_garmin_geocoding(
+    request: Request,
+    batch_size: int = Query(10, ge=1, le=100, description="Number of Garmin activities to process in this batch"),
+    waypoint_spacing_km: float = Query(
+        DEFAULT_GARMIN_WAYPOINT_SPACING_KM,
+        ge=0.1,
+        le=50.0,
+        description="Approximate spacing between mid-route waypoints in kilometres",
+    ),
+    retry_failed: bool = Query(False, description="Re-process activities with at least one no_coverage waypoint"),
+) -> GeocodingTriggerResponse:
+    """Trigger batch reverse-geocoding of Garmin activity waypoints (internal, no auth).
+
+    For each selected activity, picks the start, end, and every-``waypoint_spacing_km`` mid-route
+    track point as waypoints, then reverse-geocodes each one through Pelias.
+    """
+    return await _trigger_garmin_geocoding_impl(request, batch_size, waypoint_spacing_km, retry_failed)
+
+
+@router.post("/trigger/garmin", response_model=GeocodingTriggerResponse)
+async def trigger_garmin_geocoding(
+    request: Request,
+    batch_size: int = Query(10, ge=1, le=100, description="Number of Garmin activities to process in this batch"),
+    waypoint_spacing_km: float = Query(
+        DEFAULT_GARMIN_WAYPOINT_SPACING_KM,
+        ge=0.1,
+        le=50.0,
+        description="Approximate spacing between mid-route waypoints in kilometres",
+    ),
+    retry_failed: bool = Query(False, description="Re-process activities with at least one no_coverage waypoint"),
+    _user: dict = Depends(require_auth),
+) -> GeocodingTriggerResponse:
+    """Trigger batch reverse-geocoding of Garmin activity waypoints (auth required)."""
+    return await _trigger_garmin_geocoding_impl(request, batch_size, waypoint_spacing_km, retry_failed)
+
+
+async def _trigger_garmin_geocoding_impl(
+    request: Request,
+    batch_size: int,
+    waypoint_spacing_km: float,
+    retry_failed: bool,
+) -> GeocodingTriggerResponse:
+    db = request.app.state.db
+    config = request.app.state.config
+    pelias_base_url = config.pelias_base_url
+    pelias_timeout = config.pelias_timeout_seconds
+
+    if retry_failed:
+        activity_rows = await db.fetch(
+            "SELECT DISTINCT a.activity_id "
+            "FROM public.garmin_activities a "
+            "INNER JOIN public.geocoded_addresses ga "
+            "  ON ga.garmin_activity_id = a.activity_id AND ga.source = 'garmin' "
+            "WHERE ga.status = 'no_coverage' "
+            "ORDER BY a.activity_id LIMIT $1",
+            batch_size,
+        )
+    else:
+        activity_rows = await db.fetch(
+            "SELECT a.activity_id "
+            "FROM public.garmin_activities a "
+            "LEFT JOIN public.geocoded_addresses ga "
+            "  ON ga.garmin_activity_id = a.activity_id AND ga.source = 'garmin' "
+            "WHERE ga.id IS NULL "
+            "GROUP BY a.activity_id "
+            "ORDER BY MAX(a.start_time) DESC NULLS LAST "
+            "LIMIT $1",
+            batch_size,
+        )
+
+    processed = 0
+    skipped_dedup = 0
+    sem = asyncio.Semaphore(MAX_GEOCODE_CONCURRENCY)
+
+    async def _geocode_one(client: httpx.AsyncClient, waypoint: dict[str, Any]) -> tuple[int, int]:
+        async with sem:
+            return await _process_garmin_waypoint(db, client, pelias_base_url, waypoint)
+
+    async with httpx.AsyncClient(timeout=pelias_timeout) as client:
+        for activity in activity_rows:
+            activity_id = activity["activity_id"]
+            waypoints = await _select_garmin_waypoints(db, activity_id, waypoint_spacing_km)
+            results = await asyncio.gather(*[_geocode_one(client, wp) for wp in waypoints])
+            for proc, skip in results:
+                processed += proc
+                skipped_dedup += skip
+
+    remaining = await db.fetchval(
+        "SELECT COUNT(*) FROM public.garmin_activities a "
+        "LEFT JOIN public.geocoded_addresses ga "
+        "  ON ga.garmin_activity_id = a.activity_id AND ga.source = 'garmin' "
+        "WHERE ga.id IS NULL"
+    )
+
+    return GeocodingTriggerResponse(processed=processed, remaining=remaining, skipped_dedup=skipped_dedup)
+
+
+async def _select_garmin_waypoints(
+    db: Any,
+    activity_id: str,
+    spacing_km: float,
+) -> list[dict[str, Any]]:
+    """Pick start, end, and every-``spacing_km`` mid-route waypoints from an activity's track."""
+    rows = await db.fetch(
+        "SELECT id, latitude, longitude, timestamp, distance_from_start_km "
+        "FROM public.garmin_track_points "
+        "WHERE activity_id = $1 "
+        "ORDER BY timestamp ASC",
+        activity_id,
+    )
+    if not rows:
+        return []
+
+    points = [dict(r) for r in rows]
+    waypoints: list[dict[str, Any]] = []
+    waypoints.append({**points[0], "waypoint_kind": "start", "activity_id": activity_id})
+
+    last_d = points[0].get("distance_from_start_km") or 0.0
+    for p in points[1:-1]:
+        d = p.get("distance_from_start_km")
+        if d is None:
+            continue
+        if d - last_d >= spacing_km:
+            waypoints.append({**p, "waypoint_kind": "waypoint", "activity_id": activity_id})
+            last_d = d
+
+    if len(points) > 1:
+        waypoints.append({**points[-1], "waypoint_kind": "end", "activity_id": activity_id})
+
+    return waypoints
+
+
+async def _process_garmin_waypoint(
+    db: Any,
+    client: httpx.AsyncClient,
+    pelias_base_url: str,
+    waypoint: dict[str, Any],
+) -> tuple[int, int]:
+    """Process a single Garmin waypoint (start/end/mid) for reverse geocoding."""
+    track_point_id = waypoint["id"]
+    activity_id = waypoint["activity_id"]
+    waypoint_kind = waypoint["waypoint_kind"]
+    lat = waypoint["latitude"]
+    lon = waypoint["longitude"]
+
+    try:
+        return await _process_garmin_waypoint_inner(
+            db, client, pelias_base_url, track_point_id, activity_id, waypoint_kind, lat, lon
+        )
+    except TimeoutError:
+        logger.warning("Database timeout for garmin track point %d, skipping", track_point_id)
+        return 0, 0
+    except Exception:
+        logger.warning("Unexpected error processing garmin track point %d", track_point_id, exc_info=True)
+        try:
+            await _upsert_garmin_status(db, track_point_id, activity_id, waypoint_kind, status="error")
+        except Exception:
+            logger.warning(
+                "Failed to upsert error status for garmin track point %d",
+                track_point_id,
+                exc_info=True,
+            )
+        return 0, 0
+
+
+async def _process_garmin_waypoint_inner(
+    db: Any,
+    client: httpx.AsyncClient,
+    pelias_base_url: str,
+    track_point_id: int,
+    activity_id: str,
+    waypoint_kind: str,
+    lat: float,
+    lon: float,
+) -> tuple[int, int]:
+    """Garmin geocoding: proximity dedup -> Pelias -> upsert with FKs + waypoint_kind."""
+    neighbour = await _find_nearby_address(db, lat, lon)
+    if neighbour:
+        await _persist_garmin_from_neighbour(db, track_point_id, activity_id, waypoint_kind, neighbour)
+        return 0, 1
+
+    pelias_data = await _call_pelias(client, pelias_base_url, lat, lon)
+    if pelias_data is None:
+        await _upsert_garmin_status(db, track_point_id, activity_id, waypoint_kind, status="error")
+        return 1, 0
+
+    features = pelias_data.get("features", [])
+    if not features:
+        await _upsert_garmin_status(db, track_point_id, activity_id, waypoint_kind, status="no_coverage")
+        return 1, 0
+
+    props = features[0].get("properties", {})
+    await _persist_garmin_from_pelias(db, track_point_id, activity_id, waypoint_kind, props, pelias_data)
+    return 1, 0
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers: Pelias call, proximity dedup, persistence
+# ---------------------------------------------------------------------------
+
+
+async def _find_nearby_address(db: Any, lat: float, lon: float) -> dict[str, Any] | None:
+    """Return the nearest successfully geocoded address within 50 m, or None."""
     neighbour = await db.fetchrow(
         "SELECT ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
         "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "
         "ga.raw_response "
         "FROM public.geocoded_addresses ga "
-        "INNER JOIN public.locations l ON l.id = ga.location_id "
+        "LEFT JOIN public.locations l ON l.id = ga.location_id AND ga.source = 'owntracks' "
+        "LEFT JOIN public.garmin_track_points gtp "
+        "  ON gtp.id = ga.garmin_track_point_id AND ga.source = 'garmin' "
         "WHERE ga.status = 'success' "
         "AND ST_DWithin("
-        "  l.geog, "
+        "  COALESCE(l.geog, ST_SetSRID(ST_MakePoint(gtp.longitude, gtp.latitude), 4326)::geography), "
         "  ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, "
         "  50"
         ") "
         "ORDER BY ST_Distance("
-        "  l.geog, "
+        "  COALESCE(l.geog, ST_SetSRID(ST_MakePoint(gtp.longitude, gtp.latitude), 4326)::geography), "
         "  ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography"
         ") LIMIT 1",
         lon,
         lat,
     )
+    return dict(neighbour) if neighbour else None
 
-    if neighbour:
-        n = dict(neighbour)
-        await db.execute(
-            "INSERT INTO public.geocoded_addresses "
-            "(location_id, source, display_address, street, housenumber, "
-            "neighbourhood, locality, region, country, postalcode, "
-            "confidence, status, raw_response) "
-            "VALUES ($1, 'owntracks', $2, $3, $4, $5, $6, $7, $8, $9, $10, 'success', $11) "
-            "ON CONFLICT (location_id) DO UPDATE SET "
-            "display_address = EXCLUDED.display_address, "
-            "street = EXCLUDED.street, housenumber = EXCLUDED.housenumber, "
-            "neighbourhood = EXCLUDED.neighbourhood, locality = EXCLUDED.locality, "
-            "region = EXCLUDED.region, country = EXCLUDED.country, "
-            "postalcode = EXCLUDED.postalcode, confidence = EXCLUDED.confidence, "
-            "status = EXCLUDED.status, raw_response = EXCLUDED.raw_response, "
-            "geocoded_at = CURRENT_TIMESTAMP",
-            location_id,
-            n["display_address"],
-            n["street"],
-            n["housenumber"],
-            n["neighbourhood"],
-            n["locality"],
-            n["region"],
-            n["country"],
-            n["postalcode"],
-            n["confidence"],
-            n["raw_response"],
-        )
-        return 0, 1
 
-    # Call Pelias reverse geocoder
+async def _call_pelias(
+    client: httpx.AsyncClient,
+    pelias_base_url: str,
+    lat: float,
+    lon: float,
+) -> dict[str, Any] | None:
+    """Call the Pelias reverse-geocoder. Returns parsed JSON or None on transport error."""
     try:
         resp = await client.get(
             f"{pelias_base_url}{PELIAS_REVERSE_PATH}",
             params={"point.lat": lat, "point.lon": lon, "size": 1},
         )
         resp.raise_for_status()
-        data = resp.json()
+        data: dict[str, Any] = resp.json()
+        return data
     except httpx.HTTPError:
-        logger.warning("Pelias request failed for location %d", location_id, exc_info=True)
-        await _upsert_geocoded(db, location_id, status="error")
-        return 1, 0
+        logger.warning("Pelias request failed", exc_info=True)
+        return None
 
-    features = data.get("features", [])
-    if not features:
-        await _upsert_geocoded(db, location_id, status="no_coverage")
-        return 1, 0
 
-    props = features[0].get("properties", {})
+# --- OwnTracks persistence -------------------------------------------------
+
+
+async def _persist_owntracks_from_neighbour(db: Any, location_id: int, neighbour: dict[str, Any]) -> None:
     await db.execute(
         "INSERT INTO public.geocoded_addresses "
         "(location_id, source, display_address, street, housenumber, "
         "neighbourhood, locality, region, country, postalcode, "
         "confidence, status, raw_response) "
         "VALUES ($1, 'owntracks', $2, $3, $4, $5, $6, $7, $8, $9, $10, 'success', $11) "
-        "ON CONFLICT (location_id) DO UPDATE SET "
+        f"{_OT_CONFLICT} DO UPDATE SET "
+        "display_address = EXCLUDED.display_address, "
+        "street = EXCLUDED.street, housenumber = EXCLUDED.housenumber, "
+        "neighbourhood = EXCLUDED.neighbourhood, locality = EXCLUDED.locality, "
+        "region = EXCLUDED.region, country = EXCLUDED.country, "
+        "postalcode = EXCLUDED.postalcode, confidence = EXCLUDED.confidence, "
+        "status = EXCLUDED.status, raw_response = EXCLUDED.raw_response, "
+        "geocoded_at = CURRENT_TIMESTAMP",
+        location_id,
+        neighbour["display_address"],
+        neighbour["street"],
+        neighbour["housenumber"],
+        neighbour["neighbourhood"],
+        neighbour["locality"],
+        neighbour["region"],
+        neighbour["country"],
+        neighbour["postalcode"],
+        neighbour["confidence"],
+        neighbour["raw_response"],
+    )
+
+
+async def _persist_owntracks_from_pelias(
+    db: Any, location_id: int, props: dict[str, Any], raw_data: dict[str, Any]
+) -> None:
+    await db.execute(
+        "INSERT INTO public.geocoded_addresses "
+        "(location_id, source, display_address, street, housenumber, "
+        "neighbourhood, locality, region, country, postalcode, "
+        "confidence, status, raw_response) "
+        "VALUES ($1, 'owntracks', $2, $3, $4, $5, $6, $7, $8, $9, $10, 'success', $11) "
+        f"{_OT_CONFLICT} DO UPDATE SET "
         "display_address = EXCLUDED.display_address, "
         "street = EXCLUDED.street, housenumber = EXCLUDED.housenumber, "
         "neighbourhood = EXCLUDED.neighbourhood, locality = EXCLUDED.locality, "
@@ -265,17 +550,127 @@ async def _process_location_inner(
         props.get("country"),
         props.get("postalcode"),
         props.get("confidence"),
-        json.dumps(data),
+        json.dumps(raw_data),
     )
-    return 1, 0
 
 
-async def _upsert_geocoded(db: Any, location_id: int, *, status: str) -> None:
-    """Insert or update a geocoded_addresses row with only a status (no address data)."""
+async def _upsert_owntracks_status(db: Any, location_id: int, *, status: str) -> None:
+    """Insert or update an OwnTracks status-only row."""
     await db.execute(
         "INSERT INTO public.geocoded_addresses (location_id, source, status) "
         "VALUES ($1, 'owntracks', $2) "
-        "ON CONFLICT (location_id) DO UPDATE SET status = $2, geocoded_at = CURRENT_TIMESTAMP",
+        f"{_OT_CONFLICT} DO UPDATE SET status = $2, geocoded_at = CURRENT_TIMESTAMP",
         location_id,
+        status,
+    )
+
+
+# Back-compat alias kept for existing tests that imported _upsert_geocoded.
+_upsert_geocoded = _upsert_owntracks_status
+
+
+# --- Garmin persistence ----------------------------------------------------
+
+
+async def _persist_garmin_from_neighbour(
+    db: Any,
+    track_point_id: int,
+    activity_id: str,
+    waypoint_kind: str,
+    neighbour: dict[str, Any],
+) -> None:
+    await db.execute(
+        "INSERT INTO public.geocoded_addresses "
+        "(garmin_track_point_id, garmin_activity_id, waypoint_kind, source, "
+        "display_address, street, housenumber, neighbourhood, locality, "
+        "region, country, postalcode, confidence, status, raw_response) "
+        "VALUES ($1, $2, $3, 'garmin', $4, $5, $6, $7, $8, $9, $10, $11, $12, 'success', $13) "
+        f"{_GARMIN_CONFLICT} DO UPDATE SET "
+        "garmin_activity_id = EXCLUDED.garmin_activity_id, "
+        "waypoint_kind = EXCLUDED.waypoint_kind, "
+        "display_address = EXCLUDED.display_address, "
+        "street = EXCLUDED.street, housenumber = EXCLUDED.housenumber, "
+        "neighbourhood = EXCLUDED.neighbourhood, locality = EXCLUDED.locality, "
+        "region = EXCLUDED.region, country = EXCLUDED.country, "
+        "postalcode = EXCLUDED.postalcode, confidence = EXCLUDED.confidence, "
+        "status = EXCLUDED.status, raw_response = EXCLUDED.raw_response, "
+        "geocoded_at = CURRENT_TIMESTAMP",
+        track_point_id,
+        activity_id,
+        waypoint_kind,
+        neighbour["display_address"],
+        neighbour["street"],
+        neighbour["housenumber"],
+        neighbour["neighbourhood"],
+        neighbour["locality"],
+        neighbour["region"],
+        neighbour["country"],
+        neighbour["postalcode"],
+        neighbour["confidence"],
+        neighbour["raw_response"],
+    )
+
+
+async def _persist_garmin_from_pelias(
+    db: Any,
+    track_point_id: int,
+    activity_id: str,
+    waypoint_kind: str,
+    props: dict[str, Any],
+    raw_data: dict[str, Any],
+) -> None:
+    await db.execute(
+        "INSERT INTO public.geocoded_addresses "
+        "(garmin_track_point_id, garmin_activity_id, waypoint_kind, source, "
+        "display_address, street, housenumber, neighbourhood, locality, "
+        "region, country, postalcode, confidence, status, raw_response) "
+        "VALUES ($1, $2, $3, 'garmin', $4, $5, $6, $7, $8, $9, $10, $11, $12, 'success', $13) "
+        f"{_GARMIN_CONFLICT} DO UPDATE SET "
+        "garmin_activity_id = EXCLUDED.garmin_activity_id, "
+        "waypoint_kind = EXCLUDED.waypoint_kind, "
+        "display_address = EXCLUDED.display_address, "
+        "street = EXCLUDED.street, housenumber = EXCLUDED.housenumber, "
+        "neighbourhood = EXCLUDED.neighbourhood, locality = EXCLUDED.locality, "
+        "region = EXCLUDED.region, country = EXCLUDED.country, "
+        "postalcode = EXCLUDED.postalcode, confidence = EXCLUDED.confidence, "
+        "status = EXCLUDED.status, raw_response = EXCLUDED.raw_response, "
+        "geocoded_at = CURRENT_TIMESTAMP",
+        track_point_id,
+        activity_id,
+        waypoint_kind,
+        props.get("label"),
+        props.get("street"),
+        props.get("housenumber"),
+        props.get("neighbourhood"),
+        props.get("locality"),
+        props.get("region"),
+        props.get("country"),
+        props.get("postalcode"),
+        props.get("confidence"),
+        json.dumps(raw_data),
+    )
+
+
+async def _upsert_garmin_status(
+    db: Any,
+    track_point_id: int,
+    activity_id: str,
+    waypoint_kind: str,
+    *,
+    status: str,
+) -> None:
+    """Insert or update a Garmin status-only row."""
+    await db.execute(
+        "INSERT INTO public.geocoded_addresses "
+        "(garmin_track_point_id, garmin_activity_id, waypoint_kind, source, status) "
+        "VALUES ($1, $2, $3, 'garmin', $4) "
+        f"{_GARMIN_CONFLICT} DO UPDATE SET "
+        "garmin_activity_id = EXCLUDED.garmin_activity_id, "
+        "waypoint_kind = EXCLUDED.waypoint_kind, "
+        "status = EXCLUDED.status, "
+        "geocoded_at = CURRENT_TIMESTAMP",
+        track_point_id,
+        activity_id,
+        waypoint_kind,
         status,
     )

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
         "filterwarnings",
         "geocoded",
         "geocoder",
+        "geocodes",
         "geocoding",
         "geofence",
         "geofencing",

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -240,8 +240,9 @@ async def test_list_track_points_success_and_invalid_sort_falls_back(client: Asy
     assert len(data["items"]) == 1
 
     track_query, *params = mock_db.fetch.await_args.args
-    assert "ORDER BY timestamp desc" in track_query
+    assert "ORDER BY gtp.timestamp desc" in track_query
     assert "garmin_track_points" in track_query
+    assert "LEFT JOIN public.geocoded_addresses" in track_query
     assert params == ["20932993811", 5, 1]
 
 
@@ -286,7 +287,7 @@ async def test_list_track_points_simplify_respects_order(client: AsyncClient, mo
 
     assert response.status_code == 200
     query = mock_db.fetch.await_args.args[0]
-    assert "ORDER BY timestamp desc" in query
+    assert "ORDER BY m.timestamp desc" in query
 
 
 @pytest.mark.asyncio
@@ -679,3 +680,115 @@ async def test_garmin_date_range_empty_database(client: AsyncClient, mock_db):
     assert "MIN(start_time)" in query
     assert "MAX(start_time)" in query
     assert "FROM public.garmin_activities" in query
+
+
+# ---------------------------------------------------------------------------
+# Address-aware track points + per-activity addresses endpoint
+# ---------------------------------------------------------------------------
+
+
+def _track_row_with_address(activity_id: str = "20932993811") -> dict:
+    base = _track_row(activity_id)
+    base.update(
+        {
+            "display_address": "Pier 13, Hoboken, NJ",
+            "locality": "Hoboken",
+            "region": "New Jersey",
+            "country": "United States",
+            "waypoint_kind": "start",
+            "address_status": "success",
+        }
+    )
+    return base
+
+
+@pytest.mark.asyncio
+async def test_list_track_points_includes_address_when_present(client: AsyncClient, mock_db):
+    mock_db.fetchval.side_effect = [1, 1]
+    mock_db.fetch.return_value = [_track_row_with_address()]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/tracks")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["address"] is not None
+    assert item["address"]["display_address"] == "Pier 13, Hoboken, NJ"
+    assert item["address"]["waypoint_kind"] == "start"
+    assert item["address"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_list_track_points_address_null_when_missing(client: AsyncClient, mock_db):
+    mock_db.fetchval.side_effect = [1, 1]
+    mock_db.fetch.return_value = [_track_row()]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/tracks")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["address"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_activity_addresses_returns_ordered_list(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = [
+        {
+            "track_point_id": 1,
+            "activity_id": "20932993811",
+            "waypoint_kind": "start",
+            "timestamp": "2025-11-08T18:21:13+00:00",
+            "latitude": 40.715,
+            "longitude": -74.017,
+            "display_address": "Start Plaza",
+            "street": "Main St",
+            "housenumber": "1",
+            "neighbourhood": "Downtown",
+            "locality": "Hoboken",
+            "region": "New Jersey",
+            "country": "United States",
+            "postalcode": "07030",
+            "confidence": 0.9,
+            "status": "success",
+            "geocoded_at": "2026-02-12T08:10:55+00:00",
+        },
+        {
+            "track_point_id": 99,
+            "activity_id": "20932993811",
+            "waypoint_kind": "end",
+            "timestamp": "2025-11-08T19:00:00+00:00",
+            "latitude": 40.72,
+            "longitude": -74.02,
+            "display_address": "End Plaza",
+            "street": None,
+            "housenumber": None,
+            "neighbourhood": None,
+            "locality": "Hoboken",
+            "region": "New Jersey",
+            "country": "United States",
+            "postalcode": None,
+            "confidence": None,
+            "status": "success",
+            "geocoded_at": "2026-02-12T08:11:00+00:00",
+        },
+    ]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/addresses")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    assert body[0]["waypoint_kind"] == "start"
+    assert body[1]["waypoint_kind"] == "end"
+    query = mock_db.fetch.await_args.args[0]
+    assert "ga.source = 'garmin'" in query
+    assert "ORDER BY gtp.timestamp ASC" in query
+
+
+@pytest.mark.asyncio
+async def test_list_activity_addresses_not_found(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = None
+
+    response = await client.get("/api/v1/garmin/activities/missing/addresses")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -781,7 +781,12 @@ async def test_list_activity_addresses_returns_ordered_list(client: AsyncClient,
     assert body[1]["waypoint_kind"] == "end"
     query = mock_db.fetch.await_args.args[0]
     assert "ga.source = 'garmin'" in query
-    assert "ORDER BY gtp.timestamp ASC" in query
+    # Addresses are ordered by waypoint kind (start, waypoint, end), then timestamp.
+    assert "CASE ga.waypoint_kind" in query
+    assert "'start' THEN 0" in query
+    assert "'waypoint' THEN 1" in query
+    assert "'end' THEN 2" in query
+    assert "gtp.timestamp ASC" in query
 
 
 @pytest.mark.asyncio

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -14,7 +14,9 @@ from app.config import Config
 
 @pytest.mark.asyncio
 async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
-    mock_db.fetchval.side_effect = [1000, 600, 550, 30, 10, 10]
+    # Order: total, geocoded, ot_success, ot_pending, ot_no_coverage, ot_errors,
+    # g_success, g_pending, g_no_coverage, g_errors, activities_total, activities_geocoded
+    mock_db.fetchval.side_effect = [1000, 600, 550, 30, 10, 10, 80, 5, 4, 1, 25, 12]
 
     response = await client.get("/api/v1/geocoding/status")
 
@@ -27,11 +29,18 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     assert body["no_coverage"] == 10
     assert body["errors"] == 10
     assert body["coverage_percent"] == 60.0
+    assert body["by_source"]["owntracks"]["success"] == 550
+    assert body["by_source"]["owntracks"]["total"] == 600
+    assert body["by_source"]["garmin"]["success"] == 80
+    assert body["by_source"]["garmin"]["total"] == 90
+    assert body["by_source"]["garmin_activities_total"] == 25
+    assert body["by_source"]["garmin_activities_geocoded"] == 12
+    assert body["by_source"]["garmin_coverage_percent"] == 48.0
 
 
 @pytest.mark.asyncio
 async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: AsyncMock):
-    mock_db.fetchval.side_effect = [0, 0, 0, 0, 0, 0]
+    mock_db.fetchval.side_effect = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
     response = await client.get("/api/v1/geocoding/status")
 
@@ -39,6 +48,7 @@ async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: Asy
     body = response.json()
     assert body["total_locations"] == 0
     assert body["coverage_percent"] == 0.0
+    assert body["by_source"]["garmin_coverage_percent"] == 0.0
 
 
 @pytest.mark.asyncio
@@ -432,3 +442,85 @@ async def test_internal_trigger_disabled_by_config(config: Config, mock_db: Asyn
         response = await disabled_client.post("/internal/geocoding/trigger")
 
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Garmin trigger + waypoint selector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trigger_garmin_no_activities(client: AsyncClient, mock_db: AsyncMock):
+    mock_db.fetch.return_value = []
+    mock_db.fetchval.return_value = 0
+
+    app_obj = client._transport.app  # type: ignore[attr-defined]
+    app_obj.dependency_overrides[require_auth] = lambda: {"sub": "test"}
+    try:
+        response = await client.post("/api/v1/geocoding/trigger/garmin")
+    finally:
+        app_obj.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["processed"] == 0
+    assert body["skipped_dedup"] == 0
+
+
+@pytest.mark.asyncio
+async def test_trigger_garmin_requires_auth(client: AsyncClient, mock_db: AsyncMock):
+    app_obj = client._transport.app  # type: ignore[attr-defined]
+
+    def _deny() -> None:
+        raise HTTPException(status_code=http_status.HTTP_401_UNAUTHORIZED, detail="nope")
+
+    app_obj.dependency_overrides[require_auth] = _deny
+    try:
+        response = await client.post("/api/v1/geocoding/trigger/garmin")
+    finally:
+        app_obj.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_no_activities(client: AsyncClient, mock_db: AsyncMock):
+    mock_db.fetch.return_value = []
+    mock_db.fetchval.return_value = 0
+
+    response = await client.post("/internal/geocoding/trigger/garmin")
+
+    assert response.status_code == 200
+    assert response.json()["processed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_select_garmin_waypoints_picks_start_mid_end(mock_db: AsyncMock):
+    from app.routers.geocoding import _select_garmin_waypoints
+
+    mock_db.fetch.return_value = [
+        {"id": 1, "latitude": 40.0, "longitude": -74.0, "timestamp": "t1", "distance_from_start_km": 0.0},
+        {"id": 2, "latitude": 40.01, "longitude": -74.0, "timestamp": "t2", "distance_from_start_km": 0.5},
+        {"id": 3, "latitude": 40.02, "longitude": -74.0, "timestamp": "t3", "distance_from_start_km": 1.2},
+        {"id": 4, "latitude": 40.03, "longitude": -74.0, "timestamp": "t4", "distance_from_start_km": 2.5},
+        {"id": 5, "latitude": 40.04, "longitude": -74.0, "timestamp": "t5", "distance_from_start_km": 3.0},
+    ]
+
+    result = await _select_garmin_waypoints(mock_db, "act-1", 1.0)
+
+    kinds = [wp["waypoint_kind"] for wp in result]
+    assert kinds[0] == "start"
+    assert kinds[-1] == "end"
+    assert "waypoint" in kinds
+    # IDs 3 (1.2km) and 4 (2.5km) cross the 1km threshold from the previous waypoint.
+    mid_ids = [wp["id"] for wp in result if wp["waypoint_kind"] == "waypoint"]
+    assert mid_ids == [3, 4]
+
+
+@pytest.mark.asyncio
+async def test_select_garmin_waypoints_empty(mock_db: AsyncMock):
+    from app.routers.geocoding import _select_garmin_waypoints
+
+    mock_db.fetch.return_value = []
+    result = await _select_garmin_waypoints(mock_db, "act-1", 1.0)
+    assert result == []


### PR DESCRIPTION
## Summary

Extends the geocoding pipeline to cover **Garmin activity tracks** alongside OwnTracks. Implements the API-side of the persisted Garmin reverse-geocoding plan (Phase 2).

Depends on schema migration [homelab-database-migrations#20](https://github.com/stuartshay/homelab-database-migrations/pull/20) (multi-source \`geocoded_addresses\`).

## Changes

### Models (\`app/models/\`)
- Add \`WaypointKind\`, \`GeocodingSourceStatus\`, \`GeocodingStatusBySource\` to \`geocoding.py\`
- Add \`GeocodedAddressSummary\` (joined-row shape) and \`GarminActivityAddress\` (full address detail)
- Extend \`GarminTrackPoint\` with optional \`address: GeocodedAddressSummary | None\`
- Extend \`GeocodingStatus\` with \`by_source\` breakdown

### Router \`geocoding.py\`
- New \`POST /api/v1/geocoding/trigger/garmin\` (auth required) and \`POST /internal/geocoding/trigger/garmin\` (no auth)
- \`batch_size\` (1-100), \`waypoint_spacing_km\` (0.1-50.0), \`retry_failed\` query params
- \`_select_garmin_waypoints\`: start + every-spacing_km mid-route + end
- \`_process_garmin_waypoint\` reuses 50m PostGIS dedup across owntracks/garmin via \`COALESCE\` on \`geog\`
- \`asyncio.Semaphore(5)\` caps Pelias concurrency
- \`ON CONFLICT\` upserts use partial-index predicates (\`source='owntracks'\` / \`source='garmin'\`)
- \`/status\` aggregates per-source counts (success/pending/no_coverage/error) + Garmin activity coverage %

### Router \`garmin.py\`
- \`GET /activities/{id}/tracks\` now LEFT JOINs \`geocoded_addresses\` and attaches a \`GeocodedAddressSummary\` to each track point when available
- New \`GET /activities/{id}/addresses\` returns the full ordered list of geocoded waypoints for an activity (404 if activity missing)

### Tests
- 9 new tests covering: address join populated, address join null, per-activity addresses endpoint (success + 404 + ordering + filter), Garmin trigger (public auth + internal), waypoint selector (start/mid/end picks + empty)
- All 149 tests pass; coverage 92.62% (gate: 85%)

## Validation

- [x] \`pre-commit run -a\` clean
- [x] \`pytest\` — 149 passed
- [x] Coverage 92.62% (geocoding.py 72%, garmin.py 95%)
- [ ] Cluster validation pending deployment

Refs #110