### PR TITLE
fix(geocoding): handle Decimal distance_from_start_km in waypoint selection

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -361,14 +361,15 @@ async def _select_garmin_waypoints(
     waypoints: list[dict[str, Any]] = []
     waypoints.append({**points[0], "waypoint_kind": "start", "activity_id": activity_id})
 
-    last_d = points[0].get("distance_from_start_km") or 0.0
+    last_d = float(points[0].get("distance_from_start_km") or 0.0)
     for p in points[1:-1]:
         d = p.get("distance_from_start_km")
         if d is None:
             continue
-        if d - last_d >= spacing_km:
+        d_float = float(d)
+        if d_float - last_d >= spacing_km:
             waypoints.append({**p, "waypoint_kind": "waypoint", "activity_id": activity_id})
-            last_d = d
+            last_d = d_float
 
     if len(points) > 1:
         waypoints.append({**points[-1], "waypoint_kind": "end", "activity_id": activity_id})

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -524,3 +524,27 @@ async def test_select_garmin_waypoints_empty(mock_db: AsyncMock):
     mock_db.fetch.return_value = []
     result = await _select_garmin_waypoints(mock_db, "act-1", 1.0)
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_select_garmin_waypoints_decimal_distance(mock_db: AsyncMock):
+    """asyncpg returns NUMERIC columns as Decimal; spacing_km is float — must not raise."""
+    from decimal import Decimal
+
+    from app.routers.geocoding import _select_garmin_waypoints
+
+    mock_db.fetch.return_value = [
+        {"id": 1, "latitude": 40.0, "longitude": -74.0, "timestamp": "t1", "distance_from_start_km": Decimal("0.0")},
+        {"id": 2, "latitude": 40.01, "longitude": -74.0, "timestamp": "t2", "distance_from_start_km": Decimal("0.5")},
+        {"id": 3, "latitude": 40.02, "longitude": -74.0, "timestamp": "t3", "distance_from_start_km": Decimal("1.2")},
+        {"id": 4, "latitude": 40.03, "longitude": -74.0, "timestamp": "t4", "distance_from_start_km": Decimal("2.5")},
+        {"id": 5, "latitude": 40.04, "longitude": -74.0, "timestamp": "t5", "distance_from_start_km": Decimal("3.0")},
+    ]
+
+    result = await _select_garmin_waypoints(mock_db, "act-1", 1.0)
+
+    kinds = [wp["waypoint_kind"] for wp in result]
+    assert kinds[0] == "start"
+    assert kinds[-1] == "end"
+    mid_ids = [wp["id"] for wp in result if wp["waypoint_kind"] == "waypoint"]
+    assert mid_ids == [3, 4]


### PR DESCRIPTION
## Summary

Runtime hotfix for the Garmin geocoding pipeline shipped in v1.0.285 (PR #111).

asyncpg returns PostgreSQL `NUMERIC` columns as `decimal.Decimal`. The new `_select_garmin_waypoints` helper subtracted `Decimal` values against the `spacing_km: float` parameter, raising at runtime:

```
TypeError: unsupported operand type(s) for -: 'decimal.Decimal' and 'float'
```

Observed in production logs from `geocoding-backfill` v1.2.22 calling `POST /internal/geocoding/trigger/garmin` against otel-data-api v1.0.285 in cluster.

## Changes

- Cast `distance_from_start_km` to `float` before arithmetic in `app/routers/geocoding.py::_select_garmin_waypoints`
- Add regression test `test_select_garmin_waypoints_decimal_distance` using `Decimal` fixtures to mirror the asyncpg return type

## Validation

- `pytest tests/test_geocoding.py::test_select_garmin_waypoints_decimal_distance` PASS
- `pre-commit run --files` clean (ruff, mypy, pyright, secrets, cspell)
- Existing waypoint-selection test still passes with same expected mid IDs [3, 4]

## Acceptance

- [ ] Merge → Docker build → k8s-gitops auto-update → Argo sync → otel-data-api new image rolled
- [ ] `geocoding-backfill` Garmin trigger returns 200 (no 500/TypeError) in pod logs
- [ ] `geocoded_addresses` row count grows after Garmin batches complete