### PR TITLE
fix(garmin): drop geocoded_addresses join from /tracks simplify branch

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -369,6 +369,11 @@ async def list_track_points(
     )
 
     if simplify is not None:
+        # Map-rendering path: skip the geocoded_addresses LEFT JOIN here.
+        # The CTE chain (ST_Simplify -> ST_DumpPoints -> ROW_NUMBER de-dup)
+        # combined with the address join exceeded the asyncpg statement timeout
+        # on large activities. Addresses are still served by the non-simplify
+        # branch and by /activities/{id}/addresses (see issue #113).
         rows = await db.fetch(
             "WITH simplified AS ("
             "  SELECT ST_Simplify("
@@ -395,12 +400,8 @@ async def list_track_points(
             ") "
             "SELECT m.id, m.activity_id, m.latitude, m.longitude, "
             "m.timestamp, m.altitude, m.distance_from_start_km, m.speed_kmh, "
-            "m.heart_rate, m.cadence, m.temperature_c, m.created_at, "
-            "ga.display_address, ga.locality, ga.region, ga.country, "
-            "ga.waypoint_kind, ga.status AS address_status "
+            "m.heart_rate, m.cadence, m.temperature_c, m.created_at "
             "FROM matched m "
-            "LEFT JOIN public.geocoded_addresses ga "
-            "  ON ga.garmin_track_point_id = m.id AND ga.source = 'garmin' "
             "WHERE m.rn = 1 "
             f"ORDER BY m.timestamp {order}",
             activity_id,

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -275,6 +275,9 @@ async def test_list_track_points_simplify(client: AsyncClient, mock_db):
     assert "gtp.longitude = sc.lng AND gtp.latitude = sc.lat" in query
     assert "rn = 1" in query
     assert "gtp.timestamp, (gtp.altitude IS NOT NULL) DESC, gtp.id" in query
+    # Regression guard for #113: simplify branch must not join geocoded_addresses
+    # (the join caused asyncpg statement timeouts on large activities).
+    assert "geocoded_addresses" not in query
     assert params == ["20932993811", 0.00001]
 
 


### PR DESCRIPTION
## Summary

Fix Garmin Activity Detail map regression where the route map silently disappeared after the geocoding rollout.

Refs #113

## Root cause

`GET /api/v1/garmin/activities/{id}/tracks?simplify=...` (used by the UI route map) was timing out on large activities (~25k points). The geocoding PR added a `LEFT JOIN public.geocoded_addresses` on top of an already heavy CTE chain (`ST_Simplify` -> `ST_DumpPoints` -> `ROW_NUMBER` de-dup), pushing query time past asyncpg's statement timeout. Result: 500 from the API, no track-points in the UI, `<ActivityRouteMap>` was never mounted, hover marker invisible.

Confirmed on cluster pod `otel-data-api-646f6cf86d-jljfk`:

```
File "/app/app/routers/garmin.py", line 372, in list_track_points
    rows = await db.fetch(  ...
asyncpg ... TimeoutError
```

## Fix

Drop the `geocoded_addresses` LEFT JOIN from the **simplify branch only**. The route map consumer (`ActivityRouteMap`) only reads `latitude`/`longitude`. Addresses are still served by:

- the non-simplify branch of the same route (paginated listings), and
- `/activities/{id}/addresses` (powers `ActivityHoverDetails`).

`_row_to_track_point` already returns `address=None` when those columns are absent, so the response shape is unchanged.

## Validation

- `pre-commit run --files app/routers/garmin.py` -> all hooks pass
- `pytest tests/` -> 150 passed
- Post-deploy: will validate on cluster with `curl ...?simplify=0.00001` returning 200, then re-run Playwright `hovering one chart syncs the cursor and map marker` (currently failing on master).
