### PR TITLE
fix(geocoding): ignore Garmin activities with no track points

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -308,6 +308,10 @@ async def _trigger_garmin_geocoding_impl(
             "LEFT JOIN public.geocoded_addresses ga "
             "  ON ga.garmin_activity_id = a.activity_id AND ga.source = 'garmin' "
             "WHERE ga.id IS NULL "
+            "AND EXISTS ("
+            "  SELECT 1 FROM public.garmin_track_points gtp "
+            "  WHERE gtp.activity_id = a.activity_id"
+            ") "
             "GROUP BY a.activity_id "
             "ORDER BY MAX(a.start_time) DESC NULLS LAST "
             "LIMIT $1",
@@ -332,10 +336,14 @@ async def _trigger_garmin_geocoding_impl(
                 skipped_dedup += skip
 
     remaining = await db.fetchval(
-        "SELECT COUNT(*) FROM public.garmin_activities a "
+        "SELECT COUNT(DISTINCT a.activity_id) FROM public.garmin_activities a "
         "LEFT JOIN public.geocoded_addresses ga "
         "  ON ga.garmin_activity_id = a.activity_id AND ga.source = 'garmin' "
-        "WHERE ga.id IS NULL"
+        "WHERE ga.id IS NULL "
+        "AND EXISTS ("
+        "  SELECT 1 FROM public.garmin_track_points gtp "
+        "  WHERE gtp.activity_id = a.activity_id"
+        ")"
     )
 
     return GeocodingTriggerResponse(processed=processed, remaining=remaining, skipped_dedup=skipped_dedup)

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -493,6 +493,14 @@ async def test_internal_trigger_garmin_no_activities(client: AsyncClient, mock_d
     assert response.status_code == 200
     assert response.json()["processed"] == 0
 
+    # Activities without track points are excluded from selection and remaining count.
+    selection_sql = mock_db.fetch.call_args[0][0]
+    remaining_sql = mock_db.fetchval.call_args[0][0]
+    assert "EXISTS" in selection_sql
+    assert "garmin_track_points" in selection_sql
+    assert "EXISTS" in remaining_sql
+    assert "garmin_track_points" in remaining_sql
+
 
 @pytest.mark.asyncio
 async def test_select_garmin_waypoints_picks_start_mid_end(mock_db: AsyncMock):


### PR DESCRIPTION
## Summary
- exclude Garmin activities without any track points from backfill selection
- align Garmin remaining count to only actionable activities
- add regression assertions to ensure both selection and remaining SQL include the track-point EXISTS guard

## Validation
- make test (150 passed)
- pre-commit run -a (all hooks passed)

## Context
- live data shows 6 pending Garmin activities, all with zero rows in garmin_track_points
- patched logic yields old_remaining=6 and new_actionable_remaining=0 in production DB checks

Refs #113