### PR TITLE
feat: Extend GeocodedAddressSummary with detailed address fields for export

### DIFF
--- a/app/models/geocoding.py
+++ b/app/models/geocoding.py
@@ -149,8 +149,14 @@ class GeocodedAddressSummary(BaseModel):
     """Compact address summary embedded in track-point payloads."""
 
     display_address: str | None = Field(default=None, description="Full formatted address label from Pelias")
+    street: str | None = Field(default=None, description="Street name")
+    housenumber: str | None = Field(default=None, description="House or building number")
+    neighbourhood: str | None = Field(default=None, description="Neighbourhood name")
     locality: str | None = Field(default=None, description="City or town")
     region: str | None = Field(default=None, description="State or province")
     country: str | None = Field(default=None, description="Country name")
+    postalcode: str | None = Field(default=None, description="Postal or ZIP code")
+    confidence: float | None = Field(default=None, description="Pelias confidence score (0-1)")
     waypoint_kind: WaypointKind | None = Field(default=None, description="Role of this waypoint (Garmin only)")
     status: str = Field(description="Geocoding status: success, no_coverage, error, pending")
+    geocoded_at: datetime | None = Field(default=None, description="UTC timestamp when geocoding was performed")

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -414,8 +414,9 @@ async def list_track_points(
         "SELECT gtp.id, gtp.activity_id, gtp.latitude, gtp.longitude, gtp.timestamp, "
         "gtp.altitude, gtp.distance_from_start_km, gtp.speed_kmh, gtp.heart_rate, "
         "gtp.cadence, gtp.temperature_c, gtp.created_at, "
-        "ga.display_address, ga.locality, ga.region, ga.country, "
-        "ga.waypoint_kind, ga.status AS address_status "
+        "ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
+        "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "
+        "ga.waypoint_kind, ga.status AS address_status, ga.geocoded_at "
         "FROM public.garmin_track_points gtp "
         "LEFT JOIN public.geocoded_addresses ga "
         "  ON ga.garmin_track_point_id = gtp.id AND ga.source = 'garmin' "
@@ -466,19 +467,31 @@ def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:
     data: dict[str, Any] = dict(row)
     address_status = data.pop("address_status", None)
     display_address = data.pop("display_address", None)
+    street = data.pop("street", None)
+    housenumber = data.pop("housenumber", None)
+    neighbourhood = data.pop("neighbourhood", None)
     locality = data.pop("locality", None)
     region = data.pop("region", None)
     country = data.pop("country", None)
+    postalcode = data.pop("postalcode", None)
+    confidence = data.pop("confidence", None)
     waypoint_kind = data.pop("waypoint_kind", None)
+    geocoded_at = data.pop("geocoded_at", None)
     address: GeocodedAddressSummary | None = None
     if address_status is not None:
         address = GeocodedAddressSummary(
             display_address=display_address,
+            street=street,
+            housenumber=housenumber,
+            neighbourhood=neighbourhood,
             locality=locality,
             region=region,
             country=country,
+            postalcode=postalcode,
+            confidence=confidence,
             waypoint_kind=waypoint_kind,
             status=address_status,
+            geocoded_at=geocoded_at,
         )
     return GarminTrackPoint(**data, address=address)
 

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -695,11 +695,17 @@ def _track_row_with_address(activity_id: str = "20932993811") -> dict:
     base.update(
         {
             "display_address": "Pier 13, Hoboken, NJ",
+            "street": "Sinatra Drive",
+            "housenumber": "1301",
+            "neighbourhood": "Waterfront",
             "locality": "Hoboken",
             "region": "New Jersey",
             "country": "United States",
+            "postalcode": "07030",
+            "confidence": 0.92,
             "waypoint_kind": "start",
             "address_status": "success",
+            "geocoded_at": "2026-02-12T08:10:55+00:00",
         }
     )
     return base
@@ -716,8 +722,14 @@ async def test_list_track_points_includes_address_when_present(client: AsyncClie
     item = response.json()["items"][0]
     assert item["address"] is not None
     assert item["address"]["display_address"] == "Pier 13, Hoboken, NJ"
+    assert item["address"]["street"] == "Sinatra Drive"
+    assert item["address"]["housenumber"] == "1301"
+    assert item["address"]["neighbourhood"] == "Waterfront"
+    assert item["address"]["postalcode"] == "07030"
+    assert item["address"]["confidence"] == 0.92
     assert item["address"]["waypoint_kind"] == "start"
     assert item["address"]["status"] == "success"
+    assert item["address"]["geocoded_at"] == "2026-02-12T08:10:55Z"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Extends the `GeocodedAddressSummary` model to include detailed address fields required for CSV and GeoJSON export functionality on the Garmin Activity detail page.

## Changes
- Extended `GeocodedAddressSummary` Pydantic model with 6 new fields:
  - `street`: Street name
  - `housenumber`: House or building number
  - `neighbourhood`: Neighbourhood name
  - `postalcode`: Postal or ZIP code
  - `confidence`: Pelias confidence score (0-1)
  - `geocoded_at`: UTC timestamp when geocoding was performed

- Updated `garmin_track_points` query to include all address fields in LEFT JOIN to `geocoded_addresses` table (non-simplify path)

- Updated `_row_to_track_point()` mapper to extract and populate all address fields from database row

## Testing
- All pre-commit checks pass (ruff, mypy, pyright, cspell, detect-secrets)
- All 150 pytest tests pass
- GeocodedAddressSummary model tests included and passing

## Related Repos
- otel-data-gateway: PR to extend GraphQL schema
- otel-data-ui: PR to add export functionality

## Deployment Order
1. This PR (otel-data-api) first
2. Then otel-data-gateway
3. Then otel-data-ui