### PR TITLE
[codex] Fix Garmin export track query timeout

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -419,7 +419,9 @@ async def list_track_points(
         "ga.waypoint_kind, ga.status AS address_status, ga.geocoded_at "
         "FROM public.garmin_track_points gtp "
         "LEFT JOIN public.geocoded_addresses ga "
-        "  ON ga.garmin_track_point_id = gtp.id AND ga.source = 'garmin' "
+        "  ON ga.garmin_track_point_id = gtp.id "
+        " AND ga.garmin_activity_id = gtp.activity_id "
+        " AND ga.source = 'garmin' "
         f"WHERE gtp.activity_id = $1 ORDER BY gtp.{sort} {order} "
         f"LIMIT $2 OFFSET $3",
         activity_id,

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -243,6 +243,7 @@ async def test_list_track_points_success_and_invalid_sort_falls_back(client: Asy
     assert "ORDER BY gtp.timestamp desc" in track_query
     assert "garmin_track_points" in track_query
     assert "LEFT JOIN public.geocoded_addresses" in track_query
+    assert "ga.garmin_activity_id = gtp.activity_id" in track_query
     assert params == ["20932993811", 5, 1]
 
 


### PR DESCRIPTION
## Summary

Fixes Garmin track-point export failures caused by the REST API timing out on large address-aware track queries.

## Root Cause

The `/api/v1/garmin/activities/{activity_id}/tracks` query joined `geocoded_addresses` only on `garmin_track_point_id` and `source`. For export-sized pages (`limit=10000`), PostgreSQL chose a poor plan that timed out and surfaced through GraphQL as `REST API error 500`.

## Changes

- Constrain the Garmin address join by `ga.garmin_activity_id = gtp.activity_id`.
- Add a regression assertion so the optimized join stays in place.

## Validation

- `pytest -o cache_dir=/tmp/.pytest_cache tests/test_garmin.py -q`
- `pytest -o cache_dir=/tmp/.pytest_cache tests/ -q`
- `ruff check . && ruff format --check .`
- Manual local endpoint check: `GET /api/v1/garmin/activities/22976779663/tracks?limit=10000&offset=0` returned `200` in ~1.66s after the fix.
