### PR TITLE
fix(geocoding): broaden retry_failed to include error-status waypoints

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -113,7 +113,7 @@ async def geocoding_status(request: Request) -> GeocodingStatus:
 async def trigger_geocoding(
     request: Request,
     batch_size: int = Query(100, ge=1, le=500, description="Number of locations to geocode in this batch"),
-    retry_failed: bool = Query(False, description="Re-process records with status no_coverage or error"),
+    retry_failed: bool = Query(False, description="Re-process records with statuses no_coverage or error"),
     _user: dict = Depends(require_auth),
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of OwnTracks location records (auth required)."""
@@ -124,7 +124,7 @@ async def trigger_geocoding(
 async def internal_trigger_geocoding(
     request: Request,
     batch_size: int = Query(100, ge=1, le=1000, description="Number of locations to geocode in this batch"),
-    retry_failed: bool = Query(False, description="Re-process records with status no_coverage or error"),
+    retry_failed: bool = Query(False, description="Re-process records with statuses no_coverage or error"),
 ) -> GeocodingTriggerResponse:
     """Trigger batch OwnTracks reverse-geocoding (internal, no auth)."""
     return await _trigger_geocoding_impl(request, batch_size, retry_failed)
@@ -255,7 +255,7 @@ async def internal_trigger_garmin_geocoding(
     ),
     retry_failed: bool = Query(
         False,
-        description="Re-process activities with at least one no_coverage or error waypoint",
+        description="Re-process activities with at least one waypoint in statuses no_coverage or error",
     ),
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of Garmin activity waypoints (internal, no auth).
@@ -278,7 +278,7 @@ async def trigger_garmin_geocoding(
     ),
     retry_failed: bool = Query(
         False,
-        description="Re-process activities with at least one no_coverage or error waypoint",
+        description="Re-process activities with at least one waypoint in statuses no_coverage or error",
     ),
     _user: dict = Depends(require_auth),
 ) -> GeocodingTriggerResponse:

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -113,7 +113,7 @@ async def geocoding_status(request: Request) -> GeocodingStatus:
 async def trigger_geocoding(
     request: Request,
     batch_size: int = Query(100, ge=1, le=500, description="Number of locations to geocode in this batch"),
-    retry_failed: bool = Query(False, description="Re-process records with status no_coverage"),
+    retry_failed: bool = Query(False, description="Re-process records with status no_coverage or error"),
     _user: dict = Depends(require_auth),
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of OwnTracks location records (auth required)."""
@@ -124,7 +124,7 @@ async def trigger_geocoding(
 async def internal_trigger_geocoding(
     request: Request,
     batch_size: int = Query(100, ge=1, le=1000, description="Number of locations to geocode in this batch"),
-    retry_failed: bool = Query(False, description="Re-process records with status no_coverage"),
+    retry_failed: bool = Query(False, description="Re-process records with status no_coverage or error"),
 ) -> GeocodingTriggerResponse:
     """Trigger batch OwnTracks reverse-geocoding (internal, no auth)."""
     return await _trigger_geocoding_impl(request, batch_size, retry_failed)
@@ -145,7 +145,7 @@ async def _trigger_geocoding_impl(
             "SELECT l.id, l.latitude, l.longitude "
             "FROM public.locations l "
             "INNER JOIN public.geocoded_addresses ga ON ga.location_id = l.id "
-            "WHERE ga.source = 'owntracks' AND ga.status = 'no_coverage' "
+            "WHERE ga.source = 'owntracks' AND ga.status IN ('no_coverage', 'error') "
             "ORDER BY l.id LIMIT $1",
             batch_size,
         )
@@ -253,7 +253,10 @@ async def internal_trigger_garmin_geocoding(
         le=50.0,
         description="Approximate spacing between mid-route waypoints in kilometres",
     ),
-    retry_failed: bool = Query(False, description="Re-process activities with at least one no_coverage waypoint"),
+    retry_failed: bool = Query(
+        False,
+        description="Re-process activities with at least one no_coverage or error waypoint",
+    ),
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of Garmin activity waypoints (internal, no auth).
 
@@ -273,7 +276,10 @@ async def trigger_garmin_geocoding(
         le=50.0,
         description="Approximate spacing between mid-route waypoints in kilometres",
     ),
-    retry_failed: bool = Query(False, description="Re-process activities with at least one no_coverage waypoint"),
+    retry_failed: bool = Query(
+        False,
+        description="Re-process activities with at least one no_coverage or error waypoint",
+    ),
     _user: dict = Depends(require_auth),
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of Garmin activity waypoints (auth required)."""
@@ -297,7 +303,7 @@ async def _trigger_garmin_geocoding_impl(
             "FROM public.garmin_activities a "
             "INNER JOIN public.geocoded_addresses ga "
             "  ON ga.garmin_activity_id = a.activity_id AND ga.source = 'garmin' "
-            "WHERE ga.status = 'no_coverage' "
+            "WHERE ga.status IN ('no_coverage', 'error') "
             "ORDER BY a.activity_id LIMIT $1",
             batch_size,
         )

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -234,9 +234,11 @@ async def test_trigger_geocoding_retry_failed(client: AsyncClient, mock_db: Asyn
     response = await client.post("/api/v1/geocoding/trigger?retry_failed=true")
 
     assert response.status_code == 200
-    # Verify the retry_failed query was used (INNER JOIN with status='no_coverage')
+    # Verify the retry_failed query targets both no_coverage and error rows
     call_args = mock_db.fetch.call_args
-    assert "no_coverage" in call_args[0][0]
+    sql = call_args[0][0]
+    assert "no_coverage" in sql
+    assert "error" in sql
 
 
 # --- Internal geocoding endpoint tests ---
@@ -267,7 +269,9 @@ async def test_internal_trigger_retry_failed(client: AsyncClient, mock_db: Async
 
     assert response.status_code == 200
     call_args = mock_db.fetch.call_args
-    assert "no_coverage" in call_args[0][0]
+    sql = call_args[0][0]
+    assert "no_coverage" in sql
+    assert "error" in sql
 
 
 @pytest.mark.asyncio
@@ -500,6 +504,22 @@ async def test_internal_trigger_garmin_no_activities(client: AsyncClient, mock_d
     assert "garmin_track_points" in selection_sql
     assert "EXISTS" in remaining_sql
     assert "garmin_track_points" in remaining_sql
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_retry_failed_targets_error_and_no_coverage(
+    client: AsyncClient, mock_db: AsyncMock
+):
+    """retry_failed=true should re-pick activities with no_coverage OR error waypoints."""
+    mock_db.fetch.return_value = []
+    mock_db.fetchval.return_value = 0
+
+    response = await client.post("/internal/geocoding/trigger/garmin?retry_failed=true")
+
+    assert response.status_code == 200
+    selection_sql = mock_db.fetch.call_args[0][0]
+    assert "no_coverage" in selection_sql
+    assert "error" in selection_sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The `retry_failed=true` query parameter on the OwnTracks and Garmin
geocoding trigger endpoints previously only re-selected rows where
`geocoded_addresses.status = 'no_coverage'`. In production this filter
matches nothing useful for Garmin:

```text
GET /api/v1/geocoding/status (live)
garmin.success      = 35,300
garmin.errors       = 15,539
garmin.no_coverage  = 0
garmin.pending      = 0
```

The Semaphore Garmin backfill (project 11, template 18885) reports
"processing reverse geocode" but never advances those 15,539 stuck
`error` rows because the API selector excludes them. Running the
template with `retry_failed=true` is currently a no-op.

## Change

Broaden both selectors from `status = 'no_coverage'` to
`status IN ('no_coverage', 'error')`. Updated the matching Query()
descriptions and unit tests; added a Garmin-specific retry test
asserting the SQL targets both statuses.

## Validation

- `pytest tests/test_geocoding.py` — 24/24 pass
- `make test` — 151/151 pass, coverage threshold met
- `pre-commit run --all-files` — all hooks pass

## Post-deploy plan

1. Wait for Docker build + k8s-gitops auto-PR → Argo CD sync
2. Confirm new version live on `https://api.lab.informationcart.com/health`
3. Trigger Semaphore template 18885 with `retry_failed=true`
4. Re-check `/api/v1/geocoding/status` — expect `garmin.errors` to
   drop and `garmin.success` to climb toward full coverage

## Notes

- No schema change
- No API contract change (description text only)
- Activity-level coverage is already 99.57% (1397/1403); the 6 zero-row
  activities are out of scope for this PR and will be investigated
  separately