### PR TITLE
perf(geocoding): optimize Garmin retry path query + concurrency

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -26,7 +26,8 @@ router = APIRouter(prefix="/api/v1/geocoding", tags=["Geocoding"])
 internal_router = APIRouter(prefix="/internal/geocoding", tags=["Internal"])
 
 PELIAS_REVERSE_PATH = "/v1/reverse"
-# Per-request cap on concurrent Pelias calls. Raised from 5 to 20 in #129
+# Per-request cap on concurrent waypoint geocoding tasks (end-to-end:
+# neighbour lookup + Pelias call + upsert). Raised from 5 to 20 in #129
 # so the slow Pelias retry tail no longer dominates drain wall time.
 MAX_GEOCODE_CONCURRENCY = 20
 # Per-request cap on concurrently processed Garmin activities. Bounds the

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -26,7 +26,12 @@ router = APIRouter(prefix="/api/v1/geocoding", tags=["Geocoding"])
 internal_router = APIRouter(prefix="/internal/geocoding", tags=["Internal"])
 
 PELIAS_REVERSE_PATH = "/v1/reverse"
-MAX_GEOCODE_CONCURRENCY = 5
+# Per-request cap on concurrent Pelias calls. Raised from 5 to 20 in #129
+# so the slow Pelias retry tail no longer dominates drain wall time.
+MAX_GEOCODE_CONCURRENCY = 20
+# Per-request cap on concurrently processed Garmin activities. Bounds the
+# fan-out so the new parallel activity loop does not spike DB connections.
+GARMIN_ACTIVITY_CONCURRENCY = 4
 DEFAULT_GARMIN_WAYPOINT_SPACING_KM = 1.0
 
 # Pelias retry policy: transient failures (timeout, connection, 5xx) are retried
@@ -421,19 +426,42 @@ async def _trigger_garmin_geocoding_impl(
     processed = 0
     skipped_dedup = 0
     sem = asyncio.Semaphore(MAX_GEOCODE_CONCURRENCY)
+    activity_sem = asyncio.Semaphore(GARMIN_ACTIVITY_CONCURRENCY)
+    started_at = time.monotonic()
 
     async def _geocode_one(client: httpx.AsyncClient, waypoint: dict[str, Any]) -> tuple[int, int]:
         async with sem:
             return await _process_garmin_waypoint(db, client, pelias_base_url, waypoint)
 
+    async def _process_activity(client: httpx.AsyncClient, activity_id: str) -> tuple[int, int]:
+        async with activity_sem:
+            if retry_failed:
+                # Single-query selector: returns ONLY rows already flagged for retry.
+                # Avoids the full-track scan + Python-side thinning + second status
+                # query that the fresh-pass path needs.
+                waypoints = await _select_garmin_retry_waypoints(db, activity_id)
+            else:
+                waypoints = await _select_garmin_waypoints(db, activity_id, waypoint_spacing_km)
+            wp_results = await asyncio.gather(*[_geocode_one(client, wp) for wp in waypoints])
+            return (
+                sum(proc for proc, _ in wp_results),
+                sum(skip for _, skip in wp_results),
+            )
+
     async with httpx.AsyncClient(timeout=pelias_timeout) as client:
-        for activity in activity_rows:
-            activity_id = activity["activity_id"]
-            waypoints = await _select_garmin_waypoints(db, activity_id, waypoint_spacing_km, retry_failed=retry_failed)
-            results = await asyncio.gather(*[_geocode_one(client, wp) for wp in waypoints])
-            for proc, skip in results:
-                processed += proc
-                skipped_dedup += skip
+        activity_results = await asyncio.gather(*[_process_activity(client, a["activity_id"]) for a in activity_rows])
+    for proc, skip in activity_results:
+        processed += proc
+        skipped_dedup += skip
+
+    logger.info(
+        "garmin_geocoding_batch_complete",
+        retry_failed=retry_failed,
+        activities=len(activity_rows),
+        processed=processed,
+        skipped_dedup=skipped_dedup,
+        elapsed_seconds=round(time.monotonic() - started_at, 2),
+    )
 
     if retry_failed:
         remaining = await db.fetchval(
@@ -456,6 +484,41 @@ async def _trigger_garmin_geocoding_impl(
         )
 
     return GeocodingTriggerResponse(processed=processed, remaining=remaining, skipped_dedup=skipped_dedup)
+
+
+async def _select_garmin_retry_waypoints(
+    db: Any,
+    activity_id: str,
+) -> list[dict[str, Any]]:
+    """Return only the waypoints that already need a retry — in one SQL query.
+
+    The fresh-pass path uses ``_select_garmin_waypoints`` which pulls every
+    track point for the activity (often 5k-20k rows) and thins them to ~1 km
+    in Python, then re-queries status to filter to retryable rows. For an
+    activity with 3 failed waypoints that's >99% wasted I/O.
+    """
+    rows = await db.fetch(
+        "SELECT gtp.id, gtp.latitude, gtp.longitude, ga.waypoint_kind "
+        "FROM public.geocoded_addresses ga "
+        "INNER JOIN public.garmin_track_points gtp "
+        "  ON gtp.id = ga.garmin_track_point_id "
+        "WHERE ga.source = 'garmin' "
+        "AND ga.garmin_activity_id = $1 "
+        "AND ga.status = ANY($2::text[]) "
+        "ORDER BY ga.geocoded_at ASC NULLS FIRST",
+        activity_id,
+        list(RETRY_STATUSES),
+    )
+    return [
+        {
+            "id": r["id"],
+            "latitude": r["latitude"],
+            "longitude": r["longitude"],
+            "waypoint_kind": r["waypoint_kind"] or "waypoint",
+            "activity_id": activity_id,
+        }
+        for r in rows
+    ]
 
 
 async def _select_garmin_waypoints(

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -815,3 +815,102 @@ async def test_pelias_health_endpoint_unhealthy_on_timeout(client: AsyncClient):
     assert body["sample_features_count"] == 0
     assert body["detail"] is not None
     assert "timeout" in body["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Perf optimization (#129): single-query retry selector + parallel activities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_garmin_retry_waypoints_single_join_query(mock_db: AsyncMock):
+    """retry-mode selector must use one JOIN query returning only retryable rows."""
+    from app.routers.geocoding import _select_garmin_retry_waypoints
+
+    mock_db.fetch.return_value = [
+        {"id": 7, "latitude": 40.7, "longitude": -73.9, "waypoint_kind": "waypoint"},
+        {"id": 11, "latitude": 40.71, "longitude": -73.91, "waypoint_kind": "start"},
+    ]
+
+    result = await _select_garmin_retry_waypoints(mock_db, "act-99")
+
+    # Exactly ONE fetch call (no Python-side thinning, no second status query).
+    assert mock_db.fetch.call_count == 1
+    sql, activity_id, statuses = mock_db.fetch.call_args[0]
+    assert "INNER JOIN public.garmin_track_points" in sql
+    assert "ga.status = ANY" in sql
+    assert "ORDER BY ga.geocoded_at ASC NULLS FIRST" in sql
+    assert activity_id == "act-99"
+    assert set(statuses) == {"no_coverage", "error", "pending"}
+
+    assert [wp["id"] for wp in result] == [7, 11]
+    assert [wp["waypoint_kind"] for wp in result] == ["waypoint", "start"]
+    assert all(wp["activity_id"] == "act-99" for wp in result)
+
+
+@pytest.mark.asyncio
+async def test_select_garmin_retry_waypoints_empty(mock_db: AsyncMock):
+    """No retryable rows -> empty list, still a single query."""
+    from app.routers.geocoding import _select_garmin_retry_waypoints
+
+    mock_db.fetch.return_value = []
+    result = await _select_garmin_retry_waypoints(mock_db, "act-empty")
+    assert result == []
+    assert mock_db.fetch.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_select_garmin_retry_waypoints_defaults_waypoint_kind(mock_db: AsyncMock):
+    """Legacy rows missing waypoint_kind default to 'waypoint' (not None)."""
+    from app.routers.geocoding import _select_garmin_retry_waypoints
+
+    mock_db.fetch.return_value = [
+        {"id": 1, "latitude": 40.0, "longitude": -74.0, "waypoint_kind": None},
+    ]
+    result = await _select_garmin_retry_waypoints(mock_db, "act-1")
+    assert result[0]["waypoint_kind"] == "waypoint"
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_retry_uses_single_query_selector(client: AsyncClient, mock_db: AsyncMock):
+    """retry_failed=True must NOT issue the fresh-pass track-scan + status-filter pair.
+
+    Confirms the trigger impl routes through `_select_garmin_retry_waypoints`
+    (one fetch per activity) rather than `_select_garmin_waypoints` with
+    retry_failed=True (which would issue two fetches per activity).
+    """
+    activity_selection = [{"activity_id": "act-1"}, {"activity_id": "act-2"}]
+    retry_waypoints_act1 = [
+        {"id": 10, "latitude": 40.0, "longitude": -74.0, "waypoint_kind": "waypoint"},
+    ]
+    retry_waypoints_act2: list[dict] = []
+
+    mock_db.fetch.side_effect = [activity_selection, retry_waypoints_act1, retry_waypoints_act2]
+    mock_db.fetchval.return_value = 0
+    mock_db.fetchrow.return_value = None  # _find_nearby_address -> no neighbour
+    mock_db.execute.return_value = None
+
+    with patch("app.routers.geocoding._call_pelias", AsyncMock(return_value=None)):
+        response = await client.post("/internal/geocoding/trigger/garmin?retry_failed=true")
+
+    assert response.status_code == 200
+    # Exactly 3 fetch calls: 1 activity selector + 1 per activity (no extra status query).
+    assert mock_db.fetch.call_count == 3
+    # Second + third calls must be the new single-query retry selector.
+    for call in mock_db.fetch.call_args_list[1:]:
+        sql = call[0][0]
+        assert "INNER JOIN public.garmin_track_points" in sql
+        assert "ga.status = ANY" in sql
+
+
+@pytest.mark.asyncio
+async def test_concurrency_constants_increased_for_drain_throughput(mock_db: AsyncMock):
+    """Guard against accidental reversion of the #129 throughput tuning."""
+    from app.routers import geocoding
+
+    assert geocoding.MAX_GEOCODE_CONCURRENCY >= 20, (
+        "MAX_GEOCODE_CONCURRENCY must stay >= 20 to keep drain wall time <5min/batch"
+    )
+    assert geocoding.GARMIN_ACTIVITY_CONCURRENCY >= 2, (
+        "GARMIN_ACTIVITY_CONCURRENCY must allow >= 2 activities in parallel"
+    )


### PR DESCRIPTION
## Summary

Optimizes the Garmin geocoding retry-drain path which was running at
~11 rows/hour (60 min/batch) after the hardening in #128. Refs #129.

## Changes

- **New `_select_garmin_retry_waypoints` helper** (`app/routers/geocoding.py`):
  one `INNER JOIN public.garmin_track_points` query that returns only the
  rows already marked retryable (`status IN ('no_coverage','error','pending')`),
  replacing the fresh-pass selector's full-track scan + Python-side 1 km
  thinning + second status query for the retry path. Typically **5–10×
  less I/O** per activity (3 retry rows vs scanning 5–20k track points).
- **Parallel per-activity processing** in `_trigger_garmin_geocoding_impl`:
  the previously serial `for activity in activity_rows` loop is now an
  `asyncio.gather` bounded by a new `GARMIN_ACTIVITY_CONCURRENCY = 4`
  semaphore. Within each activity, waypoint Pelias calls remain bounded
  by the (now larger) `MAX_GEOCODE_CONCURRENCY` semaphore.
- **`MAX_GEOCODE_CONCURRENCY` raised 5 → 20** so the Pelias retry tail
  (3 attempts × 10 s timeout, ~30 s worst case per failure) no longer
  serializes drain throughput at the waypoint level.
- **Structured `garmin_geocoding_batch_complete` log** with `elapsed_seconds`
  added so before/after throughput is observable directly from worker
  logs without external timing.

## Performance — measured baseline (before)

From live drain run `manual_drain_20260524_185036` on cluster:

| Metric | Before |
|---|---|
| Wall time per batch | ~60 min |
| Rows processed / batch | 11–15 |
| Rows skipped (dedup) / batch | 57–81 |
| Effective throughput | **~0.18 rows/min (~11/hr)** |
| Time per processed row | ~330 s |

Worker log evidence:
```
[23:22:53] batch=1 processed=15 skipped=81 remaining=502
[00:23:23] batch=2 processed=11 skipped=57 remaining=496
```

## Expected after

Combining the four levers (multiplicative on the dominant retry-tail
cost; each is independently measurable from the new structured log):

| Lever | Expected gain |
|---|---|
| Single-query retry selector (vs N+1) | 5–10× fewer DB ops per activity |
| Activity concurrency 1 → 4 | up to 4× wall-time reduction |
| Waypoint concurrency 5 → 20 | up to 4× on the Pelias tail |
| Structured timing log | (observability only) |

Conservative target: batch wall time **< 5 min** (≥ 12× improvement),
throughput **≥ 2 rows/min**. The new `elapsed_seconds` field in
`garmin_geocoding_batch_complete` gives a direct A/B measurement once
deployed.

## Tests

- 5 new tests added in `tests/test_geocoding.py`:
  - `test_select_garmin_retry_waypoints_single_join_query` — asserts one
    fetch, INNER JOIN, `status = ANY`, and the three retry statuses.
  - `test_select_garmin_retry_waypoints_empty`
  - `test_select_garmin_retry_waypoints_defaults_waypoint_kind`
  - `test_internal_trigger_garmin_retry_uses_single_query_selector` —
    asserts the trigger uses the new selector (3 fetches total for 2
    activities, not 5).
  - `test_concurrency_constants_increased_for_drain_throughput` — guards
    against accidental reversion.
- All 167 tests pass; coverage 93.46% (gate: 85%).
- `pre-commit run --all-files` clean.

## Out of scope (follow-ups noted in #129)

- Env-var configuration for the new concurrency knobs.
- In-process + persistent negative cache for permanent `no_coverage`
  coordinates.
- Reducing Pelias retry attempts on the drain path.

## Validation

Post-merge validation will compare the new `elapsed_seconds` against the
60 min baseline from `manual_drain_20260524_185036`. Per repo policy
this PR uses `Refs #129` — issue #129 stays open until post-deploy
cluster acceptance evidence is posted.

Refs #129