### PR TITLE
feat(geocoding): dense per-point cell geocoding (cell-first precedence)

### DIFF
--- a/app/models/geocoding.py
+++ b/app/models/geocoding.py
@@ -59,6 +59,22 @@ class GeocodingStatus(BaseModel):
     by_source: GeocodingStatusBySource = Field(
         description="Per-source breakdown of geocoding coverage (owntracks, garmin)",
     )
+    dense_cells_total: int = Field(
+        default=0,
+        description="Total number of distinct 4dp (~11m) GPS cells observed in garmin_track_points",
+    )
+    dense_cells_geocoded: int = Field(
+        default=0,
+        description="Number of dense cells with any geocoding row (any status)",
+    )
+    dense_cells_success: int = Field(default=0, description="Number of dense cells with status='success'")
+    dense_cells_pending: int = Field(default=0, description="Number of dense cells awaiting geocoding")
+    dense_cells_no_coverage: int = Field(default=0, description="Number of dense cells outside Pelias coverage")
+    dense_cells_errors: int = Field(default=0, description="Number of dense cells that failed geocoding")
+    dense_point_coverage_percent: float = Field(
+        default=0.0,
+        description="Percentage of garmin_track_points whose 4dp cell has any geocoded row",
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -416,12 +416,21 @@ async def list_track_points(
         "gtp.cadence, gtp.temperature_c, gtp.created_at, "
         "ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
         "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "
-        "ga.waypoint_kind, ga.status AS address_status, ga.geocoded_at "
+        "ga.waypoint_kind, ga.status AS address_status, ga.geocoded_at, "
+        "gpc.display_address AS cell_display_address, gpc.street AS cell_street, "
+        "gpc.housenumber AS cell_housenumber, gpc.neighbourhood AS cell_neighbourhood, "
+        "gpc.locality AS cell_locality, gpc.region AS cell_region, "
+        "gpc.country AS cell_country, gpc.postalcode AS cell_postalcode, "
+        "gpc.confidence AS cell_confidence, gpc.status AS cell_status, "
+        "gpc.geocoded_at AS cell_geocoded_at "
         "FROM public.garmin_track_points gtp "
         "LEFT JOIN public.geocoded_addresses ga "
         "  ON ga.garmin_track_point_id = gtp.id "
         " AND ga.garmin_activity_id = gtp.activity_id "
         " AND ga.source = 'garmin' "
+        "LEFT JOIN public.geocoded_point_cells gpc "
+        "  ON gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
+        " AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER "
         f"WHERE gtp.activity_id = $1 ORDER BY gtp.{sort} {order} "
         f"LIMIT $2 OFFSET $3",
         activity_id,
@@ -465,8 +474,14 @@ async def get_chart_data(
 
 
 def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:
-    """Build a GarminTrackPoint, attaching the joined address summary when present."""
+    """Build a GarminTrackPoint, attaching the joined address summary when present.
+
+    When both a dense-cell row and a waypoint row exist for the same point,
+    the cell address takes precedence (denser, always populated once backfilled);
+    the waypoint row is used as a fallback while the cell backfill is in-flight.
+    """
     data: dict[str, Any] = dict(row)
+    # Waypoint columns (legacy / sparse).
     address_status = data.pop("address_status", None)
     display_address = data.pop("display_address", None)
     street = data.pop("street", None)
@@ -479,8 +494,36 @@ def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:
     confidence = data.pop("confidence", None)
     waypoint_kind = data.pop("waypoint_kind", None)
     geocoded_at = data.pop("geocoded_at", None)
+    # Dense-cell columns (preferred when present).
+    cell_status = data.pop("cell_status", None)
+    cell_display_address = data.pop("cell_display_address", None)
+    cell_street = data.pop("cell_street", None)
+    cell_housenumber = data.pop("cell_housenumber", None)
+    cell_neighbourhood = data.pop("cell_neighbourhood", None)
+    cell_locality = data.pop("cell_locality", None)
+    cell_region = data.pop("cell_region", None)
+    cell_country = data.pop("cell_country", None)
+    cell_postalcode = data.pop("cell_postalcode", None)
+    cell_confidence = data.pop("cell_confidence", None)
+    cell_geocoded_at = data.pop("cell_geocoded_at", None)
+
     address: GeocodedAddressSummary | None = None
-    if address_status is not None:
+    if cell_status is not None:
+        address = GeocodedAddressSummary(
+            display_address=cell_display_address,
+            street=cell_street,
+            housenumber=cell_housenumber,
+            neighbourhood=cell_neighbourhood,
+            locality=cell_locality,
+            region=cell_region,
+            country=cell_country,
+            postalcode=cell_postalcode,
+            confidence=cell_confidence,
+            waypoint_kind=None,
+            status=cell_status,
+            geocoded_at=cell_geocoded_at,
+        )
+    elif address_status is not None:
         address = GeocodedAddressSummary(
             display_address=display_address,
             street=street,

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -508,7 +508,10 @@ def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:
     cell_geocoded_at = data.pop("cell_geocoded_at", None)
 
     address: GeocodedAddressSummary | None = None
-    if cell_status is not None:
+    # Only prefer the cell address when it actually carries a usable address.
+    # Non-success cell rows (pending/error/no_coverage) must not hide a waypoint
+    # address that was successfully geocoded.
+    if cell_status == "success" and cell_display_address is not None:
         address = GeocodedAddressSummary(
             display_address=cell_display_address,
             street=cell_street,

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -102,6 +102,31 @@ async def geocoding_status(request: Request) -> GeocodingStatus:
     garmin_coverage_percent = round((activities_geocoded / activities_total * 100), 2) if activities_total else 0.0
     garmin_waypoint_success_percent = round(((g_success or 0) / g_total_rows * 100), 2) if g_total_rows else 0.0
 
+    # Dense per-point cell coverage (geocoded_point_cells, 4dp ~ 11 m resolution).
+    dense_total_cells = await db.fetchval(
+        "SELECT COUNT(DISTINCT (ROUND(latitude * 10000)::INTEGER, ROUND(longitude * 10000)::INTEGER)) "
+        "FROM public.garmin_track_points"
+    )
+    dense_success = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'success'")
+    dense_pending = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'pending'")
+    dense_no_coverage = await db.fetchval(
+        "SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'no_coverage'"
+    )
+    dense_errors = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'error'")
+    dense_geocoded = (dense_success or 0) + (dense_pending or 0) + (dense_no_coverage or 0) + (dense_errors or 0)
+    total_track_points = await db.fetchval("SELECT COUNT(*) FROM public.garmin_track_points")
+    covered_track_points = await db.fetchval(
+        "SELECT COUNT(*) FROM public.garmin_track_points gtp "
+        "WHERE EXISTS ("
+        "  SELECT 1 FROM public.geocoded_point_cells gpc "
+        "  WHERE gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
+        "    AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER"
+        ")"
+    )
+    dense_point_coverage_percent = (
+        round((covered_track_points / total_track_points * 100), 2) if total_track_points else 0.0
+    )
+
     by_source = GeocodingStatusBySource(
         owntracks=GeocodingSourceStatus(
             success=ot_success or 0,
@@ -132,6 +157,13 @@ async def geocoding_status(request: Request) -> GeocodingStatus:
         errors=ot_errors,
         coverage_percent=coverage_percent,
         by_source=by_source,
+        dense_cells_total=dense_total_cells or 0,
+        dense_cells_geocoded=dense_geocoded,
+        dense_cells_success=dense_success or 0,
+        dense_cells_pending=dense_pending or 0,
+        dense_cells_no_coverage=dense_no_coverage or 0,
+        dense_cells_errors=dense_errors or 0,
+        dense_point_coverage_percent=dense_point_coverage_percent,
     )
 
 
@@ -990,5 +1022,204 @@ async def _upsert_garmin_status(
         track_point_id,
         activity_id,
         waypoint_kind,
+        status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dense per-point cell geocoding (geocoded_point_cells, 4dp ~ 11 m resolution)
+# ---------------------------------------------------------------------------
+
+
+_CELL_CONFLICT = "ON CONFLICT (lat_4dp, lon_4dp)"
+
+
+@internal_router.post("/trigger/garmin-dense", response_model=GeocodingTriggerResponse)
+async def internal_trigger_garmin_dense(
+    request: Request,
+    batch_size: int = Query(100, ge=1, le=1000, description="Number of dense cells to process in this batch"),
+    retry_failed: bool = Query(
+        False,
+        description="Re-process cells whose status is no_coverage, error, or pending",
+    ),
+) -> GeocodingTriggerResponse:
+    """Trigger batch reverse-geocoding of distinct 4dp GPS cells (internal, no auth)."""
+    return await _trigger_garmin_dense_impl(request, batch_size, retry_failed)
+
+
+@router.post("/trigger/garmin-dense", response_model=GeocodingTriggerResponse)
+async def trigger_garmin_dense(
+    request: Request,
+    batch_size: int = Query(100, ge=1, le=500, description="Number of dense cells to process in this batch"),
+    retry_failed: bool = Query(
+        False,
+        description="Re-process cells whose status is no_coverage, error, or pending",
+    ),
+    _user: dict = Depends(require_auth),
+) -> GeocodingTriggerResponse:
+    """Trigger batch reverse-geocoding of distinct 4dp GPS cells (auth required)."""
+    return await _trigger_garmin_dense_impl(request, batch_size, retry_failed)
+
+
+async def _trigger_garmin_dense_impl(
+    request: Request,
+    batch_size: int,
+    retry_failed: bool,
+) -> GeocodingTriggerResponse:
+    db = request.app.state.db
+    config = request.app.state.config
+    pelias_base_url = config.pelias_base_url
+    pelias_timeout = config.pelias_timeout_seconds
+
+    if retry_failed:
+        cell_rows = await db.fetch(
+            "SELECT lat_4dp, lon_4dp FROM public.geocoded_point_cells "
+            "WHERE status = ANY($2::text[]) "
+            "ORDER BY geocoded_at ASC NULLS FIRST "
+            "LIMIT $1",
+            batch_size,
+            list(RETRY_STATUSES),
+        )
+    else:
+        # Distinct cells observed in garmin_track_points that have no row yet
+        # in geocoded_point_cells. Indexed equality on (lat_4dp, lon_4dp).
+        cell_rows = await db.fetch(
+            "SELECT DISTINCT "
+            "  ROUND(gtp.latitude * 10000)::INTEGER AS lat_4dp, "
+            "  ROUND(gtp.longitude * 10000)::INTEGER AS lon_4dp "
+            "FROM public.garmin_track_points gtp "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM public.geocoded_point_cells gpc "
+            "  WHERE gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
+            "    AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER"
+            ") "
+            "LIMIT $1",
+            batch_size,
+        )
+
+    processed = 0
+    sem = asyncio.Semaphore(MAX_GEOCODE_CONCURRENCY)
+
+    async def _process_one(client: httpx.AsyncClient, lat_4dp: int, lon_4dp: int) -> int:
+        async with sem:
+            return await _process_cell(db, client, pelias_base_url, lat_4dp, lon_4dp)
+
+    if cell_rows:
+        async with httpx.AsyncClient(timeout=pelias_timeout) as client:
+            results = await asyncio.gather(*[_process_one(client, row["lat_4dp"], row["lon_4dp"]) for row in cell_rows])
+            processed = sum(results)
+
+    # Remaining distinct cells not yet geocoded.
+    remaining = await db.fetchval(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT DISTINCT "
+        "    ROUND(gtp.latitude * 10000)::INTEGER AS lat_4dp, "
+        "    ROUND(gtp.longitude * 10000)::INTEGER AS lon_4dp "
+        "  FROM public.garmin_track_points gtp "
+        "  WHERE NOT EXISTS ("
+        "    SELECT 1 FROM public.geocoded_point_cells gpc "
+        "    WHERE gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
+        "      AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER"
+        "  )"
+        ") AS pending_cells"
+    )
+
+    return GeocodingTriggerResponse(
+        processed=processed,
+        remaining=remaining or 0,
+        skipped_dedup=0,
+    )
+
+
+async def _process_cell(
+    db: Any,
+    client: httpx.AsyncClient,
+    pelias_base_url: str,
+    lat_4dp: int,
+    lon_4dp: int,
+) -> int:
+    """Reverse-geocode a single 4dp cell and upsert the result.
+
+    Returns 1 if a row was upserted (success/no_coverage/error/pending), 0 if
+    the cell was skipped due to an unexpected exception (already logged).
+    """
+    lat = lat_4dp / 10000.0
+    lon = lon_4dp / 10000.0
+    try:
+        try:
+            pelias_data = await _call_pelias(client, pelias_base_url, lat, lon)
+        except PeliasTransientError:
+            await _upsert_cell_status(db, lat_4dp, lon_4dp, status="pending")
+            return 1
+
+        if pelias_data is None:
+            await _upsert_cell_status(db, lat_4dp, lon_4dp, status="error")
+            return 1
+
+        features = pelias_data.get("features", [])
+        if not features:
+            await _upsert_cell_status(db, lat_4dp, lon_4dp, status="no_coverage")
+            return 1
+
+        props = features[0].get("properties", {})
+        await _upsert_cell_from_pelias(db, lat_4dp, lon_4dp, props, pelias_data)
+        return 1
+    except Exception:
+        logger.warning(
+            "Unexpected error processing dense cell (%d, %d)",
+            lat_4dp,
+            lon_4dp,
+            exc_info=True,
+        )
+        try:
+            await _upsert_cell_status(db, lat_4dp, lon_4dp, status="error")
+        except Exception:
+            logger.warning("Failed to upsert error status for cell (%d, %d)", lat_4dp, lon_4dp, exc_info=True)
+        return 0
+
+
+async def _upsert_cell_from_pelias(
+    db: Any,
+    lat_4dp: int,
+    lon_4dp: int,
+    props: dict[str, Any],
+    raw_data: dict[str, Any],
+) -> None:
+    await db.execute(
+        "INSERT INTO public.geocoded_point_cells "
+        "(lat_4dp, lon_4dp, display_address, street, housenumber, neighbourhood, "
+        "locality, region, country, postalcode, confidence, status, raw_response) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'success', $12) "
+        f"{_CELL_CONFLICT} DO UPDATE SET "
+        "display_address = EXCLUDED.display_address, "
+        "street = EXCLUDED.street, housenumber = EXCLUDED.housenumber, "
+        "neighbourhood = EXCLUDED.neighbourhood, locality = EXCLUDED.locality, "
+        "region = EXCLUDED.region, country = EXCLUDED.country, "
+        "postalcode = EXCLUDED.postalcode, confidence = EXCLUDED.confidence, "
+        "status = EXCLUDED.status, raw_response = EXCLUDED.raw_response, "
+        "geocoded_at = CURRENT_TIMESTAMP",
+        lat_4dp,
+        lon_4dp,
+        props.get("label"),
+        props.get("street"),
+        props.get("housenumber"),
+        props.get("neighbourhood"),
+        props.get("locality"),
+        props.get("region"),
+        props.get("country"),
+        props.get("postalcode"),
+        props.get("confidence"),
+        json.dumps(raw_data),
+    )
+
+
+async def _upsert_cell_status(db: Any, lat_4dp: int, lon_4dp: int, *, status: str) -> None:
+    """Insert or update a status-only row in geocoded_point_cells."""
+    await db.execute(
+        "INSERT INTO public.geocoded_point_cells (lat_4dp, lon_4dp, status) "
+        "VALUES ($1, $2, $3) "
+        f"{_CELL_CONFLICT} DO UPDATE SET status = $3, geocoded_at = CURRENT_TIMESTAMP",
+        lat_4dp,
+        lon_4dp,
         status,
     )

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -1109,20 +1109,27 @@ async def _trigger_garmin_dense_impl(
             results = await asyncio.gather(*[_process_one(client, row["lat_4dp"], row["lon_4dp"]) for row in cell_rows])
             processed = sum(results)
 
-    # Remaining distinct cells not yet geocoded.
-    remaining = await db.fetchval(
-        "SELECT COUNT(*) FROM ("
-        "  SELECT DISTINCT "
-        "    ROUND(gtp.latitude * 10000)::INTEGER AS lat_4dp, "
-        "    ROUND(gtp.longitude * 10000)::INTEGER AS lon_4dp "
-        "  FROM public.garmin_track_points gtp "
-        "  WHERE NOT EXISTS ("
-        "    SELECT 1 FROM public.geocoded_point_cells gpc "
-        "    WHERE gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
-        "      AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER"
-        "  )"
-        ") AS pending_cells"
-    )
+    # Remaining work. In retry mode, count cells still in a retryable status;
+    # otherwise count distinct track-point cells that have no row yet.
+    if retry_failed:
+        remaining = await db.fetchval(
+            "SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = ANY($1::text[])",
+            list(RETRY_STATUSES),
+        )
+    else:
+        remaining = await db.fetchval(
+            "SELECT COUNT(*) FROM ("
+            "  SELECT DISTINCT "
+            "    ROUND(gtp.latitude * 10000)::INTEGER AS lat_4dp, "
+            "    ROUND(gtp.longitude * 10000)::INTEGER AS lon_4dp "
+            "  FROM public.garmin_track_points gtp "
+            "  WHERE NOT EXISTS ("
+            "    SELECT 1 FROM public.geocoded_point_cells gpc "
+            "    WHERE gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
+            "      AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER"
+            "  )"
+            ") AS pending_cells"
+        )
 
     return GeocodingTriggerResponse(
         processed=processed,
@@ -1173,9 +1180,10 @@ async def _process_cell(
         )
         try:
             await _upsert_cell_status(db, lat_4dp, lon_4dp, status="error")
+            return 1
         except Exception:
             logger.warning("Failed to upsert error status for cell (%d, %d)", lat_4dp, lon_4dp, exc_info=True)
-        return 0
+            return 0
 
 
 async def _upsert_cell_from_pelias(

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -813,3 +813,95 @@ async def test_list_activity_addresses_not_found(client: AsyncClient, mock_db):
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Activity not found"}
+
+
+# ---------------------------------------------------------------------------
+# Dense per-point cell address (geocoded_point_cells) — cell-first precedence
+# ---------------------------------------------------------------------------
+
+
+def _track_row_with_cell_address(activity_id: str = "20932993811") -> dict:
+    """Row with only the dense-cell address columns populated (no waypoint row)."""
+    base = _track_row(activity_id)
+    base.update(
+        {
+            # No waypoint join match -> all NULL
+            "display_address": None,
+            "street": None,
+            "housenumber": None,
+            "neighbourhood": None,
+            "locality": None,
+            "region": None,
+            "country": None,
+            "postalcode": None,
+            "confidence": None,
+            "waypoint_kind": None,
+            "address_status": None,
+            "geocoded_at": None,
+            # Dense cell join match
+            "cell_display_address": "501 Sinatra Dr, Hoboken, NJ",
+            "cell_street": "Sinatra Drive",
+            "cell_housenumber": "501",
+            "cell_neighbourhood": "Waterfront",
+            "cell_locality": "Hoboken",
+            "cell_region": "New Jersey",
+            "cell_country": "United States",
+            "cell_postalcode": "07030",
+            "cell_confidence": 0.88,
+            "cell_status": "success",
+            "cell_geocoded_at": "2026-02-13T09:00:00+00:00",
+        }
+    )
+    return base
+
+
+@pytest.mark.asyncio
+async def test_list_track_points_uses_cell_address_when_present(client: AsyncClient, mock_db):
+    mock_db.fetchval.side_effect = [1, 1]
+    mock_db.fetch.return_value = [_track_row_with_cell_address()]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/tracks")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["address"] is not None
+    assert item["address"]["display_address"] == "501 Sinatra Dr, Hoboken, NJ"
+    assert item["address"]["status"] == "success"
+    # Cell-source addresses never carry a waypoint_kind.
+    assert item["address"]["waypoint_kind"] is None
+    assert item["address"]["geocoded_at"] == "2026-02-13T09:00:00Z"
+    # Query must include the dense cell LEFT JOIN.
+    query = mock_db.fetch.await_args.args[0]
+    assert "geocoded_point_cells" in query
+    assert "ROUND(gtp.latitude * 10000)" in query
+
+
+@pytest.mark.asyncio
+async def test_cell_overrides_waypoint_when_both_present(client: AsyncClient, mock_db):
+    """When both cell and waypoint rows exist, cell wins (denser source)."""
+    row = _track_row_with_address()  # has waypoint_kind='start' + display_address
+    row.update(
+        {
+            "cell_display_address": "Cell Address Wins",
+            "cell_street": None,
+            "cell_housenumber": None,
+            "cell_neighbourhood": None,
+            "cell_locality": None,
+            "cell_region": None,
+            "cell_country": None,
+            "cell_postalcode": None,
+            "cell_confidence": 0.5,
+            "cell_status": "success",
+            "cell_geocoded_at": "2026-02-13T09:00:00+00:00",
+        }
+    )
+    mock_db.fetchval.side_effect = [1, 1]
+    mock_db.fetch.return_value = [row]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/tracks")
+
+    assert response.status_code == 200
+    addr = response.json()["items"][0]["address"]
+    assert addr["display_address"] == "Cell Address Wins"
+    # waypoint_kind from the waypoint row is dropped because cell wins.
+    assert addr["waypoint_kind"] is None

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -905,3 +905,35 @@ async def test_cell_overrides_waypoint_when_both_present(client: AsyncClient, mo
     assert addr["display_address"] == "Cell Address Wins"
     # waypoint_kind from the waypoint row is dropped because cell wins.
     assert addr["waypoint_kind"] is None
+
+
+@pytest.mark.asyncio
+async def test_pending_cell_does_not_hide_waypoint_address(client: AsyncClient, mock_db):
+    """A non-success cell row (pending/error/no_coverage) must not hide a successful waypoint address."""
+    row = _track_row_with_address()  # waypoint_kind='start', display_address set, status='success'
+    row.update(
+        {
+            "cell_display_address": None,
+            "cell_street": None,
+            "cell_housenumber": None,
+            "cell_neighbourhood": None,
+            "cell_locality": None,
+            "cell_region": None,
+            "cell_country": None,
+            "cell_postalcode": None,
+            "cell_confidence": None,
+            "cell_status": "pending",
+            "cell_geocoded_at": None,
+        }
+    )
+    mock_db.fetchval.side_effect = [1, 1]
+    mock_db.fetch.return_value = [row]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/tracks")
+
+    assert response.status_code == 200
+    addr = response.json()["items"][0]["address"]
+    # Waypoint address survives because cell is not 'success'.
+    assert addr["display_address"] == row["display_address"]
+    assert addr["waypoint_kind"] == "start"
+    assert addr["status"] == "success"

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -1211,3 +1211,22 @@ async def test_trigger_garmin_dense_public_batch_size_limit(client: AsyncClient,
     finally:
         app_obj.dependency_overrides.pop(require_auth, None)
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_dense_retry_remaining_counts_retryable(client: AsyncClient, mock_db: AsyncMock):
+    """In retry mode, `remaining` must count cells in retryable statuses, not unmatched track-point cells."""
+    mock_db.fetch.return_value = []
+    mock_db.fetchval.return_value = 7
+
+    response = await client.post("/internal/geocoding/trigger/garmin-dense?retry_failed=true")
+
+    assert response.status_code == 200
+    assert response.json()["remaining"] == 7
+    remaining_sql = mock_db.fetchval.call_args[0][0]
+    remaining_statuses = mock_db.fetchval.call_args[0][1]
+    assert "geocoded_point_cells" in remaining_sql
+    assert "status = ANY" in remaining_sql
+    assert "no_coverage" in remaining_statuses
+    assert "error" in remaining_statuses
+    assert "pending" in remaining_statuses

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -15,8 +15,30 @@ from app.config import Config
 @pytest.mark.asyncio
 async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     # Order: total, geocoded, ot_success, ot_pending, ot_no_coverage, ot_errors,
-    # g_success, g_pending, g_no_coverage, g_errors, activities_total, activities_geocoded
-    mock_db.fetchval.side_effect = [1000, 600, 550, 30, 10, 10, 80, 5, 4, 1, 25, 12]
+    # g_success, g_pending, g_no_coverage, g_errors, activities_total, activities_geocoded,
+    # dense_total_cells, dense_success, dense_pending, dense_no_coverage, dense_errors,
+    # total_track_points, covered_track_points
+    mock_db.fetchval.side_effect = [
+        1000,
+        600,
+        550,
+        30,
+        10,
+        10,
+        80,
+        5,
+        4,
+        1,
+        25,
+        12,
+        4500,
+        3000,
+        100,
+        50,
+        20,
+        50000,
+        35000,
+    ]
 
     response = await client.get("/api/v1/geocoding/status")
 
@@ -36,11 +58,18 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     assert body["by_source"]["garmin_activities_total"] == 25
     assert body["by_source"]["garmin_activities_geocoded"] == 12
     assert body["by_source"]["garmin_coverage_percent"] == 48.0
+    assert body["dense_cells_total"] == 4500
+    assert body["dense_cells_success"] == 3000
+    assert body["dense_cells_pending"] == 100
+    assert body["dense_cells_no_coverage"] == 50
+    assert body["dense_cells_errors"] == 20
+    assert body["dense_cells_geocoded"] == 3170
+    assert body["dense_point_coverage_percent"] == 70.0
 
 
 @pytest.mark.asyncio
 async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: AsyncMock):
-    mock_db.fetchval.side_effect = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    mock_db.fetchval.side_effect = [0] * 19
 
     response = await client.get("/api/v1/geocoding/status")
 
@@ -49,6 +78,9 @@ async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: Asy
     assert body["total_locations"] == 0
     assert body["coverage_percent"] == 0.0
     assert body["by_source"]["garmin_coverage_percent"] == 0.0
+    assert body["dense_cells_total"] == 0
+    assert body["dense_cells_geocoded"] == 0
+    assert body["dense_point_coverage_percent"] == 0.0
 
 
 @pytest.mark.asyncio
@@ -1036,3 +1068,146 @@ async def test_find_nearby_address_does_not_use_coalesce_query(mock_db: AsyncMoc
     assert "ga.location_id = ANY" in final_sql
     assert "ga.garmin_track_point_id = ANY" in final_sql
     assert "ST_DWithin" not in final_sql, "Final lookup must not re-filter by distance."
+
+
+# ---------------------------------------------------------------------------
+# Dense per-point cell geocoding tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_dense_no_pending(client: AsyncClient, mock_db: AsyncMock):
+    """No pending cells -> processed=0, remaining=0."""
+    mock_db.fetch.return_value = []
+    mock_db.fetchval.return_value = 0
+
+    response = await client.post("/internal/geocoding/trigger/garmin-dense")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["processed"] == 0
+    assert body["remaining"] == 0
+    selection_sql = mock_db.fetch.call_args[0][0]
+    assert "DISTINCT" in selection_sql
+    assert "geocoded_point_cells" in selection_sql
+    assert "ROUND(gtp.latitude * 10000)" in selection_sql
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_dense_happy_path(
+    client: AsyncClient, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+):
+    """Cells get reverse-geocoded and upserted with status=success."""
+    from app.routers import geocoding as geo_mod
+
+    mock_db.fetch.return_value = [
+        {"lat_4dp": 405000, "lon_4dp": -740000},
+        {"lat_4dp": 405001, "lon_4dp": -740001},
+    ]
+    mock_db.fetchval.return_value = 5  # remaining
+
+    async def _fake_pelias(client, base, lat, lon):
+        return {
+            "features": [
+                {
+                    "properties": {
+                        "label": "1 Main St, NYC",
+                        "street": "Main St",
+                        "housenumber": "1",
+                        "neighbourhood": "Downtown",
+                        "locality": "NYC",
+                        "region": "NY",
+                        "country": "USA",
+                        "postalcode": "10001",
+                        "confidence": 0.9,
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(geo_mod, "_call_pelias", _fake_pelias)
+
+    response = await client.post("/internal/geocoding/trigger/garmin-dense?batch_size=10")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["processed"] == 2
+    assert body["remaining"] == 5
+
+    # Two upserts to geocoded_point_cells with status='success'.
+    upsert_calls = [c for c in mock_db.execute.call_args_list if "geocoded_point_cells" in c[0][0]]
+    assert len(upsert_calls) == 2
+    for c in upsert_calls:
+        assert "'success'" in c[0][0]
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_dense_no_coverage(
+    client: AsyncClient, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+):
+    """Empty features -> status='no_coverage' upsert."""
+    from app.routers import geocoding as geo_mod
+
+    mock_db.fetch.return_value = [{"lat_4dp": 405000, "lon_4dp": -740000}]
+    mock_db.fetchval.return_value = 0
+
+    async def _fake_pelias(client, base, lat, lon):
+        return {"features": []}
+
+    monkeypatch.setattr(geo_mod, "_call_pelias", _fake_pelias)
+
+    response = await client.post("/internal/geocoding/trigger/garmin-dense")
+
+    assert response.status_code == 200
+    assert response.json()["processed"] == 1
+    upsert_sql = mock_db.execute.call_args[0][0]
+    assert "geocoded_point_cells" in upsert_sql
+    assert mock_db.execute.call_args[0][3] == "no_coverage"
+
+
+@pytest.mark.asyncio
+async def test_internal_trigger_garmin_dense_retry_failed_targets_statuses(client: AsyncClient, mock_db: AsyncMock):
+    """retry_failed=true selects cells with status in (no_coverage, error, pending)."""
+    mock_db.fetch.return_value = []
+    mock_db.fetchval.return_value = 0
+
+    response = await client.post("/internal/geocoding/trigger/garmin-dense?retry_failed=true")
+
+    assert response.status_code == 200
+    call_args = mock_db.fetch.call_args
+    selection_sql = call_args[0][0]
+    statuses = call_args[0][2]
+    assert "status = ANY" in selection_sql
+    assert "geocoded_point_cells" in selection_sql
+    assert "no_coverage" in statuses
+    assert "error" in statuses
+    assert "pending" in statuses
+
+
+@pytest.mark.asyncio
+async def test_trigger_garmin_dense_requires_auth(client: AsyncClient, mock_db: AsyncMock):
+    """Public dense endpoint must require auth."""
+    app_obj = client._transport.app  # type: ignore[attr-defined]
+
+    def _deny() -> None:
+        raise HTTPException(status_code=http_status.HTTP_401_UNAUTHORIZED, detail="nope")
+
+    app_obj.dependency_overrides[require_auth] = _deny
+    try:
+        response = await client.post("/api/v1/geocoding/trigger/garmin-dense")
+    finally:
+        app_obj.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_trigger_garmin_dense_public_batch_size_limit(client: AsyncClient, mock_db: AsyncMock):
+    """Public endpoint caps batch_size at 500."""
+    app_obj = client._transport.app  # type: ignore[attr-defined]
+    app_obj.dependency_overrides[require_auth] = lambda: {"sub": "test"}
+    try:
+        response = await client.post("/api/v1/geocoding/trigger/garmin-dense?batch_size=501")
+    finally:
+        app_obj.dependency_overrides.pop(require_auth, None)
+    assert response.status_code == 422


### PR DESCRIPTION
Refs #134

## Summary

Adds dense per-point reverse geocoding for Garmin track points using a new
`geocoded_point_cells` table keyed by `(lat_4dp, lon_4dp)` (~11m cells).
Each physical cell is reverse-geocoded once and reused across all track points
and activities that pass through it.

Companion migration: stuartshay/homelab-database-migrations#36 (must merge + apply first).

## Changes

### New endpoints (`app/routers/geocoding.py`)
- `POST /internal/geocoding/trigger/garmin-dense` — internal trigger, no auth, batch 1-1000
- `POST /api/v1/geocoding/trigger/garmin-dense` — public trigger, Cognito JWT required, batch 1-500
- Both support `retry_failed=true` to retry cells in `pending`/`no_coverage`/`error` status

### Status endpoint extended (`app/routers/geocoding.py`)
`/api/v1/geocoding/status` now returns:
- `dense_cells_total`, `dense_cells_success`, `dense_cells_pending`,
  `dense_cells_no_coverage`, `dense_cells_errors`, `dense_cells_geocoded`
- `dense_point_coverage_percent` — track points whose cell has been geocoded ÷ total track points

### Track-point queries (`app/routers/garmin.py`)
Standard branch of `GET /api/v1/garmin/activities/{id}/tracks` now LEFT JOINs
`geocoded_point_cells` on `(ROUND(lat*10000), ROUND(lon*10000))`. When both
a cell address and a waypoint address exist for the same point, the **cell
address wins** (denser); `waypoint_kind` is `null` for cell-source addresses.

The simplify branch (issue #113 statement-timeout fix) is intentionally
**unmodified** to preserve its query plan.

### Tests
- 6 new tests for dense trigger endpoints (auth, retry path, no-coverage, success)
- 2 new tests for cell-first precedence in track point output
- Full suite: 179 passed, coverage 93%

## Validation

```
pre-commit run -a   # all green
pytest -q           # 179 passed
```

## Deployment Order

1. Merge + apply migration PR #36 (homelab-database-migrations)
2. Merge this PR
3. Docker build publishes `stuartshay/otel-data-api`
4. k8s-gitops PR bumps image tag → Argo CD sync
5. Follow-up: otel-agents DAG `garmin_geocoding_densify` to drive the new trigger on schedule