### PR TITLE
perf(geocoding): read dense_cells_total from mv_garmin_track_point_cells

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -103,10 +103,10 @@ async def geocoding_status(request: Request) -> GeocodingStatus:
     garmin_waypoint_success_percent = round(((g_success or 0) / g_total_rows * 100), 2) if g_total_rows else 0.0
 
     # Dense per-point cell coverage (geocoded_point_cells, 4dp ~ 11 m resolution).
-    dense_total_cells = await db.fetchval(
-        "SELECT COUNT(DISTINCT (ROUND(latitude * 10000)::INTEGER, ROUND(longitude * 10000)::INTEGER)) "
-        "FROM public.garmin_track_points"
-    )
+    # Read distinct-cell totals from the mv_garmin_track_point_cells materialized view
+    # (migration 18) — a direct COUNT(DISTINCT ...) over garmin_track_points takes ~18s on
+    # prod and exceeds the API's database command timeout.
+    dense_total_cells = await db.fetchval("SELECT COUNT(*) FROM public.mv_garmin_track_point_cells")
     dense_success = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'success'")
     dense_pending = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'pending'")
     dense_no_coverage = await db.fetchval(

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -65,6 +65,11 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     assert body["dense_cells_errors"] == 20
     assert body["dense_cells_geocoded"] == 3170
     assert body["dense_point_coverage_percent"] == 70.0
+    # Guard against regressing dense_cells_total back to the slow
+    # COUNT(DISTINCT ...) over garmin_track_points (migration 18 MV).
+    fetchval_queries = [call.args[0] for call in mock_db.fetchval.await_args_list]
+    assert any("mv_garmin_track_point_cells" in sql for sql in fetchval_queries)
+    assert not any("COUNT(DISTINCT" in sql and "garmin_track_points" in sql for sql in fetchval_queries)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Switch `/api/v1/geocoding/status` to read `dense_cells_total` from the new `public.mv_garmin_track_point_cells` materialized view (homelab-database-migrations#37, migration 18) instead of doing a `COUNT(DISTINCT (ROUND(lat*10000), ROUND(lon*10000)))` over the ~4.4M-row `garmin_track_points` table.

## Why
The original query took ~18 s on prod and exceeded the API's 15 s `command_timeout`, causing `GET /api/v1/geocoding/status` to return HTTP 500 (`asyncpg.QueryCanceledError`). This blocked criterion 1 of #134.

## Validation
- Prod `SELECT COUNT(*) FROM public.mv_garmin_track_point_cells` → `555303` in **61ms** (vs ~18s before).
- Prod `covered_track_points` EXISTS query → **138ms**, no change needed.
- `pytest tests/test_geocoding.py` → 51 passed (mocks rely on call count, not query string).
- `pre-commit` → all checks pass.

## Deployment
After merge, bump image in `k8s-gitops` via `apps/base/otel-data-api/update-version.sh` and let Argo CD sync, then validate #134 acceptance criteria 1, 3, 4 on the live cluster.

Refs #134