### PR TITLE
feat: expose Garmin HR availability and extended activity stats fields

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -22,6 +22,23 @@ class GarminActivity(BaseModel):
     duration_seconds: int | None = Field(default=None, description="Active duration in seconds (excludes pauses)")
     avg_heart_rate: int | None = Field(default=None, description="Average heart rate in beats per minute")
     max_heart_rate: int | None = Field(default=None, description="Maximum heart rate in beats per minute")
+    hr_available: bool = Field(
+        default=False,
+        description="Whether this activity has usable heart-rate data in summary or track points",
+    )
+    min_heart_rate: int | None = Field(default=None, description="Minimum heart rate in beats per minute")
+    aerobic_training_effect: float | None = Field(default=None, description="Aerobic training effect score")
+    anaerobic_training_effect: float | None = Field(default=None, description="Anaerobic training effect score")
+    exercise_load: int | None = Field(default=None, description="Exercise load score")
+    avg_respiration_rate: int | None = Field(default=None, description="Average respiration rate in breaths per minute")
+    min_respiration_rate: int | None = Field(default=None, description="Minimum respiration rate in breaths per minute")
+    max_respiration_rate: int | None = Field(default=None, description="Maximum respiration rate in breaths per minute")
+    sweat_loss_ml: int | None = Field(default=None, description="Estimated sweat loss in millilitres")
+    moderate_intensity_minutes: int | None = Field(default=None, description="Moderate intensity minutes")
+    vigorous_intensity_minutes: int | None = Field(default=None, description="Vigorous intensity minutes")
+    total_intensity_minutes: int | None = Field(default=None, description="Total intensity minutes")
+    paved_distance_km: float | None = Field(default=None, description="Distance over paved surfaces in kilometres")
+    unpaved_distance_km: float | None = Field(default=None, description="Distance over unpaved surfaces in kilometres")
     avg_cadence: int | None = Field(default=None, description="Average cadence in RPM")
     max_cadence: int | None = Field(default=None, description="Maximum cadence in RPM")
     calories: int | None = Field(default=None, description="Total calories burned")
@@ -56,6 +73,20 @@ class GarminActivity(BaseModel):
                     "duration_seconds": 6932,
                     "avg_heart_rate": 142,
                     "max_heart_rate": 178,
+                    "hr_available": True,
+                    "min_heart_rate": 98,
+                    "aerobic_training_effect": 2.6,
+                    "anaerobic_training_effect": 0.0,
+                    "exercise_load": 48,
+                    "avg_respiration_rate": 25,
+                    "min_respiration_rate": 16,
+                    "max_respiration_rate": 32,
+                    "sweat_loss_ml": 1629,
+                    "moderate_intensity_minutes": 88,
+                    "vigorous_intensity_minutes": 29,
+                    "total_intensity_minutes": 146,
+                    "paved_distance_km": 21.09,
+                    "unpaved_distance_km": 0.65,
                     "avg_cadence": 78,
                     "max_cadence": 112,
                     "calories": 1689,

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -203,6 +203,10 @@ async def list_activities(
     data_query = (
         f"SELECT a.activity_id, a.sport, a.sub_sport, a.start_time, a.end_time, "
         f"a.distance_km, a.duration_seconds, a.avg_heart_rate, a.max_heart_rate, "
+        f"(a.avg_heart_rate IS NOT NULL OR a.max_heart_rate IS NOT NULL OR EXISTS ("
+        f"SELECT 1 FROM public.garmin_track_points t_hr "
+        f"WHERE t_hr.activity_id = a.activity_id AND t_hr.heart_rate IS NOT NULL"
+        f")) AS hr_available, "
         f"a.avg_cadence, a.max_cadence, a.calories, a.avg_speed_kmh, a.max_speed_kmh, "
         f"a.total_ascent_m, a.total_descent_m, a.total_distance, a.avg_pace, "
         f"a.device_manufacturer, a.avg_temperature_c, a.min_temperature_c, "
@@ -306,6 +310,10 @@ async def get_activity(
     row = await db.fetchrow(
         "SELECT a.activity_id, a.sport, a.sub_sport, a.start_time, a.end_time, "
         "a.distance_km, a.duration_seconds, a.avg_heart_rate, a.max_heart_rate, "
+        "(a.avg_heart_rate IS NOT NULL OR a.max_heart_rate IS NOT NULL OR EXISTS ("
+        "SELECT 1 FROM public.garmin_track_points t_hr "
+        "WHERE t_hr.activity_id = a.activity_id AND t_hr.heart_rate IS NOT NULL"
+        ")) AS hr_available, "
         "a.avg_cadence, a.max_cadence, a.calories, a.avg_speed_kmh, a.max_speed_kmh, "
         "a.total_ascent_m, a.total_descent_m, a.total_distance, a.avg_pace, "
         "a.device_manufacturer, a.avg_temperature_c, a.min_temperature_c, "

--- a/cspell.json
+++ b/cspell.json
@@ -61,6 +61,7 @@
         "locustio",
         "lookback",
         "markdownlint",
+        "millilitres",
         "MQTT",
         "mypy",
         "neighbour",

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -20,6 +20,7 @@ def _activity_row(activity_id: str = "20932993811") -> dict:
         "duration_seconds": 6932,
         "avg_heart_rate": 142,
         "max_heart_rate": 178,
+        "hr_available": True,
         "avg_cadence": 78,
         "max_cadence": 112,
         "calories": 1689,
@@ -211,6 +212,21 @@ async def test_get_activity_success(client: AsyncClient, mock_db):
     data = response.json()
     assert data["activity_id"] == "20932993811"
     assert data["sport"] == "cycling"
+    assert data["hr_available"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_activity_hr_availability_defaults_false(client: AsyncClient, mock_db):
+    row = _activity_row()
+    row["avg_heart_rate"] = None
+    row["max_heart_rate"] = None
+    row["hr_available"] = False
+    mock_db.fetchrow.return_value = row
+
+    response = await client.get("/api/v1/garmin/activities/20932993811")
+
+    assert response.status_code == 200
+    assert response.json()["hr_available"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extend Garmin activity response model with optional advanced stats fields
- compute and expose hr_available in activities/detail queries
- add API tests for hr availability behavior

## Validation
- API pytest could not run here due missing fastapi/pytest in active environment
