### PR TITLE
feat: add manual Garmin activity updates and sync passthrough filters

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -125,8 +125,12 @@ class GarminTrackPoint(BaseModel):
     )
     speed_kmh: float | None = Field(default=None, description="Instantaneous speed in km/h")
     heart_rate: int | None = Field(default=None, description="Heart rate in beats per minute")
+    hr_zone: int | None = Field(default=None, description="Heart-rate zone index (1-5)")
+    respiration_rate: int | None = Field(default=None, description="Respiration rate in breaths per minute")
     cadence: int | None = Field(default=None, description="Pedal/step cadence in RPM")
     temperature_c: int | None = Field(default=None, description="Ambient temperature in degrees C")
+    surface_type: str | None = Field(default=None, description="Road or terrain type")
+    effort_level: str | None = Field(default=None, description="Effort classification label")
     created_at: datetime | None = Field(default=None, description="UTC timestamp when the record was inserted")
     address: GeocodedAddressSummary | None = Field(
         default=None,
@@ -147,8 +151,12 @@ class GarminTrackPoint(BaseModel):
                     "distance_from_start_km": 0.0,
                     "speed_kmh": 24.5,
                     "heart_rate": 135,
+                    "hr_zone": 3,
+                    "respiration_rate": 22,
                     "cadence": 80,
                     "temperature_c": 18,
+                    "surface_type": "paved",
+                    "effort_level": "steady",
                     "created_at": "2026-02-09T23:56:37Z",
                     "address": None,
                 }
@@ -167,8 +175,12 @@ class GarminChartPoint(BaseModel):
     )
     speed_kmh: float | None = Field(default=None, description="Instantaneous speed in km/h")
     heart_rate: int | None = Field(default=None, description="Heart rate in beats per minute")
+    hr_zone: int | None = Field(default=None, description="Heart-rate zone index (1-5)")
+    respiration_rate: int | None = Field(default=None, description="Respiration rate in breaths per minute")
     cadence: int | None = Field(default=None, description="Pedal/step cadence in RPM")
     temperature_c: int | None = Field(default=None, description="Ambient temperature in degrees C")
+    surface_type: str | None = Field(default=None, description="Road or terrain type")
+    effort_level: str | None = Field(default=None, description="Effort classification label")
     latitude: float = Field(description="GPS latitude in decimal degrees (WGS 84)")
     longitude: float = Field(description="GPS longitude in decimal degrees (WGS 84)")
 
@@ -181,8 +193,12 @@ class GarminChartPoint(BaseModel):
                     "distance_from_start_km": 0.0,
                     "speed_kmh": 24.5,
                     "heart_rate": 135,
+                    "hr_zone": 3,
+                    "respiration_rate": 22,
                     "cadence": 80,
                     "temperature_c": 18,
+                    "surface_type": "paved",
+                    "effort_level": "steady",
                     "latitude": 40.71501586586237,
                     "longitude": -74.01768794283271,
                 }
@@ -275,4 +291,64 @@ class GarminActivityTotal(BaseModel):
                 }
             ]
         }
+    }
+
+
+class GarminActivityManualUpdate(BaseModel):
+    """Partial manual update payload for Garmin activity records."""
+
+    sport: str | None = Field(default=None, description="Primary sport type (e.g. cycling, running)")
+    sub_sport: str | None = Field(default=None, description="Sub-sport classification (e.g. road, trail)")
+    start_time: datetime | None = Field(default=None, description="Activity start time in UTC")
+    end_time: datetime | None = Field(default=None, description="Activity end time in UTC")
+    distance_km: float | None = Field(default=None, description="Total distance in kilometres")
+    duration_seconds: int | None = Field(default=None, description="Active duration in seconds (excludes pauses)")
+    avg_heart_rate: int | None = Field(default=None, description="Average heart rate in beats per minute")
+    max_heart_rate: int | None = Field(default=None, description="Maximum heart rate in beats per minute")
+    min_heart_rate: int | None = Field(default=None, description="Minimum heart rate in beats per minute")
+    aerobic_training_effect: float | None = Field(default=None, description="Aerobic training effect score")
+    anaerobic_training_effect: float | None = Field(default=None, description="Anaerobic training effect score")
+    exercise_load: int | None = Field(default=None, description="Exercise load score")
+    avg_respiration_rate: int | None = Field(default=None, description="Average respiration rate in breaths per minute")
+    min_respiration_rate: int | None = Field(default=None, description="Minimum respiration rate in breaths per minute")
+    max_respiration_rate: int | None = Field(default=None, description="Maximum respiration rate in breaths per minute")
+    sweat_loss_ml: int | None = Field(default=None, description="Estimated sweat loss in millilitres")
+    moderate_intensity_minutes: int | None = Field(default=None, description="Moderate intensity minutes")
+    vigorous_intensity_minutes: int | None = Field(default=None, description="Vigorous intensity minutes")
+    total_intensity_minutes: int | None = Field(default=None, description="Total intensity minutes")
+    paved_distance_km: float | None = Field(default=None, description="Distance over paved surfaces in kilometres")
+    unpaved_distance_km: float | None = Field(default=None, description="Distance over unpaved surfaces in kilometres")
+    avg_cadence: int | None = Field(default=None, description="Average cadence in RPM")
+    max_cadence: int | None = Field(default=None, description="Maximum cadence in RPM")
+    calories: int | None = Field(default=None, description="Total calories burned")
+    avg_speed_kmh: float | None = Field(default=None, description="Average speed in km/h")
+    max_speed_kmh: float | None = Field(default=None, description="Maximum speed in km/h")
+    total_ascent_m: int | None = Field(default=None, description="Total elevation gain in meters")
+    total_descent_m: int | None = Field(default=None, description="Total elevation loss in meters")
+    total_distance: float | None = Field(default=None, description="Raw total distance in meters from FIT file")
+    avg_pace: float | None = Field(default=None, description="Average pace in minutes per kilometre")
+    device_manufacturer: str | None = Field(default=None, description="Device manufacturer (e.g. garmin)")
+    avg_temperature_c: int | None = Field(default=None, description="Average ambient temperature in degrees C")
+    min_temperature_c: int | None = Field(default=None, description="Minimum ambient temperature in degrees C")
+    max_temperature_c: int | None = Field(default=None, description="Maximum ambient temperature in degrees C")
+    total_elapsed_time: float | None = Field(
+        default=None,
+        description="Total elapsed time in seconds (includes pauses)",
+    )
+    total_timer_time: float | None = Field(default=None, description="Total timer time in seconds (active recording)")
+    uploaded_at: datetime | None = Field(default=None, description="UTC timestamp when the FIT file was uploaded")
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "avg_heart_rate": 141,
+                    "max_heart_rate": 172,
+                    "avg_cadence": 82,
+                    "aerobic_training_effect": 3.2,
+                    "device_manufacturer": "polar_electro",
+                }
+            ]
+        },
     }

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -10,12 +10,14 @@ from typing import Any, Literal
 import fastapi
 import httpx
 import structlog
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import ValidationError
 
+from app.auth import require_auth
 from app.models import PaginatedResponse
 from app.models.garmin import (
     GarminActivity,
+    GarminActivityManualUpdate,
     GarminActivityTotal,
     GarminChartPoint,
     GarminDateRange,
@@ -30,6 +32,27 @@ logger = structlog.get_logger(__name__)
 
 ACTIVITY_SORT_WHITELIST = {"start_time", "distance_km", "duration_seconds", "sport", "created_at"}
 TRACK_SORT_WHITELIST = {"timestamp", "altitude", "speed_kmh", "heart_rate", "created_at"}
+
+ACTIVITY_BY_ID_SELECT = (
+    "SELECT a.activity_id, a.sport, a.sub_sport, a.start_time, a.end_time, "
+    "a.distance_km, a.duration_seconds, a.avg_heart_rate, a.max_heart_rate, "
+    "(a.avg_heart_rate IS NOT NULL OR a.max_heart_rate IS NOT NULL OR EXISTS ("
+    "SELECT 1 FROM public.garmin_track_points t_hr "
+    "WHERE t_hr.activity_id = a.activity_id AND t_hr.heart_rate IS NOT NULL"
+    ")) AS hr_available, "
+    "a.min_heart_rate, a.aerobic_training_effect, a.anaerobic_training_effect, "
+    "a.exercise_load, a.avg_respiration_rate, a.min_respiration_rate, "
+    "a.max_respiration_rate, a.sweat_loss_ml, a.moderate_intensity_minutes, "
+    "a.vigorous_intensity_minutes, a.total_intensity_minutes, "
+    "a.paved_distance_km, a.unpaved_distance_km, a.avg_cadence, a.max_cadence, "
+    "a.calories, a.avg_speed_kmh, a.max_speed_kmh, a.total_ascent_m, "
+    "a.total_descent_m, a.total_distance, a.avg_pace, a.device_manufacturer, "
+    "a.avg_temperature_c, a.min_temperature_c, a.max_temperature_c, "
+    "a.total_elapsed_time, a.total_timer_time, a.created_at, a.uploaded_at, "
+    "(SELECT COUNT(*) FROM public.garmin_track_points t "
+    "WHERE t.activity_id = a.activity_id) AS track_point_count "
+    "FROM public.garmin_activities a WHERE a.activity_id = $1"
+)
 
 
 def _parse_date(value: str) -> date:
@@ -75,6 +98,18 @@ async def trigger_sync(
         ge=1,
         description="Optional sync window in hours. Positive integer.",
     ),
+    resync_existing: bool | None = Query(
+        None,
+        description="Whether to re-sync activities that already exist in the database.",
+    ),
+    activity_id: list[str] | None = Query(
+        None,
+        description="Optional Garmin activity_id filter (repeatable).",
+    ),
+    activity_ids: list[str] | None = Query(
+        None,
+        description="Optional Garmin activity_ids filter (repeatable).",
+    ),
 ) -> GarminSyncResponse:
     """Trigger an on-demand Garmin sync via the in-cluster garmin-sync service."""
     sync_id = request.headers.get("X-Garmin-Sync-Id") or str(uuid.uuid4())
@@ -89,11 +124,17 @@ async def trigger_sync(
 
     config = request.app.state.config
     base_url = config.garmin_sync_base_url.rstrip("/")
-    params = {}
+    params: dict[str, Any] = {}
     if lookback is not None:
         params["lookback"] = lookback
     if window_hours is not None:
         params["window_hours"] = window_hours
+    if resync_existing is not None:
+        params["resync_existing"] = "true" if resync_existing else "false"
+    if activity_id:
+        params["activity_id"] = activity_id
+    if activity_ids:
+        params["activity_ids"] = activity_ids
 
     logger.info("garmin_sync_trigger", sync_id=sync_id, params=params)
 
@@ -307,23 +348,51 @@ async def get_activity(
 ) -> GarminActivity:
     """Get a single Garmin activity by ID with track point count."""
     db = request.app.state.db
-    row = await db.fetchrow(
-        "SELECT a.activity_id, a.sport, a.sub_sport, a.start_time, a.end_time, "
-        "a.distance_km, a.duration_seconds, a.avg_heart_rate, a.max_heart_rate, "
-        "(a.avg_heart_rate IS NOT NULL OR a.max_heart_rate IS NOT NULL OR EXISTS ("
-        "SELECT 1 FROM public.garmin_track_points t_hr "
-        "WHERE t_hr.activity_id = a.activity_id AND t_hr.heart_rate IS NOT NULL"
-        ")) AS hr_available, "
-        "a.avg_cadence, a.max_cadence, a.calories, a.avg_speed_kmh, a.max_speed_kmh, "
-        "a.total_ascent_m, a.total_descent_m, a.total_distance, a.avg_pace, "
-        "a.device_manufacturer, a.avg_temperature_c, a.min_temperature_c, "
-        "a.max_temperature_c, a.total_elapsed_time, a.total_timer_time, "
-        "a.created_at, a.uploaded_at, "
-        "(SELECT COUNT(*) FROM public.garmin_track_points t "
-        "WHERE t.activity_id = a.activity_id) AS track_point_count "
-        "FROM public.garmin_activities a WHERE a.activity_id = $1",
-        activity_id,
+    row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    return GarminActivity(**dict(row))
+
+
+@router.patch(
+    "/activities/{activity_id}",
+    response_model=GarminActivity,
+    responses={
+        400: {"description": "No fields to update"},
+        401: {"description": "Authentication required"},
+        404: {"description": "Activity not found"},
+    },
+)
+async def patch_activity(
+    request: Request,
+    body: GarminActivityManualUpdate = fastapi.Body(...),
+    activity_id: str = fastapi.Path(description="Garmin activity ID", examples=["20932993811"]),
+    _user: dict = Depends(require_auth),
+) -> GarminActivity:
+    """Manually patch Garmin activity fields (auth required when OAuth2 is enabled)."""
+    db = request.app.state.db
+
+    updates = body.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    set_parts: list[str] = []
+    params: list[Any] = []
+    idx = 1
+    for field_name, value in updates.items():
+        set_parts.append(f"{field_name} = ${idx}")
+        params.append(value)
+        idx += 1
+
+    params.append(activity_id)
+    updated = await db.fetchrow(
+        f"UPDATE public.garmin_activities SET {', '.join(set_parts)} WHERE activity_id = ${idx} RETURNING activity_id",
+        *params,
     )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
     if not row:
         raise HTTPException(status_code=404, detail="Activity not found")
     return GarminActivity(**dict(row))
@@ -396,7 +465,8 @@ async def list_track_points(
             "), matched AS ("
             "  SELECT gtp.id, gtp.activity_id, gtp.latitude, gtp.longitude, "
             "  gtp.timestamp, gtp.altitude, gtp.distance_from_start_km, gtp.speed_kmh, "
-            "  gtp.heart_rate, gtp.cadence, gtp.temperature_c, gtp.created_at, "
+            "  gtp.heart_rate, gtp.hr_zone, gtp.respiration_rate, gtp.cadence, "
+            "  gtp.temperature_c, gtp.surface_type, gtp.effort_level, gtp.created_at, "
             "  ROW_NUMBER() OVER ("
             "    PARTITION BY gtp.longitude, gtp.latitude "
             "    ORDER BY gtp.timestamp, (gtp.altitude IS NOT NULL) DESC, gtp.id"
@@ -408,7 +478,8 @@ async def list_track_points(
             ") "
             "SELECT m.id, m.activity_id, m.latitude, m.longitude, "
             "m.timestamp, m.altitude, m.distance_from_start_km, m.speed_kmh, "
-            "m.heart_rate, m.cadence, m.temperature_c, m.created_at "
+            "m.heart_rate, m.hr_zone, m.respiration_rate, m.cadence, "
+            "m.temperature_c, m.surface_type, m.effort_level, m.created_at "
             "FROM matched m "
             "WHERE m.rn = 1 "
             f"ORDER BY m.timestamp {order}",
@@ -421,7 +492,8 @@ async def list_track_points(
     rows = await db.fetch(
         "SELECT gtp.id, gtp.activity_id, gtp.latitude, gtp.longitude, gtp.timestamp, "
         "gtp.altitude, gtp.distance_from_start_km, gtp.speed_kmh, gtp.heart_rate, "
-        "gtp.cadence, gtp.temperature_c, gtp.created_at, "
+        "gtp.hr_zone, gtp.respiration_rate, gtp.cadence, gtp.temperature_c, "
+        "gtp.surface_type, gtp.effort_level, gtp.created_at, "
         "ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
         "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "
         "ga.waypoint_kind, ga.status AS address_status, ga.geocoded_at, "
@@ -473,7 +545,8 @@ async def get_chart_data(
 
     rows = await db.fetch(
         "SELECT latitude, longitude, timestamp, altitude, "
-        "distance_from_start_km, speed_kmh, heart_rate, cadence, temperature_c "
+        "distance_from_start_km, speed_kmh, heart_rate, hr_zone, respiration_rate, "
+        "cadence, temperature_c, surface_type, effort_level "
         "FROM public.garmin_track_points WHERE activity_id = $1 ORDER BY timestamp ASC",
         activity_id,
     )

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -2,10 +2,12 @@
 
 from datetime import date
 
+import fastapi
 import httpx
 import pytest
 from httpx import AsyncClient
 
+from app.auth import require_auth
 from app.config import Config
 
 
@@ -53,8 +55,12 @@ def _track_row(activity_id: str = "20932993811") -> dict:
         "distance_from_start_km": 0.0,
         "speed_kmh": 24.5,
         "heart_rate": 135,
+        "hr_zone": 3,
+        "respiration_rate": 22,
         "cadence": 80,
         "temperature_c": 18,
+        "surface_type": "paved",
+        "effort_level": "steady",
         "created_at": "2026-02-09T23:56:37+00:00",
     }
 
@@ -240,6 +246,70 @@ async def test_get_activity_not_found(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_patch_activity_success(client: AsyncClient, mock_db):
+    updated = _activity_row()
+    updated["avg_heart_rate"] = 141
+    updated["aerobic_training_effect"] = 3.2
+
+    mock_db.fetchrow.side_effect = [{"activity_id": "20932993811"}, updated]
+
+    response = await client.patch(
+        "/api/v1/garmin/activities/20932993811",
+        json={"avg_heart_rate": 141, "aerobic_training_effect": 3.2},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["activity_id"] == "20932993811"
+    assert response.json()["avg_heart_rate"] == 141
+    assert response.json()["aerobic_training_effect"] == 3.2
+
+    update_query, *update_params = mock_db.fetchrow.await_args_list[0].args
+    assert "UPDATE public.garmin_activities SET" in update_query
+    assert "avg_heart_rate = $1" in update_query
+    assert "aerobic_training_effect = $2" in update_query
+    assert update_params == [141, 3.2, "20932993811"]
+
+
+@pytest.mark.asyncio
+async def test_patch_activity_requires_body_fields(client: AsyncClient, mock_db):
+    response = await client.patch("/api/v1/garmin/activities/20932993811", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "No fields to update"}
+
+
+@pytest.mark.asyncio
+async def test_patch_activity_not_found(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = None
+
+    response = await client.patch(
+        "/api/v1/garmin/activities/missing",
+        json={"avg_heart_rate": 141},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+@pytest.mark.asyncio
+async def test_patch_activity_auth_required_when_dependency_denies(client: AsyncClient, app):
+    async def _deny_auth():
+        raise fastapi.HTTPException(status_code=401, detail="Authentication required")
+
+    app.dependency_overrides[require_auth] = _deny_auth
+    try:
+        response = await client.patch(
+            "/api/v1/garmin/activities/20932993811",
+            json={"avg_heart_rate": 141},
+        )
+    finally:
+        app.dependency_overrides.pop(require_auth, None)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+@pytest.mark.asyncio
 async def test_list_track_points_success_and_invalid_sort_falls_back(client: AsyncClient, mock_db):
     mock_db.fetchval.side_effect = [1, 2]
     mock_db.fetch.return_value = [_track_row()]
@@ -254,6 +324,10 @@ async def test_list_track_points_success_and_invalid_sort_falls_back(client: Asy
     assert data["limit"] == 5
     assert data["offset"] == 1
     assert len(data["items"]) == 1
+    assert data["items"][0]["hr_zone"] == 3
+    assert data["items"][0]["respiration_rate"] == 22
+    assert data["items"][0]["surface_type"] == "paved"
+    assert data["items"][0]["effort_level"] == "steady"
 
     track_query, *params = mock_db.fetch.await_args.args
     assert "ORDER BY gtp.timestamp desc" in track_query
@@ -336,8 +410,12 @@ def _chart_row() -> dict:
         "distance_from_start_km": 0.0,
         "speed_kmh": 24.5,
         "heart_rate": 135,
+        "hr_zone": 3,
+        "respiration_rate": 22,
         "cadence": 80,
         "temperature_c": 18,
+        "surface_type": "paved",
+        "effort_level": "steady",
         "latitude": 40.715,
         "longitude": -74.017,
     }
@@ -357,6 +435,10 @@ async def test_get_chart_data_success(client: AsyncClient, mock_db):
     assert data[0]["latitude"] == 40.715
     assert data[0]["altitude"] == 12.4
     assert data[0]["speed_kmh"] == 24.5
+    assert data[0]["hr_zone"] == 3
+    assert data[0]["respiration_rate"] == 22
+    assert data[0]["surface_type"] == "paved"
+    assert data[0]["effort_level"] == "steady"
 
     query = mock_db.fetch.await_args.args[0]
     assert "garmin_track_points" in query
@@ -466,6 +548,55 @@ async def test_trigger_sync_lookback_passthrough(client: AsyncClient, monkeypatc
     assert response.json()["lookback"] == 7
     assert captured["path"] == "/api/v1/sync"
     assert captured["params"] == {"lookback": 7}
+    assert "X-Garmin-Sync-Id" in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_passthrough_resync_and_activity_filters(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    captured: dict = {}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def __init__(self, *, base_url: str, timeout: float):
+            captured["base_url"] = base_url
+            captured["timeout"] = timeout
+
+        async def post(self, path: str, params=None, headers=None):
+            captured["path"] = path
+            captured["params"] = params
+            captured["headers"] = headers
+            return _FakeSyncResponse(
+                202,
+                {
+                    "status": "accepted",
+                    "message": "Sync started",
+                    "triggered_at": "2026-03-12T01:00:00Z",
+                    "resync_existing": True,
+                    "activity_ids": ["23157610603", "23157610604"],
+                },
+            )
+
+    monkeypatch.setattr("app.routers.garmin.httpx.AsyncClient", _FakeClient)
+
+    response = await client.post(
+        "/api/v1/garmin/sync?resync_existing=true&activity_id=23157610603&activity_ids=23157610604"
+    )
+
+    assert response.status_code == 202
+    assert response.json()["status"] == "accepted"
+    assert captured["path"] == "/api/v1/sync"
+    assert captured["params"] == {
+        "resync_existing": "true",
+        "activity_id": ["23157610603"],
+        "activity_ids": ["23157610604"],
+    }
     assert "X-Garmin-Sync-Id" in captured["headers"]
 
 


### PR DESCRIPTION
## Summary
- add authenticated PATCH endpoint for manual Garmin activity field updates
- extend Garmin sync trigger passthrough to support resync_existing and activity_id/activity_ids filters
- include tests for manual update flow and sync passthrough parameters

## Validation
- /home/ubuntu/git/otel-data-api/venv/bin/python -m pytest tests/test_garmin.py -q