### PR TITLE
fix: populate message field for New Relic logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -148,16 +148,16 @@
         "filename": "tests/test_logging.py",
         "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 161
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_logging.py",
         "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 162
       }
     ]
   },
-  "generated_at": "2026-06-09T00:11:39Z"
+  "generated_at": "2026-06-09T05:03:57Z"
 }

--- a/app/logging.py
+++ b/app/logging.py
@@ -77,6 +77,17 @@ def _add_trace_context(
     return event_dict
 
 
+def _ensure_message_field(
+    logger: Any,
+    method_name: str,
+    event_dict: structlog.types.EventDict,
+) -> structlog.types.EventDict:
+    """Populate ``message`` from structlog ``event`` for log UIs expecting it."""
+    if "message" not in event_dict and "event" in event_dict:
+        event_dict["message"] = event_dict["event"]
+    return event_dict
+
+
 def _build_otel_resource(config: Config) -> Resource:
     return Resource.create(
         {
@@ -120,6 +131,7 @@ def configure_logging(config: Config) -> LoggerProvider | None:
         structlog.processors.format_exc_info,
         _add_service_context(config),
         _add_trace_context,
+        _ensure_message_field,
     ]
 
     if config.log_format == "console":

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -48,6 +48,7 @@ class TestConfigureLogging:
         data = json.loads(line)
 
         assert data["event"] == "hello"
+        assert data["message"] == "hello"
         assert data["key"] == "value"
         assert data["level"] == "info"
         assert "timestamp" in data


### PR DESCRIPTION
## Summary
- copy structlog event into message when message is missing
- keep existing structured event payload intact for downstream consumers
- add logging test coverage to verify the message field is emitted

## Validation
- ./venv/bin/python -m pytest -q tests/test_logging.py
- pre-commit run --files app/logging.py tests/test_logging.py