### PR TITLE
ci(renovate): group all opentelemetry packages into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,23 +48,13 @@
       "groupSlug": "pydantic"
     },
     {
-      "description": "Group OpenTelemetry core packages (excluding instrumentation)",
+      "description": "Group ALL OpenTelemetry packages (core + instrumentation) into one PR. They must move in lockstep: opentelemetry-sdk and the instrumentation packages each pin a matching opentelemetry-semantic-conventions, so bumping them in separate PRs causes pip ResolutionImpossible.",
+      "matchManagers": ["pip_requirements"],
       "matchPackageNames": [
-        "opentelemetry-api",
-        "opentelemetry-sdk",
-        "/^opentelemetry-exporter-/",
-        "/^opentelemetry-proto/"
+        "/^opentelemetry-/"
       ],
-      "groupName": "opentelemetry-core",
-      "groupSlug": "opentelemetry-core"
-    },
-    {
-      "description": "Group OpenTelemetry instrumentation packages",
-      "matchPackageNames": [
-        "/^opentelemetry-instrumentation/"
-      ],
-      "groupName": "opentelemetry-instrumentation",
-      "groupSlug": "opentelemetry-instrumentation"
+      "groupName": "opentelemetry",
+      "groupSlug": "opentelemetry"
     },
     {
       "description": "Group database drivers",


### PR DESCRIPTION
## Summary

Prevents recurrence of the OpenTelemetry dependency conflict that broke PR #118.

Refs #150

## Problem

`renovate.json` split OpenTelemetry into two groups (`opentelemetry-core` and `opentelemetry-instrumentation`). Because OTel core (`1.x`) and instrumentation/semconv (`0.Nbx`) release in lockstep — and both `opentelemetry-sdk` and the instrumentation packages pin an exact `opentelemetry-semantic-conventions==X` — updating them in separate PRs let them drift to incompatible versions, causing pip `ResolutionImpossible` (PR #118: core 1.42.1 / semconv 0.63b1 vs instrumentation 0.62b1).

## Change

- `renovate.json`: replace the two OTel groups with a single `opentelemetry` group matching `/^opentelemetry-/` (pip_requirements). Core + instrumentation now always bump together in one installable PR.

## Validation

- `renovate.json` is valid JSON (pre-commit `check json` passes)
- Single `opentelemetry` group present; no separate core/instrumentation groups

## Related

- PR #118 (immediate fix: instrumentation `0.62b1 → 0.63b1`)
