### PR TITLE
perf(geocoding): optimize slow SQL (NOT EXISTS, GROUP BY, /status cache)

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -55,6 +56,20 @@ RETRY_STATUSES = ("no_coverage", "error", "pending")
 _OT_CONFLICT = "ON CONFLICT (location_id) WHERE source = 'owntracks'"
 _GARMIN_CONFLICT = "ON CONFLICT (garmin_track_point_id) WHERE source = 'garmin'"
 
+# Cache TTL for the /status response. The aggregates scan large tables and change
+# slowly, so caching per-process avoids re-running the heavy COUNT queries on
+# every dashboard poll.
+_STATUS_CACHE_TTL_SECONDS = 60.0
+
+
+@dataclass
+class _StatusCache:
+    """Per-process cache holder for the geocoding /status response."""
+
+    value: GeocodingStatus | None = None
+    expires_at: float = 0.0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
 
 class PeliasTransientError(Exception):
     """Raised by ``_call_pelias`` after all retry attempts have failed transiently."""
@@ -62,58 +77,75 @@ class PeliasTransientError(Exception):
 
 @router.get("/status", response_model=GeocodingStatus)
 async def geocoding_status(request: Request) -> GeocodingStatus:
-    """Get geocoding coverage statistics for both OwnTracks and Garmin sources."""
-    db = request.app.state.db
+    """Get geocoding coverage statistics for both OwnTracks and Garmin sources.
+
+    The underlying aggregates scan large tables (millions of garmin_track_points)
+    and change slowly, so the response is cached per-process for
+    ``_STATUS_CACHE_TTL_SECONDS`` to avoid repeatedly running the heavy COUNT
+    queries on every dashboard poll.
+    """
+    cache: _StatusCache | None = getattr(request.app.state, "_geocoding_status_cache", None)
+    if cache is None:
+        cache = _StatusCache()
+        request.app.state._geocoding_status_cache = cache
+
+    if cache.value is not None and time.monotonic() < cache.expires_at:
+        return cache.value
+
+    async with cache.lock:
+        # Re-check after acquiring the lock so only one request recomputes.
+        if cache.value is not None and time.monotonic() < cache.expires_at:
+            return cache.value
+        status = await _compute_geocoding_status(request.app.state.db)
+        cache.value = status
+        cache.expires_at = time.monotonic() + _STATUS_CACHE_TTL_SECONDS
+        return status
+
+
+async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
+    """Compute geocoding coverage statistics (uncached)."""
+    # Per-(source, status) counts for geocoded_addresses in a single GROUP BY
+    # instead of eight separate COUNT(*) round-trips.
+    addr_rows = await db.fetch(
+        "SELECT source, status, COUNT(*) AS n FROM public.geocoded_addresses "
+        "WHERE source IN ('owntracks', 'garmin') GROUP BY source, status"
+    )
+    addr: dict[tuple[str, str], int] = {(r["source"], r["status"]): r["n"] for r in addr_rows}
+    ot_success = addr.get(("owntracks", "success"), 0)
+    ot_pending = addr.get(("owntracks", "pending"), 0)
+    ot_no_coverage = addr.get(("owntracks", "no_coverage"), 0)
+    ot_errors = addr.get(("owntracks", "error"), 0)
+    geocoded = sum(n for (src, _status), n in addr.items() if src == "owntracks")
+    g_success = addr.get(("garmin", "success"), 0)
+    g_pending = addr.get(("garmin", "pending"), 0)
+    g_no_coverage = addr.get(("garmin", "no_coverage"), 0)
+    g_errors = addr.get(("garmin", "error"), 0)
+    g_total_rows = g_success + g_pending + g_no_coverage + g_errors
 
     total = await db.fetchval("SELECT COUNT(*) FROM public.locations")
-    geocoded = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks'")
-    ot_success = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'success'"
-    )
-    ot_pending = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'pending'"
-    )
-    ot_no_coverage = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'no_coverage'"
-    )
-    ot_errors = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'owntracks' AND status = 'error'"
-    )
-    coverage_percent = round((geocoded / total * 100), 2) if total > 0 else 0.0
-
-    g_success = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'success'"
-    )
-    g_pending = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'pending'"
-    )
-    g_no_coverage = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'no_coverage'"
-    )
-    g_errors = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_addresses WHERE source = 'garmin' AND status = 'error'"
-    )
-    g_total_rows = (g_success or 0) + (g_pending or 0) + (g_no_coverage or 0) + (g_errors or 0)
+    coverage_percent = round((geocoded / total * 100), 2) if total else 0.0
 
     activities_total = await db.fetchval("SELECT COUNT(*) FROM public.garmin_activities")
     activities_geocoded = await db.fetchval(
         "SELECT COUNT(DISTINCT garmin_activity_id) FROM public.geocoded_addresses WHERE source = 'garmin'"
     )
     garmin_coverage_percent = round((activities_geocoded / activities_total * 100), 2) if activities_total else 0.0
-    garmin_waypoint_success_percent = round(((g_success or 0) / g_total_rows * 100), 2) if g_total_rows else 0.0
+    garmin_waypoint_success_percent = round((g_success / g_total_rows * 100), 2) if g_total_rows else 0.0
 
     # Dense per-point cell coverage (geocoded_point_cells, 4dp ~ 11 m resolution).
+    # Per-status counts in a single GROUP BY instead of four separate COUNT(*) calls.
+    cell_rows = await db.fetch("SELECT status, COUNT(*) AS n FROM public.geocoded_point_cells GROUP BY status")
+    cell: dict[str, int] = {r["status"]: r["n"] for r in cell_rows}
+    dense_success = cell.get("success", 0)
+    dense_pending = cell.get("pending", 0)
+    dense_no_coverage = cell.get("no_coverage", 0)
+    dense_errors = cell.get("error", 0)
+    dense_geocoded = dense_success + dense_pending + dense_no_coverage + dense_errors
+
     # Read distinct-cell totals from the mv_garmin_track_point_cells materialized view
     # (migration 18) — a direct COUNT(DISTINCT ...) over garmin_track_points takes ~18s on
     # prod and exceeds the API's database command timeout.
     dense_total_cells = await db.fetchval("SELECT COUNT(*) FROM public.mv_garmin_track_point_cells")
-    dense_success = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'success'")
-    dense_pending = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'pending'")
-    dense_no_coverage = await db.fetchval(
-        "SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'no_coverage'"
-    )
-    dense_errors = await db.fetchval("SELECT COUNT(*) FROM public.geocoded_point_cells WHERE status = 'error'")
-    dense_geocoded = (dense_success or 0) + (dense_pending or 0) + (dense_no_coverage or 0) + (dense_errors or 0)
     total_track_points = await db.fetchval("SELECT COUNT(*) FROM public.garmin_track_points")
     covered_track_points = await db.fetchval(
         "SELECT COUNT(*) FROM public.garmin_track_points gtp "
@@ -272,9 +304,10 @@ async def _trigger_geocoding_impl(
         rows = await db.fetch(
             "SELECT l.id, l.latitude, l.longitude "
             "FROM public.locations l "
-            "LEFT JOIN public.geocoded_addresses ga "
-            "  ON ga.location_id = l.id AND ga.source = 'owntracks' "
-            "WHERE ga.id IS NULL "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM public.geocoded_addresses ga "
+            "  WHERE ga.location_id = l.id AND ga.source = 'owntracks'"
+            ") "
             "ORDER BY l.id LIMIT $1",
             batch_size,
         )
@@ -295,9 +328,10 @@ async def _trigger_geocoding_impl(
 
     remaining = await db.fetchval(
         "SELECT COUNT(*) FROM public.locations l "
-        "LEFT JOIN public.geocoded_addresses ga "
-        "  ON ga.location_id = l.id AND ga.source = 'owntracks' "
-        "WHERE ga.id IS NULL"
+        "WHERE NOT EXISTS ("
+        "  SELECT 1 FROM public.geocoded_addresses ga "
+        "  WHERE ga.location_id = l.id AND ga.source = 'owntracks'"
+        ")"
     )
 
     return GeocodingTriggerResponse(processed=processed, remaining=remaining, skipped_dedup=skipped_dedup)

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -14,30 +14,35 @@ from app.config import Config
 
 @pytest.mark.asyncio
 async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
-    # Order: total, geocoded, ot_success, ot_pending, ot_no_coverage, ot_errors,
-    # g_success, g_pending, g_no_coverage, g_errors, activities_total, activities_geocoded,
-    # dense_total_cells, dense_success, dense_pending, dense_no_coverage, dense_errors,
-    # total_track_points, covered_track_points
+    # geocoded_addresses and geocoded_point_cells status counts now come from
+    # two GROUP BY queries (db.fetch); the remaining six scalars come from
+    # db.fetchval in this order: total_locations, activities_total,
+    # activities_geocoded, dense_total_cells, total_track_points,
+    # covered_track_points.
+    addr_rows = [
+        {"source": "owntracks", "status": "success", "n": 550},
+        {"source": "owntracks", "status": "pending", "n": 30},
+        {"source": "owntracks", "status": "no_coverage", "n": 10},
+        {"source": "owntracks", "status": "error", "n": 10},
+        {"source": "garmin", "status": "success", "n": 80},
+        {"source": "garmin", "status": "pending", "n": 5},
+        {"source": "garmin", "status": "no_coverage", "n": 4},
+        {"source": "garmin", "status": "error", "n": 1},
+    ]
+    cell_rows = [
+        {"status": "success", "n": 3000},
+        {"status": "pending", "n": 100},
+        {"status": "no_coverage", "n": 50},
+        {"status": "error", "n": 20},
+    ]
+    mock_db.fetch.side_effect = [addr_rows, cell_rows]
     mock_db.fetchval.side_effect = [
-        1000,
-        600,
-        550,
-        30,
-        10,
-        10,
-        80,
-        5,
-        4,
-        1,
-        25,
-        12,
-        4500,
-        3000,
-        100,
-        50,
-        20,
-        50000,
-        35000,
+        1000,  # total locations
+        25,  # garmin activities total
+        12,  # garmin activities geocoded
+        4500,  # dense_total_cells (mv)
+        50000,  # total_track_points
+        35000,  # covered_track_points
     ]
 
     response = await client.get("/api/v1/geocoding/status")
@@ -74,7 +79,9 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
 
 @pytest.mark.asyncio
 async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: AsyncMock):
-    mock_db.fetchval.side_effect = [0] * 19
+    # Both GROUP BY queries return no rows; the six scalar counts are zero.
+    mock_db.fetch.side_effect = [[], []]
+    mock_db.fetchval.side_effect = [0] * 6
 
     response = await client.get("/api/v1/geocoding/status")
 

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -96,6 +96,50 @@ async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: Asy
 
 
 @pytest.mark.asyncio
+async def test_geocoding_status_cached_within_ttl(client: AsyncClient, mock_db: AsyncMock):
+    """A second /status call within the TTL is served from cache without re-querying."""
+    addr_rows = [
+        {"source": "owntracks", "status": "success", "n": 100},
+        {"source": "garmin", "status": "success", "n": 50},
+    ]
+    cell_rows = [{"status": "success", "n": 200}]
+    # Only enough side-effects for ONE computation — if caching is bypassed the
+    # second request exhausts these and raises StopAsyncIteration.
+    mock_db.fetch.side_effect = [addr_rows, cell_rows]
+    mock_db.fetchval.side_effect = [1000, 10, 5, 300, 50000, 35000]
+
+    first = await client.get("/api/v1/geocoding/status")
+    second = await client.get("/api/v1/geocoding/status")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    # Underlying queries ran exactly once: 2 GROUP BY fetches + 6 scalars.
+    assert mock_db.fetch.await_count == 2
+    assert mock_db.fetchval.await_count == 6
+
+
+@pytest.mark.asyncio
+async def test_geocoding_status_cache_expires(client: AsyncClient, mock_db: AsyncMock):
+    """After the TTL elapses the /status response is recomputed."""
+    addr_rows = [{"source": "owntracks", "status": "success", "n": 100}]
+    cell_rows = [{"status": "success", "n": 200}]
+    mock_db.fetch.side_effect = [addr_rows, cell_rows, addr_rows, cell_rows]
+    mock_db.fetchval.side_effect = [1000, 10, 5, 300, 50000, 35000] * 2
+
+    now = [0.0]
+    with patch("app.routers.geocoding.time.monotonic", side_effect=lambda: now[0]):
+        await client.get("/api/v1/geocoding/status")
+        assert mock_db.fetch.await_count == 2  # first computation
+        now[0] = 1000.0  # advance well beyond the 60s TTL
+        await client.get("/api/v1/geocoding/status")
+
+    # Cache was stale, so the queries ran a second time.
+    assert mock_db.fetch.await_count == 4
+    assert mock_db.fetchval.await_count == 12
+
+
+@pytest.mark.asyncio
 async def test_trigger_geocoding_no_pending(client: AsyncClient, mock_db: AsyncMock):
     mock_db.fetch.return_value = []
     mock_db.fetchval.return_value = 0


### PR DESCRIPTION
## Summary

Reduces otel-data-api "Slow SQL query" log volume by optimizing the geocoding endpoints, which production `EXPLAIN ANALYZE` identified as the source (large tables: garmin_track_points 4.5M rows / 1.6 GB).

Refs #152

## Changes (`app/routers/geocoding.py`)

1. **Anti-join → `NOT EXISTS`** for the geocoding-trigger "find/count ungeocoded locations" queries. Merge Anti Join + index-only scan instead of heap-fetching `ga.id`. Validated on prod: **2302ms → 719ms** and **1732ms → 636ms**.
2. **`geocoding_status` consolidation:** 8 per-(source, status) counts → 1 `GROUP BY`; 4 dense-cell counts → 1 `GROUP BY`. Work extracted into `_compute_geocoding_status`.
3. **60s per-process TTL cache** (`_StatusCache` on `app.state`) for `GET /api/v1/geocoding/status`. The heavy aggregates (incl. the 5.2s EXISTS-ROUND count) now run at most once per 60s per pod instead of on every dashboard poll. Counts remain **exact**.

KNN nearest-address query left unchanged (already 18ms via the existing GiST index).

## Validation

- `make test`: **189 passed**, coverage **92.4%** (≥85% gate)
- `pre-commit run -a`: clean (ruff, mypy, pyright, cspell)
- Prod-validated query rewrites via `EXPLAIN (ANALYZE, BUFFERS)`

## Behavior note

`GET /api/v1/geocoding/status` may be up to 60s stale (cached). Values are otherwise identical and exact.

## Follow-up (Phase 2 — separate, needs DB migration)

- Covering index `geocoded_addresses(source, status)` → status GROUP BY ~ms (currently ~1s seq scan over 535 MB).
- Denormalize `locations.geocoded_at` + partial index → anti-join ~ms.
- Summary table / MV for the 5.2s EXISTS-ROUND "geocoded garmin points" count.

## Post-deploy check

After deploy, compare slow-query volume in New Relic:
```
FROM Log_otel_operations SELECT count(*) WHERE service.name = 'otel-data-api' AND message = 'Slow SQL query' SINCE 1 day ago TIMESERIES
```
