### PR TITLE
feat(garmin): log full activity detail response for NR verification

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,9 @@ class Config:
     log_sql: bool = True
     log_sql_params: bool = False
     log_http_query_params: bool = True
+    # Diagnostic: log the full Garmin activity detail response payload (off by default;
+    # enable temporarily to verify responses, e.g. in New Relic Logs).
+    log_garmin_activity_detail: bool = False
 
     # CORS
     cors_origins: tuple[str, ...] = ()
@@ -105,6 +108,7 @@ class Config:
             log_sql=os.getenv("LOG_SQL", "true").lower() == "true",
             log_sql_params=os.getenv("LOG_SQL_PARAMS", "false").lower() == "true",
             log_http_query_params=os.getenv("LOG_HTTP_QUERY_PARAMS", "true").lower() == "true",
+            log_garmin_activity_detail=os.getenv("LOG_GARMIN_ACTIVITY_DETAIL", "false").lower() == "true",
             # CORS
             cors_origins=cors_origins,
             # Garmin sync proxy

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -352,11 +352,12 @@ async def get_activity(
     if not row:
         raise HTTPException(status_code=404, detail="Activity not found")
     activity = GarminActivity(**dict(row))
-    logger.info(
-        "garmin.activity.detail",
-        garmin_activity_id=activity_id,
-        response=activity.model_dump(mode="json"),
-    )
+    if request.app.state.config.log_garmin_activity_detail:
+        logger.info(
+            "garmin.activity.detail",
+            garmin_activity_id=activity_id,
+            response=activity.model_dump(mode="json"),
+        )
     return activity
 
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -351,7 +351,13 @@ async def get_activity(
     row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
     if not row:
         raise HTTPException(status_code=404, detail="Activity not found")
-    return GarminActivity(**dict(row))
+    activity = GarminActivity(**dict(row))
+    logger.info(
+        "garmin.activity.detail",
+        garmin_activity_id=activity_id,
+        response=activity.model_dump(mode="json"),
+    )
+    return activity
 
 
 @router.patch(

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -5,6 +5,7 @@ from datetime import date
 import fastapi
 import httpx
 import pytest
+import structlog
 from httpx import AsyncClient
 
 from app.auth import require_auth
@@ -222,7 +223,23 @@ async def test_get_activity_success(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
-async def test_get_activity_hr_availability_defaults_false(client: AsyncClient, mock_db):
+async def test_get_activity_logs_full_response(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = _activity_row()
+
+    with structlog.testing.capture_logs() as logs:
+        response = await client.get("/api/v1/garmin/activities/20932993811")
+
+    assert response.status_code == 200
+    detail_logs = [entry for entry in logs if entry.get("event") == "garmin.activity.detail"]
+    assert len(detail_logs) == 1
+    entry = detail_logs[0]
+    assert entry["garmin_activity_id"] == "20932993811"
+    assert entry["response"]["activity_id"] == "20932993811"
+    # Full payload is logged, including respiration fields (None when absent from the row)
+    assert "avg_respiration_rate" in entry["response"]
+    assert "min_respiration_rate" in entry["response"]
+    assert "max_respiration_rate" in entry["response"]
+
     row = _activity_row()
     row["avg_heart_rate"] = None
     row["max_heart_rate"] = None

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,13 +1,15 @@
 """Tests for Garmin endpoints."""
 
+import dataclasses
 from datetime import date
 
 import fastapi
 import httpx
 import pytest
 import structlog
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
+from app import create_app
 from app.auth import require_auth
 from app.config import Config
 
@@ -223,23 +225,39 @@ async def test_get_activity_success(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
-async def test_get_activity_logs_full_response(client: AsyncClient, mock_db):
+async def test_get_activity_logs_full_response_when_enabled(config: Config, mock_db):
+    enabled_config = dataclasses.replace(config, log_garmin_activity_detail=True)
+    app = create_app(enabled_config)
+    app.state.db = mock_db
     mock_db.fetchrow.return_value = _activity_row()
 
-    with structlog.testing.capture_logs() as logs:
-        response = await client.get("/api/v1/garmin/activities/20932993811")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        with structlog.testing.capture_logs() as logs:
+            response = await client.get("/api/v1/garmin/activities/20932993811")
 
     assert response.status_code == 200
     detail_logs = [entry for entry in logs if entry.get("event") == "garmin.activity.detail"]
     assert len(detail_logs) == 1
     entry = detail_logs[0]
     assert entry["garmin_activity_id"] == "20932993811"
-    assert entry["response"]["activity_id"] == "20932993811"
-    # Full payload is logged, including respiration fields (None when absent from the row)
-    assert "avg_respiration_rate" in entry["response"]
-    assert "min_respiration_rate" in entry["response"]
-    assert "max_respiration_rate" in entry["response"]
+    # The logged payload must match the full HTTP response body exactly.
+    assert entry["response"] == response.json()
 
+
+@pytest.mark.asyncio
+async def test_get_activity_detail_logging_disabled_by_default(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = _activity_row()
+
+    with structlog.testing.capture_logs() as logs:
+        response = await client.get("/api/v1/garmin/activities/20932993811")
+
+    assert response.status_code == 200
+    assert not [entry for entry in logs if entry.get("event") == "garmin.activity.detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_activity_hr_availability_defaults_false(client: AsyncClient, mock_db):
     row = _activity_row()
     row["avg_heart_rate"] = None
     row["max_heart_rate"] = None


### PR DESCRIPTION
## Summary

Adds an INFO-level structured log, `garmin.activity.detail`, to the single
Garmin activity endpoint (`GET /api/v1/garmin/activities/{activity_id}`). It
emits the **full** `GarminActivity` response payload via
`model_dump(mode="json")` plus a flat `garmin_activity_id` attribute.

This is a diagnostic first step to verify what the API actually returns for a
given activity in **New Relic Logs** — specifically to investigate missing
**Respiration** data (avg/min/max) for activity `23241368288`, which renders as
dashes in the otel-data-ui Garmin Activity detail. Logging the full payload also
lets other fields be verified at the same time.

## Changes

- `app/routers/garmin.py` — build the `GarminActivity` once, log
  `garmin.activity.detail` with the full payload, then return it.
- `tests/test_garmin.py` — new `test_get_activity_logs_full_response` using
  `structlog.testing.capture_logs()` asserting the event fires with the full
  payload (including respiration fields).

## Validation

- `pre-commit run --all-files` — pass (ruff, mypy, pyright, cspell).
- `make test` — 191 passed, coverage gate held.

## How to verify in New Relic (after deploy)

Query NR Logs for `garmin_activity_id = '23241368288'` (or
`message = 'garmin.activity.detail'`) and expand the `response` attribute (NR
flattens to `response.avg_respiration_rate`, `response.min_respiration_rate`,
`response.max_respiration_rate`, etc.).

## Scope / follow-up

- Diagnostic logging only. Fixing the upstream respiration data import
  (garmin-sync) is out of scope and tracked separately.

## Notes

- Per repo policy, no auto-close keywords are used; acceptance will be validated
  in NR on the deployed cluster before closing any linked issue.