### PR TITLE
perf(geocoding): split nearest-address lookup into per-source indexed queries

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -772,34 +772,59 @@ async def _find_nearby_address(db: Any, lat: float, lon: float) -> dict[str, Any
     if not ow_ids and not gt_ids:
         return None
 
-    # Order by true distance against the candidate's geog so dedup picks the
-    # *nearest* neighbour deterministically. Candidate set is bounded by
-    # 2 * _NEARBY_CANDIDATE_LIMIT rows, so the join + sort is cheap.
-    neighbour = await db.fetchrow(
-        "SELECT ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
+    # Look up the geocoded address for each source independently. A single
+    # OR-across-columns LEFT JOIN forced a sequential scan over all 'success'
+    # rows in geocoded_addresses (NR slow-query analysis: avg ~1.8 s, max
+    # ~13 s). Splitting by source lets the planner use the partial unique
+    # indexes (location_id WHERE source='owntracks' / garmin_track_point_id
+    # WHERE source='garmin'); each side then sorts the bounded candidate set
+    # by true distance and returns its nearest neighbour. See #132.
+    _ADDRESS_COLS = (
+        "ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
         "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "
-        "ga.raw_response "
-        "FROM public.geocoded_addresses ga "
-        "LEFT JOIN public.locations l "
-        "  ON ga.source = 'owntracks' AND ga.location_id = l.id "
-        "LEFT JOIN public.garmin_track_points gtp "
-        "  ON ga.source = 'garmin' AND ga.garmin_track_point_id = gtp.id "
-        "WHERE ga.status = 'success' "
-        "AND ("
-        "  (ga.source = 'owntracks' AND ga.location_id = ANY($1::bigint[])) "
-        "  OR (ga.source = 'garmin' AND ga.garmin_track_point_id = ANY($2::bigint[]))"
-        ") "
-        "ORDER BY ST_Distance("
-        "  COALESCE(l.geog, gtp.geog), "
-        "  ST_SetSRID(ST_MakePoint($3, $4), 4326)::geography"
-        ") ASC "
-        "LIMIT 1",
-        ow_ids,
-        gt_ids,
-        lon,
-        lat,
+        "ga.raw_response"
     )
-    return dict(neighbour) if neighbour else None
+    _POINT = "ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography"
+    candidates: list[Any] = []
+
+    if ow_ids:
+        ow_match = await db.fetchrow(
+            f"SELECT {_ADDRESS_COLS}, ST_Distance(l.geog, {_POINT}) AS _dist "
+            "FROM public.geocoded_addresses ga "
+            "JOIN public.locations l ON l.id = ga.location_id "
+            "WHERE ga.source = 'owntracks' AND ga.status = 'success' "
+            "AND ga.location_id = ANY($3::bigint[]) "
+            "ORDER BY _dist ASC LIMIT 1",
+            lon,
+            lat,
+            ow_ids,
+        )
+        if ow_match:
+            candidates.append(ow_match)
+
+    if gt_ids:
+        gt_match = await db.fetchrow(
+            f"SELECT {_ADDRESS_COLS}, ST_Distance(gtp.geog, {_POINT}) AS _dist "
+            "FROM public.geocoded_addresses ga "
+            "JOIN public.garmin_track_points gtp ON gtp.id = ga.garmin_track_point_id "
+            "WHERE ga.source = 'garmin' AND ga.status = 'success' "
+            "AND ga.garmin_track_point_id = ANY($3::bigint[]) "
+            "ORDER BY _dist ASC LIMIT 1",
+            lon,
+            lat,
+            gt_ids,
+        )
+        if gt_match:
+            candidates.append(gt_match)
+
+    if not candidates:
+        return None
+
+    nearest = min(
+        candidates,
+        key=lambda r: r["_dist"] if r["_dist"] is not None else float("inf"),
+    )
+    return {key: value for key, value in dict(nearest).items() if key != "_dist"}
 
 
 async def _call_pelias(

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -740,9 +740,10 @@ async def _find_nearby_address(db: Any, lat: float, lon: float) -> dict[str, Any
     """Return the nearest successfully geocoded address within 50 m, or None.
 
     Implemented as two GIST-indexed candidate lookups (locations + garmin
-    track points) followed by a single lookup in ``geocoded_addresses`` via
-    the existing unique partial btree indexes. A combined ``COALESCE``-based
-    query would force a sequential scan over all success rows; see #132.
+    track points; #132) followed by a per-source lookup in
+    ``geocoded_addresses`` via the existing unique partial btree indexes. A
+    combined ``COALESCE``/OR query forced a sequential scan over all success
+    rows, so each source is now queried independently; see #165.
     """
     ow_candidates = await db.fetch(
         "SELECT id "
@@ -778,7 +779,7 @@ async def _find_nearby_address(db: Any, lat: float, lon: float) -> dict[str, Any
     # ~13 s). Splitting by source lets the planner use the partial unique
     # indexes (location_id WHERE source='owntracks' / garmin_track_point_id
     # WHERE source='garmin'); each side then sorts the bounded candidate set
-    # by true distance and returns its nearest neighbour. See #132.
+    # by true distance and returns its nearest neighbour. See #165.
     _ADDRESS_COLS = (
         "ga.display_address, ga.street, ga.housenumber, ga.neighbourhood, "
         "ga.locality, ga.region, ga.country, ga.postalcode, ga.confidence, "

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -255,6 +255,7 @@ async def test_trigger_geocoding_dedup_from_neighbour(client: AsyncClient, mock_
         "postalcode": "10001",
         "confidence": 0.9,
         "raw_response": {},
+        "_dist": 5.0,
     }
 
     response = await client.post("/api/v1/geocoding/trigger?batch_size=1")
@@ -424,7 +425,18 @@ async def test_trigger_geocoding_db_timeout_handled(client: AsyncClient, mock_db
         {"id": 100, "latitude": 40.7128, "longitude": -74.006},
         {"id": 101, "latitude": 40.7130, "longitude": -74.007},
     ]
-    mock_db.fetchrow.side_effect = [TimeoutError("query timed out"), None]
+    # The nearest-address lookup now issues up to two fetchrow calls (one per
+    # source). Raise the timeout on the first neighbour lookup only, then return
+    # None — robust to concurrent processing order and the new call count.
+    _timeout_calls = {"n": 0}
+
+    def _fetchrow_timeout(*_args: object, **_kwargs: object) -> None:
+        _timeout_calls["n"] += 1
+        if _timeout_calls["n"] == 1:
+            raise TimeoutError("query timed out")
+        return None
+
+    mock_db.fetchrow.side_effect = _fetchrow_timeout
     mock_db.fetchval.return_value = 10  # remaining
 
     pelias_response = {
@@ -473,8 +485,18 @@ async def test_trigger_geocoding_unexpected_error_upserts_error_status(client: A
         {"id": 200, "latitude": 40.7128, "longitude": -74.006},
         {"id": 201, "latitude": 40.7130, "longitude": -74.007},
     ]
-    # First location raises unexpected error; second returns no neighbour
-    mock_db.fetchrow.side_effect = [RuntimeError("unexpected"), None]
+    # First neighbour lookup raises an unexpected error; subsequent per-source
+    # lookups return None. Call-counter form is robust to the two-query split
+    # and concurrent location processing.
+    _err_calls = {"n": 0}
+
+    def _fetchrow_error(*_args: object, **_kwargs: object) -> None:
+        _err_calls["n"] += 1
+        if _err_calls["n"] == 1:
+            raise RuntimeError("unexpected")
+        return None
+
+    mock_db.fetchrow.side_effect = _fetchrow_error
     mock_db.fetchval.return_value = 8  # remaining
 
     pelias_response = {
@@ -1044,7 +1066,7 @@ async def test_find_nearby_address_no_candidates_short_circuits(mock_db: AsyncMo
 
 @pytest.mark.asyncio
 async def test_find_nearby_address_owntracks_only_hit(mock_db: AsyncMock):
-    """Owntracks candidates only → final lookup runs with empty gt_ids."""
+    """Owntracks candidates only → only the owntracks lookup runs."""
     from app.routers.geocoding import _find_nearby_address
 
     address: dict = {
@@ -1060,24 +1082,27 @@ async def test_find_nearby_address_owntracks_only_hit(mock_db: AsyncMock):
         "raw_response": {},
     }
     mock_db.fetch.side_effect = [[{"id": 42}], []]
-    mock_db.fetchrow.return_value = address
+    mock_db.fetchrow.return_value = {**address, "_dist": 12.5}
 
     result = await _find_nearby_address(mock_db, lat=40.0, lon=-74.0)
 
+    # The internal _dist ranking column must be stripped from the result.
     assert result == address
+    # gt_ids is empty, so only the owntracks lookup runs.
     assert mock_db.fetchrow.call_count == 1
     final_call = mock_db.fetchrow.call_args
     sql = final_call[0][0]
+    assert "ga.source = 'owntracks'" in sql
     assert "ga.location_id = ANY" in sql
-    assert "ga.garmin_track_point_id = ANY" in sql
-    # Positional args: ow_ids, gt_ids
-    assert final_call[0][1] == [42]
-    assert final_call[0][2] == []
+    # Positional args: lon, lat, ow_ids
+    assert final_call[0][1] == -74.0
+    assert final_call[0][2] == 40.0
+    assert final_call[0][3] == [42]
 
 
 @pytest.mark.asyncio
 async def test_find_nearby_address_garmin_only_hit(mock_db: AsyncMock):
-    """Garmin candidates only → final lookup runs with empty ow_ids."""
+    """Garmin candidates only → only the garmin lookup runs."""
     from app.routers.geocoding import _find_nearby_address
 
     address: dict = {
@@ -1093,19 +1118,51 @@ async def test_find_nearby_address_garmin_only_hit(mock_db: AsyncMock):
         "raw_response": {},
     }
     mock_db.fetch.side_effect = [[], [{"id": 99}, {"id": 100}]]
-    mock_db.fetchrow.return_value = address
+    mock_db.fetchrow.return_value = {**address, "_dist": 7.0}
 
     result = await _find_nearby_address(mock_db, lat=40.0, lon=-74.0)
 
     assert result == address
+    assert mock_db.fetchrow.call_count == 1
     final_call = mock_db.fetchrow.call_args
-    assert final_call[0][1] == []
-    assert final_call[0][2] == [99, 100]
+    sql = final_call[0][0]
+    assert "ga.source = 'garmin'" in sql
+    assert "ga.garmin_track_point_id = ANY" in sql
+    # Positional args: lon, lat, gt_ids
+    assert final_call[0][3] == [99, 100]
+
+
+@pytest.mark.asyncio
+async def test_find_nearby_address_both_sources_picks_nearest(mock_db: AsyncMock):
+    """Both sources hit → the smaller _dist wins and two lookups run."""
+    from app.routers.geocoding import _find_nearby_address
+
+    base: dict = {
+        "street": None,
+        "housenumber": None,
+        "neighbourhood": None,
+        "locality": None,
+        "region": None,
+        "country": None,
+        "postalcode": None,
+        "raw_response": {},
+    }
+    ow = {**base, "display_address": "OW", "confidence": 0.9, "_dist": 30.0}
+    gt = {**base, "display_address": "GT", "confidence": 0.8, "_dist": 5.0}
+    mock_db.fetch.side_effect = [[{"id": 1}], [{"id": 2}]]
+    mock_db.fetchrow.side_effect = [ow, gt]
+
+    result = await _find_nearby_address(mock_db, lat=40.0, lon=-74.0)
+
+    assert mock_db.fetchrow.call_count == 2
+    assert result is not None
+    assert result["display_address"] == "GT"  # nearer (smaller _dist)
+    assert "_dist" not in result
 
 
 @pytest.mark.asyncio
 async def test_find_nearby_address_does_not_use_coalesce_query(mock_db: AsyncMock):
-    """Guard against regression to the slow COALESCE Seq Scan plan."""
+    """Guard against regression to the slow COALESCE/OR Seq Scan plan."""
     from app.routers.geocoding import _find_nearby_address
 
     mock_db.fetch.side_effect = [[{"id": 1}], [{"id": 2}]]
@@ -1117,13 +1174,14 @@ async def test_find_nearby_address_does_not_use_coalesce_query(mock_db: AsyncMoc
         sql = call[0][0]
         assert "COALESCE" not in sql, "Candidate lookup must hit GIST indexes directly — no COALESCE allowed."
         assert "ST_DWithin(geog" in sql
-    final_sql = mock_db.fetchrow.call_args[0][0]
-    # Final lookup must filter via the indexed id columns, NOT via geog over the
-    # whole geocoded_addresses table. COALESCE/LEFT JOIN are now permitted in
-    # ORDER BY over the small candidate set, but the WHERE clause must use ANY.
-    assert "ga.location_id = ANY" in final_sql
-    assert "ga.garmin_track_point_id = ANY" in final_sql
-    assert "ST_DWithin" not in final_sql, "Final lookup must not re-filter by distance."
+    # Each per-source final lookup filters via its indexed id column with ANY,
+    # never via a COALESCE/OR across both columns (the old Seq Scan plan).
+    assert mock_db.fetchrow.call_count == 2
+    for call in mock_db.fetchrow.call_args_list:
+        final_sql = call[0][0]
+        assert "COALESCE" not in final_sql, "Final lookup must not seq-scan via COALESCE."
+        assert "ANY" in final_sql
+        assert "ST_DWithin" not in final_sql, "Final lookup must not re-filter by distance."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the **highest cumulative-cost slow query** identified from New Relic (APM datastore spans + `Slow SQL query` logs in the `Log_otel_operations` partition).

`_find_nearby_address` combined both data sources in a single OR-across-columns `LEFT JOIN` ordered by `ST_Distance(COALESCE(l.geog, gtp.geog), …)`. That predicate prevented the planner from using the partial unique indexes on `geocoded_addresses`, so it sequentially scanned all `status='success'` rows.

**New Relic (7d):** ~14,299 calls, avg ~1.8 s, p95 ~2 s, **max ~13 s, ~60 min total DB time** — the single biggest cumulative DB cost for `otel-data-api`.

## Change

Split the final lookup into **two per-source indexed queries**:
- owntracks → filter `source='owntracks' AND location_id = ANY($ids)` (uses the `location_id WHERE source='owntracks'` partial unique index), joined to `locations` by PK.
- garmin → filter `source='garmin' AND garmin_track_point_id = ANY($ids)` (uses the `garmin_track_point_id WHERE source='garmin'` partial unique index), joined to `garmin_track_points` by PK.

Each query orders its bounded candidate set by true `ST_Distance`; the nearer of the two is selected in Python. A source with no GiST candidates is skipped entirely (avoids `= ANY('{}')` scans). No schema change.

## Tests
- Updated `_find_nearby_address` unit tests for the two-query split (`_dist` ranking column, per-source call shape).
- Added `test_find_nearby_address_both_sources_picks_nearest`.
- Updated trigger tests (`dedup`, `db_timeout`, `unexpected_error`) for the new call count using concurrency-robust call-counter mocks.
- `pytest` full suite: **194 passed**; `pre-commit` (ruff, mypy, pyright, cspell): green.

## Follow-ups (separate work)
- #1 worst *per-call* query (avg ~5.2 s): `COUNT(*) garmin_track_points WHERE EXISTS(ROUND(lat*1e4), ROUND(lon*1e4))` on `/geocoding/status` — best fixed by adding a `point_count` to `mv_garmin_track_point_cells` (DB migration) or an expression index; needs EXPLAIN validation.
- Lighten the DB health check (`SELECT version(), NOW()` → `SELECT 1`) — 226k hits/7d.
- Investigate connection-reset churn / pool sizing vs PgBouncer.

Refs #165