### PR TITLE
perf(geocoding): derive /status coverage from MV point_count (~6x)

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -143,17 +143,20 @@ async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
     dense_geocoded = dense_success + dense_pending + dense_no_coverage + dense_errors
 
     # Read distinct-cell totals from the mv_garmin_track_point_cells materialized view
-    # (migration 18) — a direct COUNT(DISTINCT ...) over garmin_track_points takes ~18s on
-    # prod and exceeds the API's database command timeout.
+    # (migrations 18 + 21). A direct COUNT(DISTINCT ...) over garmin_track_points takes
+    # ~18s on prod, and the dense per-point coverage COUNT(*) ... WHERE EXISTS(ROUND ...)
+    # was a ~5.2s Parallel Seq Scan over ~4.5M rows. Both totals are now derived from the
+    # MV (which carries a per-cell point_count) by joining to geocoded_point_cells on the
+    # indexed (lat_4dp, lon_4dp) cell key (~0.9s). Counts are MV-snapshot-consistent;
+    # staleness of hours is acceptable (see migration 21).
     dense_total_cells = await db.fetchval("SELECT COUNT(*) FROM public.mv_garmin_track_point_cells")
-    total_track_points = await db.fetchval("SELECT COUNT(*) FROM public.garmin_track_points")
+    total_track_points = await db.fetchval(
+        "SELECT COALESCE(SUM(point_count), 0)::BIGINT FROM public.mv_garmin_track_point_cells"
+    )
     covered_track_points = await db.fetchval(
-        "SELECT COUNT(*) FROM public.garmin_track_points gtp "
-        "WHERE EXISTS ("
-        "  SELECT 1 FROM public.geocoded_point_cells gpc "
-        "  WHERE gpc.lat_4dp = ROUND(gtp.latitude * 10000)::INTEGER "
-        "    AND gpc.lon_4dp = ROUND(gtp.longitude * 10000)::INTEGER"
-        ")"
+        "SELECT COALESCE(SUM(m.point_count), 0)::BIGINT "
+        "FROM public.mv_garmin_track_point_cells m "
+        "JOIN public.geocoded_point_cells g USING (lat_4dp, lon_4dp)"
     )
     dense_point_coverage_percent = (
         round((covered_track_points / total_track_points * 100), 2) if total_track_points else 0.0

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -142,22 +142,25 @@ async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
     dense_errors = cell.get("error", 0)
     dense_geocoded = dense_success + dense_pending + dense_no_coverage + dense_errors
 
-    # Read distinct-cell totals from the mv_garmin_track_point_cells materialized view
-    # (migrations 18 + 21). A direct COUNT(DISTINCT ...) over garmin_track_points takes
-    # ~18s on prod, and the dense per-point coverage COUNT(*) ... WHERE EXISTS(ROUND ...)
-    # was a ~5.2s Parallel Seq Scan over ~4.5M rows. Both totals are now derived from the
-    # MV (which carries a per-cell point_count) by joining to geocoded_point_cells on the
-    # indexed (lat_4dp, lon_4dp) cell key (~0.9s). Counts are MV-snapshot-consistent;
-    # staleness of hours is acceptable (see migration 21).
-    dense_total_cells = await db.fetchval("SELECT COUNT(*) FROM public.mv_garmin_track_point_cells")
-    total_track_points = await db.fetchval(
-        "SELECT COALESCE(SUM(point_count), 0)::BIGINT FROM public.mv_garmin_track_point_cells"
-    )
-    covered_track_points = await db.fetchval(
-        "SELECT COALESCE(SUM(m.point_count), 0)::BIGINT "
+    # Derive all materialized-view metrics in a SINGLE query so dense_total_cells,
+    # total and covered come from one MV snapshot. The MV (migrations 18 + 21) is
+    # refreshed out-of-band, so computing these as separate statements could span a
+    # refresh and briefly skew the coverage percentage. The MV carries a per-cell
+    # point_count; a LEFT JOIN to geocoded_point_cells on the indexed (lat_4dp, lon_4dp)
+    # key yields covered points via FILTER — replacing the old ~5.2s COUNT(*) ...
+    # WHERE EXISTS(ROUND ...) Parallel Seq Scan over ~4.5M garmin_track_points rows
+    # (~0.9s now). Staleness of hours is acceptable (see migration 21).
+    mv_metrics = await db.fetchrow(
+        "SELECT COUNT(*)::BIGINT AS dense_total_cells, "
+        "COALESCE(SUM(m.point_count), 0)::BIGINT AS total_track_points, "
+        "COALESCE(SUM(m.point_count) FILTER (WHERE g.lat_4dp IS NOT NULL), 0)::BIGINT "
+        "AS covered_track_points "
         "FROM public.mv_garmin_track_point_cells m "
-        "JOIN public.geocoded_point_cells g USING (lat_4dp, lon_4dp)"
+        "LEFT JOIN public.geocoded_point_cells g USING (lat_4dp, lon_4dp)"
     )
+    dense_total_cells = mv_metrics["dense_total_cells"] if mv_metrics else 0
+    total_track_points = mv_metrics["total_track_points"] if mv_metrics else 0
+    covered_track_points = mv_metrics["covered_track_points"] if mv_metrics else 0
     dense_point_coverage_percent = (
         round((covered_track_points / total_track_points * 100), 2) if total_track_points else 0.0
     )

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -14,11 +14,11 @@ from app.config import Config
 
 @pytest.mark.asyncio
 async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
-    # geocoded_addresses and geocoded_point_cells status counts now come from
-    # two GROUP BY queries (db.fetch); the remaining six scalars come from
-    # db.fetchval in this order: total_locations, activities_total,
-    # activities_geocoded, dense_total_cells, total_track_points,
-    # covered_track_points.
+    # geocoded_addresses and geocoded_point_cells status counts come from two
+    # GROUP BY queries (db.fetch); three scalars come from db.fetchval in this
+    # order (total_locations, activities_total, activities_geocoded); and the
+    # MV-derived metrics (dense_total_cells, total_track_points,
+    # covered_track_points) come from a single db.fetchrow.
     addr_rows = [
         {"source": "owntracks", "status": "success", "n": 550},
         {"source": "owntracks", "status": "pending", "n": 30},
@@ -40,10 +40,12 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
         1000,  # total locations
         25,  # garmin activities total
         12,  # garmin activities geocoded
-        4500,  # dense_total_cells (mv)
-        50000,  # total_track_points
-        35000,  # covered_track_points
     ]
+    mock_db.fetchrow.return_value = {
+        "dense_total_cells": 4500,
+        "total_track_points": 50000,
+        "covered_track_points": 35000,
+    }
 
     response = await client.get("/api/v1/geocoding/status")
 
@@ -70,23 +72,29 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     assert body["dense_cells_errors"] == 20
     assert body["dense_cells_geocoded"] == 3170
     assert body["dense_point_coverage_percent"] == 70.0
-    # Guard against regressing dense_cells_total back to the slow
-    # COUNT(DISTINCT ...) over garmin_track_points (migration 18 MV).
-    fetchval_queries = [call.args[0] for call in mock_db.fetchval.await_args_list]
-    assert any("mv_garmin_track_point_cells" in sql for sql in fetchval_queries)
-    assert not any("COUNT(DISTINCT" in sql and "garmin_track_points" in sql for sql in fetchval_queries)
-    # Guard against regressing covered/total back to the ~5.2s seq scans:
-    # both are now derived from the MV point_count (migration 21), never via a
-    # COUNT(*) ... WHERE EXISTS(ROUND ...) over garmin_track_points.
-    assert not any("WHERE EXISTS" in sql and "ROUND(gtp" in sql for sql in fetchval_queries)
-    assert any("SUM(m.point_count)" in sql for sql in fetchval_queries)
+    # Guard against regressing the MV-derived metrics back to slow scans over
+    # garmin_track_points. The metrics now come from a single db.fetchrow.
+    mv_queries = [call.args[0] for call in mock_db.fetchrow.await_args_list]
+    all_queries = [c.args[0] for c in mock_db.fetchval.await_args_list] + mv_queries
+    assert any("mv_garmin_track_point_cells" in sql for sql in mv_queries)
+    assert any("SUM(m.point_count)" in sql for sql in mv_queries)
+    # Never via COUNT(DISTINCT ...) or COUNT(*) ... WHERE EXISTS(ROUND ...) over
+    # garmin_track_points (the old ~18s / ~5.2s seq scans).
+    assert not any("COUNT(DISTINCT" in sql and "garmin_track_points" in sql for sql in all_queries)
+    assert not any("WHERE EXISTS" in sql and "garmin_track_points" in sql for sql in all_queries)
 
 
 @pytest.mark.asyncio
 async def test_geocoding_status_empty_database(client: AsyncClient, mock_db: AsyncMock):
-    # Both GROUP BY queries return no rows; the six scalar counts are zero.
+    # Both GROUP BY queries return no rows; the three scalar counts and the MV
+    # metrics row are all zero.
     mock_db.fetch.side_effect = [[], []]
-    mock_db.fetchval.side_effect = [0] * 6
+    mock_db.fetchval.side_effect = [0] * 3
+    mock_db.fetchrow.return_value = {
+        "dense_total_cells": 0,
+        "total_track_points": 0,
+        "covered_track_points": 0,
+    }
 
     response = await client.get("/api/v1/geocoding/status")
 
@@ -111,7 +119,12 @@ async def test_geocoding_status_cached_within_ttl(client: AsyncClient, mock_db: 
     # Only enough side-effects for ONE computation — if caching is bypassed the
     # second request exhausts these and raises StopAsyncIteration.
     mock_db.fetch.side_effect = [addr_rows, cell_rows]
-    mock_db.fetchval.side_effect = [1000, 10, 5, 300, 50000, 35000]
+    mock_db.fetchval.side_effect = [1000, 10, 5]
+    mock_db.fetchrow.return_value = {
+        "dense_total_cells": 300,
+        "total_track_points": 50000,
+        "covered_track_points": 35000,
+    }
 
     first = await client.get("/api/v1/geocoding/status")
     second = await client.get("/api/v1/geocoding/status")
@@ -119,9 +132,10 @@ async def test_geocoding_status_cached_within_ttl(client: AsyncClient, mock_db: 
     assert first.status_code == 200
     assert second.status_code == 200
     assert first.json() == second.json()
-    # Underlying queries ran exactly once: 2 GROUP BY fetches + 6 scalars.
+    # Underlying queries ran exactly once: 2 GROUP BY fetches + 3 scalars + 1 MV row.
     assert mock_db.fetch.await_count == 2
-    assert mock_db.fetchval.await_count == 6
+    assert mock_db.fetchval.await_count == 3
+    assert mock_db.fetchrow.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -130,7 +144,11 @@ async def test_geocoding_status_cache_expires(client: AsyncClient, mock_db: Asyn
     addr_rows = [{"source": "owntracks", "status": "success", "n": 100}]
     cell_rows = [{"status": "success", "n": 200}]
     mock_db.fetch.side_effect = [addr_rows, cell_rows, addr_rows, cell_rows]
-    mock_db.fetchval.side_effect = [1000, 10, 5, 300, 50000, 35000] * 2
+    mock_db.fetchval.side_effect = [1000, 10, 5] * 2
+    mock_db.fetchrow.side_effect = [
+        {"dense_total_cells": 300, "total_track_points": 50000, "covered_track_points": 35000},
+        {"dense_total_cells": 300, "total_track_points": 50000, "covered_track_points": 35000},
+    ]
 
     now = [0.0]
     with patch("app.routers.geocoding.time.monotonic", side_effect=lambda: now[0]):
@@ -141,7 +159,8 @@ async def test_geocoding_status_cache_expires(client: AsyncClient, mock_db: Asyn
 
     # Cache was stale, so the queries ran a second time.
     assert mock_db.fetch.await_count == 4
-    assert mock_db.fetchval.await_count == 12
+    assert mock_db.fetchval.await_count == 6
+    assert mock_db.fetchrow.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -75,6 +75,11 @@ async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     fetchval_queries = [call.args[0] for call in mock_db.fetchval.await_args_list]
     assert any("mv_garmin_track_point_cells" in sql for sql in fetchval_queries)
     assert not any("COUNT(DISTINCT" in sql and "garmin_track_points" in sql for sql in fetchval_queries)
+    # Guard against regressing covered/total back to the ~5.2s seq scans:
+    # both are now derived from the MV point_count (migration 21), never via a
+    # COUNT(*) ... WHERE EXISTS(ROUND ...) over garmin_track_points.
+    assert not any("WHERE EXISTS" in sql and "ROUND(gtp" in sql for sql in fetchval_queries)
+    assert any("SUM(m.point_count)" in sql for sql in fetchval_queries)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Second highest-impact slow query from the New Relic review, now **diagnosed with EXPLAIN ANALYZE** against prod-sized data.

`/api/v1/geocoding/status` computed dense per-point coverage with:
```sql
SELECT COUNT(*) FROM garmin_track_points gtp
WHERE EXISTS (SELECT 1 FROM geocoded_point_cells gpc
  WHERE gpc.lat_4dp = ROUND(gtp.latitude*10000)::int
    AND gpc.lon_4dp = ROUND(gtp.longitude*10000)::int);
```
**EXPLAIN:** Parallel Seq Scan over ~4.5 M `garmin_track_points` → **5,251 ms** (NR max ~13.8 s, occasionally tripping the 15 s statement timeout → HTTP 500).

## Change

Derive **both** `total` and `covered` track points from `mv_garmin_track_point_cells` (now carrying a per-cell `point_count`) by joining to `geocoded_point_cells` on the indexed `(lat_4dp, lon_4dp)` cell key:
```sql
-- covered
SELECT COALESCE(SUM(m.point_count),0)::bigint
FROM mv_garmin_track_point_cells m JOIN geocoded_point_cells g USING (lat_4dp, lon_4dp);
-- total
SELECT COALESCE(SUM(point_count),0)::bigint FROM mv_garmin_track_point_cells;
```
**Validated ~900 ms (~6×)**, eliminates the timeout tail, and adds **zero overhead on the hot `garmin_track_points` insert path** (vs an expression index). Coverage % is now computed from a single MV snapshot, so it's internally consistent; hours of staleness is acceptable (same trade-off the MV already made for `dense_cells_total`).

## ⚠️ Deployment ordering

Depends on **homelab-database-migrations#46** (adds `point_count` to the MV). **Apply that migration first** — this code reads `point_count`. The `/status` response is cached 60 s.

## Tests
- Existing status tests pass (fetchval ordering preserved); added guards that covered/total no longer use `WHERE EXISTS(ROUND …)` and do use `SUM(m.point_count)`.
- Full suite: **194 passed**; pre-commit (ruff/mypy/pyright/cspell): green.

## Diagnostics (EXPLAIN, prod-sized)
- locations KNN candidate probe: **8.5 ms** in isolation (the NR 1.5 s is backfill-burst contention, not the query — tracked separately).
- COUNT EXISTS ROUND: 5,251 ms → MV join 881 ms.

Refs #165