### PR TITLE
feat(garmin): expose device metadata on activity endpoints

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import date as date_type
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field
 
 from app.models.geocoding import GeocodedAddressSummary
+
+
+class GarminDevice(BaseModel):
+    """Recording device metadata for a Garmin activity."""
+
+    device_id: int | None = Field(default=None, description="Recording device serial number")
+    manufacturer: str | None = Field(default=None, description="Device manufacturer (e.g. garmin)")
+    garmin_product: int | None = Field(
+        default=None, description="Raw Garmin product enum id from the FIT file (e.g. 4061)"
+    )
+    model: str | None = Field(default=None, description="Friendly device model name (e.g. Edge 540 Solar)")
+    software_version: str | None = Field(default=None, description="Device firmware/software version (e.g. 31.30)")
 
 
 class GarminActivity(BaseModel):
@@ -60,6 +74,31 @@ class GarminActivity(BaseModel):
     created_at: datetime | None = Field(default=None, description="UTC timestamp when the record was inserted")
     uploaded_at: datetime | None = Field(default=None, description="UTC timestamp when the FIT file was uploaded")
     track_point_count: int | None = Field(default=None, description="Number of GPS track points in this activity")
+    device: GarminDevice | None = Field(default=None, description="Recording device metadata")
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> GarminActivity:
+        """Build an activity from a DB row, folding joined device columns into ``device``.
+
+        Device columns are selected with a ``dev_`` prefix (plus ``device_id``)
+        so they do not collide with the activity's own ``device_manufacturer``.
+        """
+        data = dict(row)
+        device_id = data.pop("device_id", None)
+        dev_manufacturer = data.pop("dev_manufacturer", None)
+        dev_garmin_product = data.pop("dev_garmin_product", None)
+        dev_model = data.pop("dev_model", None)
+        dev_software_version = data.pop("dev_software_version", None)
+        device = None
+        if device_id is not None:
+            device = GarminDevice(
+                device_id=device_id,
+                manufacturer=dev_manufacturer,
+                garmin_product=dev_garmin_product,
+                model=dev_model,
+                software_version=dev_software_version,
+            )
+        return cls(**data, device=device)
 
     model_config = {
         "json_schema_extra": {
@@ -107,6 +146,13 @@ class GarminActivity(BaseModel):
                     "created_at": "2026-02-09T23:56:37+00:00",
                     "uploaded_at": "2026-02-09T23:56:37+00:00",
                     "track_point_count": 10707,
+                    "device": {
+                        "device_id": 3444454776,
+                        "manufacturer": "garmin",
+                        "garmin_product": 4061,
+                        "model": "Edge 540 Solar",
+                        "software_version": "31.30",
+                    },
                 }
             ]
         }

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -49,9 +49,14 @@ ACTIVITY_BY_ID_SELECT = (
     "a.total_descent_m, a.total_distance, a.avg_pace, a.device_manufacturer, "
     "a.avg_temperature_c, a.min_temperature_c, a.max_temperature_c, "
     "a.total_elapsed_time, a.total_timer_time, a.created_at, a.uploaded_at, "
+    "a.device_id, d.manufacturer AS dev_manufacturer, "
+    "d.garmin_product AS dev_garmin_product, d.model AS dev_model, "
+    "d.software_version AS dev_software_version, "
     "(SELECT COUNT(*) FROM public.garmin_track_points t "
     "WHERE t.activity_id = a.activity_id) AS track_point_count "
-    "FROM public.garmin_activities a WHERE a.activity_id = $1"
+    "FROM public.garmin_activities a "
+    "LEFT JOIN public.garmin_devices d ON d.device_id = a.device_id "
+    "WHERE a.activity_id = $1"
 )
 
 
@@ -253,16 +258,20 @@ async def list_activities(
         f"a.device_manufacturer, a.avg_temperature_c, a.min_temperature_c, "
         f"a.max_temperature_c, a.total_elapsed_time, a.total_timer_time, "
         f"a.created_at, a.uploaded_at, "
+        f"a.device_id, d.manufacturer AS dev_manufacturer, "
+        f"d.garmin_product AS dev_garmin_product, d.model AS dev_model, "
+        f"d.software_version AS dev_software_version, "
         f"(SELECT COUNT(*) FROM public.garmin_track_points t "
         f"WHERE t.activity_id = a.activity_id) AS track_point_count "
-        f"FROM public.garmin_activities a {where} "
+        f"FROM public.garmin_activities a "
+        f"LEFT JOIN public.garmin_devices d ON d.device_id = a.device_id {where} "
         f"ORDER BY a.{sort} {order} "
         f"LIMIT ${idx} OFFSET ${idx + 1}"
     )
     params.extend([limit, offset])
     rows = await db.fetch(data_query, *params)
 
-    items = [GarminActivity(**dict(row)) for row in rows]
+    items = [GarminActivity.from_row(row) for row in rows]
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
@@ -351,7 +360,7 @@ async def get_activity(
     row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
     if not row:
         raise HTTPException(status_code=404, detail="Activity not found")
-    activity = GarminActivity(**dict(row))
+    activity = GarminActivity.from_row(row)
     if request.app.state.config.log_garmin_activity_detail:
         logger.info(
             "garmin.activity.detail",
@@ -402,7 +411,7 @@ async def patch_activity(
     row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
     if not row:
         raise HTTPException(status_code=404, detail="Activity not found")
-    return GarminActivity(**dict(row))
+    return GarminActivity.from_row(row)
 
 
 @router.get(

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3015,6 +3015,17 @@
             ],
             "title": "Track Point Count",
             "description": "Number of GPS track points in this activity"
+          },
+          "device": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GarminDevice"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Recording device metadata"
           }
         },
         "type": "object",
@@ -3037,6 +3048,13 @@
             "avg_temperature_c": 18,
             "calories": 1689,
             "created_at": "2026-02-09T23:56:37+00:00",
+            "device": {
+              "device_id": 3444454776,
+              "garmin_product": 4061,
+              "manufacturer": "garmin",
+              "model": "Edge 540 Solar",
+              "software_version": "31.30"
+            },
             "device_manufacturer": "garmin",
             "distance_km": 50.6,
             "duration_seconds": 6932,
@@ -3998,6 +4016,73 @@
             "min_date": "2025-11-08T18:21:13+00:00"
           }
         ]
+      },
+      "GarminDevice": {
+        "properties": {
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id",
+            "description": "Recording device serial number"
+          },
+          "manufacturer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manufacturer",
+            "description": "Device manufacturer (e.g. garmin)"
+          },
+          "garmin_product": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Garmin Product",
+            "description": "Raw Garmin product enum id from the FIT file (e.g. 4061)"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "Friendly device model name (e.g. Edge 540 Solar)"
+          },
+          "software_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Software Version",
+            "description": "Device firmware/software version (e.g. 31.30)"
+          }
+        },
+        "type": "object",
+        "title": "GarminDevice",
+        "description": "Recording device metadata for a Garmin activity."
       },
       "GarminSyncResponse": {
         "properties": {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -825,6 +825,13 @@ export type components = {
          *       "avg_temperature_c": 18,
          *       "calories": 1689,
          *       "created_at": "2026-02-09T23:56:37+00:00",
+         *       "device": {
+         *         "device_id": 3444454776,
+         *         "garmin_product": 4061,
+         *         "manufacturer": "garmin",
+         *         "model": "Edge 540 Solar",
+         *         "software_version": "31.30"
+         *       },
          *       "device_manufacturer": "garmin",
          *       "distance_km": 50.6,
          *       "duration_seconds": 6932,
@@ -1070,6 +1077,8 @@ export type components = {
              * @description Number of GPS track points in this activity
              */
             track_point_count?: number | null;
+            /** @description Recording device metadata */
+            device?: components["schemas"]["GarminDevice"] | null;
         };
         /**
          * GarminActivityAddress
@@ -1520,6 +1529,37 @@ export type components = {
              * @description Timestamp of the latest Garmin activity
              */
             max_date: string;
+        };
+        /**
+         * GarminDevice
+         * @description Recording device metadata for a Garmin activity.
+         */
+        GarminDevice: {
+            /**
+             * Device Id
+             * @description Recording device serial number
+             */
+            device_id?: number | null;
+            /**
+             * Manufacturer
+             * @description Device manufacturer (e.g. garmin)
+             */
+            manufacturer?: string | null;
+            /**
+             * Garmin Product
+             * @description Raw Garmin product enum id from the FIT file (e.g. 4061)
+             */
+            garmin_product?: number | null;
+            /**
+             * Model
+             * @description Friendly device model name (e.g. Edge 540 Solar)
+             */
+            model?: string | null;
+            /**
+             * Software Version
+             * @description Device firmware/software version (e.g. 31.30)
+             */
+            software_version?: string | null;
         };
         /**
          * GarminSyncResponse

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -252,6 +252,8 @@ async def test_get_activity_includes_device(client: AsyncClient, mock_db):
 @pytest.mark.asyncio
 async def test_get_activity_without_device(client: AsyncClient, mock_db):
     row = _activity_row()
+    # The SELECT always projects the joined device columns; when no device is
+    # linked they come back as explicit NULLs (not missing keys).
     for key in (
         "device_id",
         "dev_manufacturer",
@@ -259,7 +261,7 @@ async def test_get_activity_without_device(client: AsyncClient, mock_db):
         "dev_model",
         "dev_software_version",
     ):
-        row.pop(key)
+        row[key] = None
     mock_db.fetchrow.return_value = row
 
     response = await client.get("/api/v1/garmin/activities/20932993811")

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -45,6 +45,11 @@ def _activity_row(activity_id: str = "20932993811") -> dict:
         "created_at": "2026-02-09T23:56:37+00:00",
         "uploaded_at": "2026-02-09T23:56:37+00:00",
         "track_point_count": 10707,
+        "device_id": 3444454776,
+        "dev_manufacturer": "garmin",
+        "dev_garmin_product": 4061,
+        "dev_model": "Edge 540 Solar",
+        "dev_software_version": "31.30",
     }
 
 
@@ -225,6 +230,42 @@ async def test_get_activity_success(client: AsyncClient, mock_db):
     assert data["sport"] == "cycling"
     assert data["hr_available"] is True
     assert data["total_strokes"] == 4250
+
+
+@pytest.mark.asyncio
+async def test_get_activity_includes_device(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = _activity_row()
+
+    response = await client.get("/api/v1/garmin/activities/20932993811")
+
+    assert response.status_code == 200
+    device = response.json()["device"]
+    assert device == {
+        "device_id": 3444454776,
+        "manufacturer": "garmin",
+        "garmin_product": 4061,
+        "model": "Edge 540 Solar",
+        "software_version": "31.30",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_activity_without_device(client: AsyncClient, mock_db):
+    row = _activity_row()
+    for key in (
+        "device_id",
+        "dev_manufacturer",
+        "dev_garmin_product",
+        "dev_model",
+        "dev_software_version",
+    ):
+        row.pop(key)
+    mock_db.fetchrow.return_value = row
+
+    response = await client.get("/api/v1/garmin/activities/20932993811")
+
+    assert response.status_code == 200
+    assert response.json()["device"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Phase 3 of the Garmin device-metadata feature. Surfaces the device that recorded each Garmin activity on the REST API.

## Changes

- `app/routers/garmin.py`: `ACTIVITY_BY_ID_SELECT` and the list `data_query` now `LEFT JOIN public.garmin_devices` and select `device_id` plus prefixed device columns (`dev_manufacturer`, `dev_garmin_product`, `dev_model`, `dev_software_version`). All three call sites (list/get/patch) map rows via `GarminActivity.from_row`.
- `app/models/garmin.py`: new `GarminDevice` model and nested `device: GarminDevice | None` field on `GarminActivity`; `from_row` classmethod builds the nested device from the prefixed columns (device is `null` when the activity has no linked device).
- `tests/test_garmin.py`: device columns added to the shared row fixture; new tests assert the nested device object is present and that it is `null` when no device is linked.
- Regenerated `docs/openapi.json` and `packages/otel-data-types/index.d.ts` (adds `GarminDevice` schema + `device` field).

## Validation

- `pre-commit run -a` ✅
- `make test` ✅ (196 passed, coverage gate met)

## Context

Builds on the deployed `garmin_devices` table (db-migrations #50) and garmin-sync v1.2.126 backfill. Downstream: publishing `@stuartshay/otel-data-types` will trigger the gateway dependency PR (phase 4).