### PR TITLE
Add Garmin activity laps API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,6 @@ repos:
     hooks:
       - id: cspell
         name: Spell check
-        args: [--no-progress, --no-summary, --gitignore]
         additional_dependencies:
           - '@cspell/dict-python'
           - '@cspell/dict-bash'

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ flowchart LR
 | GET | `/api/v1/garmin/sports` | List sport types |
 | GET | `/api/v1/garmin/activities/{id}` | Activity detail |
 | GET | `/api/v1/garmin/activities/{id}/tracks` | Track points |
+| GET | `/api/v1/garmin/activities/{id}/laps` | Activity laps |
 | POST | `/api/v1/garmin/sync` | Trigger on-demand Garmin sync |
 | GET | `/api/v1/gps/unified` | Unified GPS points (view) |
 | GET | `/api/v1/gps/daily-summary` | Daily activity summary |
@@ -182,6 +183,7 @@ The API reads from these tables managed by
 - `public.locations` — OwnTracks GPS data
 - `public.garmin_activities` — Garmin Connect activities
 - `public.garmin_track_points` — Garmin GPS track points
+- `public.garmin_activity_laps` — Garmin-native and derived activity laps
 - `public.reference_locations` — Named reference locations
 - `unified_gps_points` (view) — Combined GPS data
 - `daily_activity_summary` (view) — Aggregated daily stats

--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -302,6 +302,30 @@ class GarminActivityClimb(BaseModel):
     updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
 
 
+class GarminActivityLap(BaseModel):
+    """Garmin-native or derived activity lap row."""
+
+    id: int = Field(description="Unique lap row identifier")
+    activity_id: str = Field(description="Parent Garmin activity identifier")
+    lap_index: int = Field(description="One-based lap order within the activity")
+    start_time: datetime | None = Field(default=None, description="UTC lap start time")
+    end_time: datetime | None = Field(default=None, description="UTC lap end time")
+    duration_seconds: float | None = Field(default=None, description="Lap timer duration in seconds")
+    elapsed_duration_seconds: float | None = Field(default=None, description="Lap elapsed duration in seconds")
+    moving_duration_seconds: float | None = Field(default=None, description="Lap moving duration in seconds")
+    distance_meters: float | None = Field(default=None, description="Lap distance in meters")
+    paved_distance_meters: float | None = Field(default=None, description="Lap paved distance in meters")
+    unpaved_distance_meters: float | None = Field(default=None, description="Lap unpaved distance in meters")
+    avg_speed_mps: float | None = Field(default=None, description="Average lap speed in meters per second")
+    avg_heart_rate: int | None = Field(default=None, description="Average lap heart rate in bpm")
+    max_heart_rate: int | None = Field(default=None, description="Maximum lap heart rate in bpm")
+    total_ascent_meters: float | None = Field(default=None, description="Lap elevation gain in meters")
+    total_descent_meters: float | None = Field(default=None, description="Lap elevation loss in meters")
+    calories: float | None = Field(default=None, description="Calories recorded for this lap")
+    created_at: datetime | None = Field(default=None, description="UTC timestamp when the row was inserted")
+    updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
+
+
 class SportInfo(BaseModel):
     """Sport type with its activity count."""
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -18,6 +18,7 @@ from app.models import PaginatedResponse
 from app.models.garmin import (
     GarminActivity,
     GarminActivityClimb,
+    GarminActivityLap,
     GarminActivityManualUpdate,
     GarminActivityTotal,
     GarminChartPoint,
@@ -625,6 +626,36 @@ async def list_activity_climbs(
     )
 
     return [GarminActivityClimb(**dict(row)) for row in rows]
+
+
+@router.get(
+    "/activities/{activity_id}/laps",
+    response_model=list[GarminActivityLap],
+    responses={404: {"description": "Activity not found"}},
+)
+async def list_activity_laps(
+    request: Request,
+    activity_id: str = fastapi.Path(description="Garmin activity ID", examples=["20932993811"]),
+) -> list[GarminActivityLap]:
+    """Return Garmin-native or derived laps for an activity."""
+    db = request.app.state.db
+
+    exists = await db.fetchval("SELECT 1 FROM public.garmin_activities WHERE activity_id = $1", activity_id)
+    if not exists:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    rows = await db.fetch(
+        "SELECT id, activity_id, lap_index, start_time, end_time, "
+        "duration_seconds, elapsed_duration_seconds, moving_duration_seconds, "
+        "distance_meters, paved_distance_meters, unpaved_distance_meters, "
+        "avg_speed_mps, avg_heart_rate, max_heart_rate, total_ascent_meters, "
+        "total_descent_meters, calories, created_at, updated_at "
+        "FROM public.garmin_activity_laps WHERE activity_id = $1 "
+        "ORDER BY lap_index ASC",
+        activity_id,
+    )
+
+    return [GarminActivityLap(**dict(row)) for row in rows]
 
 
 def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1237,6 +1237,61 @@
         }
       }
     },
+    "/api/v1/garmin/activities/{activity_id}/laps": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "List Activity Laps",
+        "description": "Return Garmin-native or derived laps for an activity.",
+        "operationId": "list_activity_laps_api_v1_garmin_activities__activity_id__laps_get",
+        "parameters": [
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Garmin activity ID",
+              "examples": [
+                "20932993811"
+              ],
+              "title": "Activity Id"
+            },
+            "description": "Garmin activity ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GarminActivityLap"
+                  },
+                  "title": "Response List Activity Laps Api V1 Garmin Activities  Activity Id  Laps Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Activity not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/garmin/activities/{activity_id}/addresses": {
       "get": {
         "tags": [
@@ -3763,6 +3818,229 @@
         ],
         "title": "GarminActivityClimb",
         "description": "Garmin-native ClimbPro typed split for an activity."
+      },
+      "GarminActivityLap": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "Unique lap row identifier"
+          },
+          "activity_id": {
+            "type": "string",
+            "title": "Activity Id",
+            "description": "Parent Garmin activity identifier"
+          },
+          "lap_index": {
+            "type": "integer",
+            "title": "Lap Index",
+            "description": "One-based lap order within the activity"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time",
+            "description": "UTC lap start time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time",
+            "description": "UTC lap end time"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds",
+            "description": "Lap timer duration in seconds"
+          },
+          "elapsed_duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Elapsed Duration Seconds",
+            "description": "Lap elapsed duration in seconds"
+          },
+          "moving_duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Moving Duration Seconds",
+            "description": "Lap moving duration in seconds"
+          },
+          "distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Meters",
+            "description": "Lap distance in meters"
+          },
+          "paved_distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paved Distance Meters",
+            "description": "Lap paved distance in meters"
+          },
+          "unpaved_distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unpaved Distance Meters",
+            "description": "Lap unpaved distance in meters"
+          },
+          "avg_speed_mps": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Speed Mps",
+            "description": "Average lap speed in meters per second"
+          },
+          "avg_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Heart Rate",
+            "description": "Average lap heart rate in bpm"
+          },
+          "max_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Heart Rate",
+            "description": "Maximum lap heart rate in bpm"
+          },
+          "total_ascent_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Ascent Meters",
+            "description": "Lap elevation gain in meters"
+          },
+          "total_descent_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Descent Meters",
+            "description": "Lap elevation loss in meters"
+          },
+          "calories": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Calories",
+            "description": "Calories recorded for this lap"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "UTC timestamp when the row was inserted"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "UTC timestamp when the row was last updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "activity_id",
+          "lap_index"
+        ],
+        "title": "GarminActivityLap",
+        "description": "Garmin-native or derived activity lap row."
       },
       "GarminActivityManualUpdate": {
         "properties": {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -369,6 +369,26 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/garmin/activities/{activity_id}/laps": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Activity Laps
+         * @description Return Garmin-native or derived laps for an activity.
+         */
+        get: operations["list_activity_laps_api_v1_garmin_activities__activity_id__laps_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/garmin/activities/{activity_id}/addresses": {
         parameters: {
             query?: never;
@@ -1386,6 +1406,107 @@ export type components = {
              * @description Maximum temperature in degrees C
              */
             max_temperature_c?: number | null;
+            /**
+             * Created At
+             * @description UTC timestamp when the row was inserted
+             */
+            created_at?: string | null;
+            /**
+             * Updated At
+             * @description UTC timestamp when the row was last updated
+             */
+            updated_at?: string | null;
+        };
+        /**
+         * GarminActivityLap
+         * @description Garmin-native or derived activity lap row.
+         */
+        GarminActivityLap: {
+            /**
+             * Id
+             * @description Unique lap row identifier
+             */
+            id: number;
+            /**
+             * Activity Id
+             * @description Parent Garmin activity identifier
+             */
+            activity_id: string;
+            /**
+             * Lap Index
+             * @description One-based lap order within the activity
+             */
+            lap_index: number;
+            /**
+             * Start Time
+             * @description UTC lap start time
+             */
+            start_time?: string | null;
+            /**
+             * End Time
+             * @description UTC lap end time
+             */
+            end_time?: string | null;
+            /**
+             * Duration Seconds
+             * @description Lap timer duration in seconds
+             */
+            duration_seconds?: number | null;
+            /**
+             * Elapsed Duration Seconds
+             * @description Lap elapsed duration in seconds
+             */
+            elapsed_duration_seconds?: number | null;
+            /**
+             * Moving Duration Seconds
+             * @description Lap moving duration in seconds
+             */
+            moving_duration_seconds?: number | null;
+            /**
+             * Distance Meters
+             * @description Lap distance in meters
+             */
+            distance_meters?: number | null;
+            /**
+             * Paved Distance Meters
+             * @description Lap paved distance in meters
+             */
+            paved_distance_meters?: number | null;
+            /**
+             * Unpaved Distance Meters
+             * @description Lap unpaved distance in meters
+             */
+            unpaved_distance_meters?: number | null;
+            /**
+             * Avg Speed Mps
+             * @description Average lap speed in meters per second
+             */
+            avg_speed_mps?: number | null;
+            /**
+             * Avg Heart Rate
+             * @description Average lap heart rate in bpm
+             */
+            avg_heart_rate?: number | null;
+            /**
+             * Max Heart Rate
+             * @description Maximum lap heart rate in bpm
+             */
+            max_heart_rate?: number | null;
+            /**
+             * Total Ascent Meters
+             * @description Lap elevation gain in meters
+             */
+            total_ascent_meters?: number | null;
+            /**
+             * Total Descent Meters
+             * @description Lap elevation loss in meters
+             */
+            total_descent_meters?: number | null;
+            /**
+             * Calories
+             * @description Calories recorded for this lap
+             */
+            calories?: number | null;
             /**
              * Created At
              * @description UTC timestamp when the row was inserted
@@ -3651,6 +3772,45 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GarminActivityClimb"][];
+                };
+            };
+            /** @description Activity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_activity_laps_api_v1_garmin_activities__activity_id__laps_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Garmin activity ID */
+                activity_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GarminActivityLap"][];
                 };
             };
             /** @description Activity not found */

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -114,6 +114,30 @@ def _climb_row(activity_id: str = "20932993811") -> dict:
     }
 
 
+def _lap_row(activity_id: str = "20932993811", lap_index: int = 1) -> dict:
+    return {
+        "id": lap_index,
+        "activity_id": activity_id,
+        "lap_index": lap_index,
+        "start_time": "2026-03-08T19:58:56+00:00",
+        "end_time": "2026-03-08T20:26:13+00:00",
+        "duration_seconds": 1637.0,
+        "elapsed_duration_seconds": 1637.0,
+        "moving_duration_seconds": 1600.0,
+        "distance_meters": 8046.72,
+        "paved_distance_meters": 7805.32,
+        "unpaved_distance_meters": 241.4,
+        "avg_speed_mps": 4.92,
+        "avg_heart_rate": 130,
+        "max_heart_rate": 150,
+        "total_ascent_meters": 98.0,
+        "total_descent_meters": 88.0,
+        "calories": 210.0,
+        "created_at": "2026-07-03T03:00:00+00:00",
+        "updated_at": "2026-07-03T03:00:00+00:00",
+    }
+
+
 @pytest.mark.asyncio
 async def test_list_activities_empty(client: AsyncClient, mock_db):
     mock_db.fetch.return_value = []
@@ -629,6 +653,49 @@ async def test_list_activity_climbs_not_found(client: AsyncClient, mock_db):
     mock_db.fetchval.return_value = None
 
     response = await client.get("/api/v1/garmin/activities/nonexistent/climbs")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+@pytest.mark.asyncio
+async def test_list_activity_laps_success(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = [_lap_row(lap_index=1), _lap_row(lap_index=2)]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/laps")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["activity_id"] == "20932993811"
+    assert data[0]["lap_index"] == 1
+    assert data[0]["distance_meters"] == 8046.72
+    assert data[0]["avg_heart_rate"] == 130
+    assert data[0]["max_heart_rate"] == 150
+    assert data[0]["total_ascent_meters"] == 98.0
+
+    query = mock_db.fetch.await_args.args[0]
+    assert "public.garmin_activity_laps" in query
+    assert "ORDER BY lap_index ASC" in query
+
+
+@pytest.mark.asyncio
+async def test_list_activity_laps_empty_for_existing_activity(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = []
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/laps")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_activity_laps_not_found(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = None
+
+    response = await client.get("/api/v1/garmin/activities/nonexistent/laps")
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Activity not found"}


### PR DESCRIPTION
## Summary
- Add `GarminActivityLap` response model for Garmin-native or derived lap rows.
- Add `GET /api/v1/garmin/activities/{activity_id}/laps`, ordered by `lap_index ASC`.
- Return `404` only when the parent activity is missing and `[]` for existing activities without lap rows.
- Regenerate `docs/openapi.json` and `packages/otel-data-types/index.d.ts`.
- Fix the cspell pre-commit hook args for `cspell-cli` v10 commit-mode compatibility.

## Validation
- `PATH=/home/ubuntu/git/otel-data-api/venv/bin:$PATH pytest tests/test_garmin.py -q`
- `PATH=/home/ubuntu/git/otel-data-api/venv/bin:$PATH pytest --cov=app --cov-report=term-missing`
- `PATH=/home/ubuntu/git/otel-data-api/venv/bin:$PATH pre-commit run -a`

## Follow-up
- After merge/release, verify `@stuartshay/otel-data-types` publish and the downstream otel-data-gateway dependency update PR.
