### PR TITLE
Add batch laps endpoint GET /garmin/laps for cross-activity comparison

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -326,6 +326,28 @@ class GarminActivityLap(BaseModel):
     updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
 
 
+class GarminLapsActivity(BaseModel):
+    """Activity summary metadata for a batch laps response item."""
+
+    activity_id: str = Field(description="Garmin activity identifier")
+    sport: str | None = Field(default=None, description="Sport type (e.g. cycling)")
+    sub_sport: str | None = Field(default=None, description="Sub-sport type (e.g. road)")
+    start_time: datetime | None = Field(default=None, description="UTC activity start time")
+    distance_km: float | None = Field(default=None, description="Total activity distance in kilometers")
+    duration_seconds: float | None = Field(default=None, description="Total activity duration in seconds")
+    avg_speed_kmh: float | None = Field(default=None, description="Average activity speed in km/h")
+    avg_heart_rate: int | None = Field(default=None, description="Average activity heart rate in bpm")
+    max_heart_rate: int | None = Field(default=None, description="Maximum activity heart rate in bpm")
+    total_ascent_m: float | None = Field(default=None, description="Total activity elevation gain in meters")
+
+
+class GarminActivityLapsGroup(BaseModel):
+    """Laps for a single activity within the batch laps response."""
+
+    activity: GarminLapsActivity = Field(description="Parent activity summary")
+    laps: list[GarminActivityLap] = Field(description="Laps ordered by lap_index ascending")
+
+
 class SportInfo(BaseModel):
     """Sport type with its activity count."""
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -19,11 +19,13 @@ from app.models.garmin import (
     GarminActivity,
     GarminActivityClimb,
     GarminActivityLap,
+    GarminActivityLapsGroup,
     GarminActivityManualUpdate,
     GarminActivityTotal,
     GarminChartPoint,
     GarminDateRange,
     GarminDeviceCount,
+    GarminLapsActivity,
     GarminSyncResponse,
     GarminTrackPoint,
     SportInfo,
@@ -656,6 +658,82 @@ async def list_activity_laps(
     )
 
     return [GarminActivityLap(**dict(row)) for row in rows]
+
+
+@router.get("/laps", response_model=PaginatedResponse[GarminActivityLapsGroup])
+async def list_laps(
+    request: Request,
+    sport: str | None = Query(None, description="Filter by sport type", examples=["cycling"]),
+    date_from: str | None = Query(None, description="Filter from date (YYYY-MM-DD)", examples=["2026-01-01"]),
+    date_to: str | None = Query(None, description="Filter to date (YYYY-MM-DD)", examples=["2026-06-30"]),
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of activities to return per page"),
+    offset: int = Query(0, ge=0, description="Number of activities to skip for pagination"),
+) -> PaginatedResponse[GarminActivityLapsGroup]:
+    """Batch laps across activities for cross-activity comparison.
+
+    Returns activities (newest first) that have at least one lap, each with
+    its laps ordered by ``lap_index`` ascending, so lap N can be compared
+    across dates. Pagination applies to activities, not individual laps.
+    """
+    db = request.app.state.db
+
+    conditions: list[str] = ["EXISTS (SELECT 1 FROM public.garmin_activity_laps l WHERE l.activity_id = a.activity_id)"]
+    params: list = []
+    idx = 1
+
+    if sport:
+        conditions.append(f"a.sport = ${idx}")
+        params.append(sport)
+        idx += 1
+
+    if date_from:
+        conditions.append(f"a.start_time >= ${idx}::date")
+        params.append(_parse_date(date_from))
+        idx += 1
+
+    if date_to:
+        conditions.append(f"a.start_time < (${idx}::date + INTERVAL '1 day')")
+        params.append(_parse_date(date_to))
+        idx += 1
+
+    where = f"WHERE {' AND '.join(conditions)}"
+
+    total = await db.fetchval(f"SELECT COUNT(*) FROM public.garmin_activities a {where}", *params)
+
+    activity_rows = await db.fetch(
+        f"SELECT a.activity_id, a.sport, a.sub_sport, a.start_time, a.distance_km, "
+        f"a.duration_seconds, a.avg_speed_kmh, a.avg_heart_rate, a.max_heart_rate, a.total_ascent_m "
+        f"FROM public.garmin_activities a {where} "
+        f"ORDER BY a.start_time DESC "
+        f"LIMIT ${idx} OFFSET ${idx + 1}",
+        *params,
+        limit,
+        offset,
+    )
+
+    activities = [GarminLapsActivity(**dict(row)) for row in activity_rows]
+    laps_by_activity: dict[str, list[GarminActivityLap]] = {a.activity_id: [] for a in activities}
+
+    if activities:
+        lap_rows = await db.fetch(
+            "SELECT id, activity_id, lap_index, start_time, end_time, "
+            "duration_seconds, elapsed_duration_seconds, moving_duration_seconds, "
+            "distance_meters, paved_distance_meters, unpaved_distance_meters, "
+            "avg_speed_mps, avg_heart_rate, max_heart_rate, total_ascent_meters, "
+            "total_descent_meters, calories, created_at, updated_at "
+            "FROM public.garmin_activity_laps WHERE activity_id = ANY($1::text[]) "
+            "ORDER BY lap_index ASC",
+            list(laps_by_activity.keys()),
+        )
+        for row in lap_rows:
+            lap = GarminActivityLap(**dict(row))
+            laps_by_activity[lap.activity_id].append(lap)
+
+    items = [
+        GarminActivityLapsGroup(activity=activity, laps=laps_by_activity[activity.activity_id])
+        for activity in activities
+    ]
+    return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
 def _row_to_track_point(row: Mapping[str, Any]) -> GarminTrackPoint:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1292,6 +1292,130 @@
         }
       }
     },
+    "/api/v1/garmin/laps": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "List Laps",
+        "description": "Batch laps across activities for cross-activity comparison.\n\nReturns activities (newest first) that have at least one lap, each with\nits laps ordered by ``lap_index`` ascending, so lap N can be compared\nacross dates. Pagination applies to activities, not individual laps.",
+        "operationId": "list_laps_api_v1_garmin_laps_get",
+        "parameters": [
+          {
+            "name": "sport",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by sport type",
+              "examples": [
+                "cycling"
+              ],
+              "title": "Sport"
+            },
+            "description": "Filter by sport type"
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter from date (YYYY-MM-DD)",
+              "examples": [
+                "2026-01-01"
+              ],
+              "title": "Date From"
+            },
+            "description": "Filter from date (YYYY-MM-DD)"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to date (YYYY-MM-DD)",
+              "examples": [
+                "2026-06-30"
+              ],
+              "title": "Date To"
+            },
+            "description": "Filter to date (YYYY-MM-DD)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Maximum number of activities to return per page",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of activities to return per page"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of activities to skip for pagination",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of activities to skip for pagination"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_GarminActivityLapsGroup_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/garmin/activities/{activity_id}/addresses": {
       "get": {
         "tags": [
@@ -4042,6 +4166,29 @@
         "title": "GarminActivityLap",
         "description": "Garmin-native or derived activity lap row."
       },
+      "GarminActivityLapsGroup": {
+        "properties": {
+          "activity": {
+            "$ref": "#/components/schemas/GarminLapsActivity",
+            "description": "Parent activity summary"
+          },
+          "laps": {
+            "items": {
+              "$ref": "#/components/schemas/GarminActivityLap"
+            },
+            "type": "array",
+            "title": "Laps",
+            "description": "Laps ordered by lap_index ascending"
+          }
+        },
+        "type": "object",
+        "required": [
+          "activity",
+          "laps"
+        ],
+        "title": "GarminActivityLapsGroup",
+        "description": "Laps for a single activity within the batch laps response."
+      },
       "GarminActivityManualUpdate": {
         "properties": {
           "sport": {
@@ -4893,6 +5040,130 @@
             "label": "Manual"
           }
         ]
+      },
+      "GarminLapsActivity": {
+        "properties": {
+          "activity_id": {
+            "type": "string",
+            "title": "Activity Id",
+            "description": "Garmin activity identifier"
+          },
+          "sport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sport",
+            "description": "Sport type (e.g. cycling)"
+          },
+          "sub_sport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sub Sport",
+            "description": "Sub-sport type (e.g. road)"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time",
+            "description": "UTC activity start time"
+          },
+          "distance_km": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Km",
+            "description": "Total activity distance in kilometers"
+          },
+          "duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Seconds",
+            "description": "Total activity duration in seconds"
+          },
+          "avg_speed_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Speed Kmh",
+            "description": "Average activity speed in km/h"
+          },
+          "avg_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Heart Rate",
+            "description": "Average activity heart rate in bpm"
+          },
+          "max_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Heart Rate",
+            "description": "Maximum activity heart rate in bpm"
+          },
+          "total_ascent_m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Ascent M",
+            "description": "Total activity elevation gain in meters"
+          }
+        },
+        "type": "object",
+        "required": [
+          "activity_id"
+        ],
+        "title": "GarminLapsActivity",
+        "description": "Activity summary metadata for a batch laps response item."
       },
       "GarminSyncResponse": {
         "properties": {
@@ -6292,6 +6563,41 @@
           "offset"
         ],
         "title": "PaginatedResponse[DailyActivitySummary]"
+      },
+      "PaginatedResponse_GarminActivityLapsGroup_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/GarminActivityLapsGroup"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "List of items in the current page"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total number of items matching the query"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of items per page"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "Number of items skipped from the start"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "PaginatedResponse[GarminActivityLapsGroup]"
       },
       "PaginatedResponse_GarminActivity_": {
         "properties": {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -389,6 +389,30 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/garmin/laps": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Laps
+         * @description Batch laps across activities for cross-activity comparison.
+         *
+         *     Returns activities (newest first) that have at least one lap, each with
+         *     its laps ordered by ``lap_index`` ascending, so lap N can be compared
+         *     across dates. Pagination applies to activities, not individual laps.
+         */
+        get: operations["list_laps_api_v1_garmin_laps_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/garmin/activities/{activity_id}/addresses": {
         parameters: {
             query?: never;
@@ -1519,6 +1543,19 @@ export type components = {
             updated_at?: string | null;
         };
         /**
+         * GarminActivityLapsGroup
+         * @description Laps for a single activity within the batch laps response.
+         */
+        GarminActivityLapsGroup: {
+            /** @description Parent activity summary */
+            activity: components["schemas"]["GarminLapsActivity"];
+            /**
+             * Laps
+             * @description Laps ordered by lap_index ascending
+             */
+            laps: components["schemas"]["GarminActivityLap"][];
+        };
+        /**
          * GarminActivityManualUpdate
          * @description Partial manual update payload for Garmin activity records.
          * @example {
@@ -1933,6 +1970,62 @@ export type components = {
              * @description Number of activities for this device label
              */
             activity_count: number;
+        };
+        /**
+         * GarminLapsActivity
+         * @description Activity summary metadata for a batch laps response item.
+         */
+        GarminLapsActivity: {
+            /**
+             * Activity Id
+             * @description Garmin activity identifier
+             */
+            activity_id: string;
+            /**
+             * Sport
+             * @description Sport type (e.g. cycling)
+             */
+            sport?: string | null;
+            /**
+             * Sub Sport
+             * @description Sub-sport type (e.g. road)
+             */
+            sub_sport?: string | null;
+            /**
+             * Start Time
+             * @description UTC activity start time
+             */
+            start_time?: string | null;
+            /**
+             * Distance Km
+             * @description Total activity distance in kilometers
+             */
+            distance_km?: number | null;
+            /**
+             * Duration Seconds
+             * @description Total activity duration in seconds
+             */
+            duration_seconds?: number | null;
+            /**
+             * Avg Speed Kmh
+             * @description Average activity speed in km/h
+             */
+            avg_speed_kmh?: number | null;
+            /**
+             * Avg Heart Rate
+             * @description Average activity heart rate in bpm
+             */
+            avg_heart_rate?: number | null;
+            /**
+             * Max Heart Rate
+             * @description Maximum activity heart rate in bpm
+             */
+            max_heart_rate?: number | null;
+            /**
+             * Total Ascent M
+             * @description Total activity elevation gain in meters
+             */
+            total_ascent_m?: number | null;
         };
         /**
          * GarminSyncResponse
@@ -2735,6 +2828,29 @@ export type components = {
              * @description List of items in the current page
              */
             items: components["schemas"]["DailyActivitySummary"][];
+            /**
+             * Total
+             * @description Total number of items matching the query
+             */
+            total: number;
+            /**
+             * Limit
+             * @description Maximum number of items per page
+             */
+            limit: number;
+            /**
+             * Offset
+             * @description Number of items skipped from the start
+             */
+            offset: number;
+        };
+        /** PaginatedResponse[GarminActivityLapsGroup] */
+        PaginatedResponse_GarminActivityLapsGroup_: {
+            /**
+             * Items
+             * @description List of items in the current page
+             */
+            items: components["schemas"]["GarminActivityLapsGroup"][];
             /**
              * Total
              * @description Total number of items matching the query
@@ -3819,6 +3935,46 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_laps_api_v1_garmin_laps_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by sport type */
+                sport?: string | null;
+                /** @description Filter from date (YYYY-MM-DD) */
+                date_from?: string | null;
+                /** @description Filter to date (YYYY-MM-DD) */
+                date_to?: string | null;
+                /** @description Maximum number of activities to return per page */
+                limit?: number;
+                /** @description Number of activities to skip for pagination */
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_GarminActivityLapsGroup_"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -701,6 +701,105 @@ async def test_list_activity_laps_not_found(client: AsyncClient, mock_db):
     assert response.json() == {"detail": "Activity not found"}
 
 
+def _laps_activity_row(activity_id: str = "20932993811") -> dict:
+    return {
+        "activity_id": activity_id,
+        "sport": "cycling",
+        "sub_sport": "road",
+        "start_time": "2026-03-08T19:58:56+00:00",
+        "distance_km": 52.35,
+        "duration_seconds": 11045.0,
+        "avg_speed_kmh": 17.1,
+        "avg_heart_rate": 118,
+        "max_heart_rate": 149,
+        "total_ascent_m": 191.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_laps_batch_success(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 2
+    mock_db.fetch.side_effect = [
+        [_laps_activity_row("111"), _laps_activity_row("222")],
+        [
+            _lap_row(activity_id="111", lap_index=1),
+            _lap_row(activity_id="111", lap_index=2),
+            _lap_row(activity_id="222", lap_index=1),
+        ],
+    ]
+
+    response = await client.get("/api/v1/garmin/laps")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    assert data["limit"] == 50
+    assert data["offset"] == 0
+    assert len(data["items"]) == 2
+
+    first = data["items"][0]
+    assert first["activity"]["activity_id"] == "111"
+    assert first["activity"]["sport"] == "cycling"
+    assert [lap["lap_index"] for lap in first["laps"]] == [1, 2]
+
+    second = data["items"][1]
+    assert second["activity"]["activity_id"] == "222"
+    assert len(second["laps"]) == 1
+
+    activity_query = mock_db.fetch.await_args_list[0].args[0]
+    assert "EXISTS (SELECT 1 FROM public.garmin_activity_laps" in activity_query
+    assert "ORDER BY a.start_time DESC" in activity_query
+
+    laps_query = mock_db.fetch.await_args_list[1].args[0]
+    assert "activity_id = ANY($1::text[])" in laps_query
+    assert "ORDER BY lap_index ASC" in laps_query
+
+
+@pytest.mark.asyncio
+async def test_list_laps_batch_sport_and_date_filters(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.side_effect = [
+        [_laps_activity_row("111")],
+        [_lap_row(activity_id="111", lap_index=1)],
+    ]
+
+    response = await client.get(
+        "/api/v1/garmin/laps",
+        params={"sport": "cycling", "date_from": "2026-01-01", "date_to": "2026-06-30"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+
+    count_query = mock_db.fetchval.await_args.args[0]
+    assert "a.sport = $1" in count_query
+    assert "a.start_time >= $2::date" in count_query
+    assert "a.start_time < ($3::date + INTERVAL '1 day')" in count_query
+
+
+@pytest.mark.asyncio
+async def test_list_laps_batch_empty(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 0
+    mock_db.fetch.side_effect = [[]]
+
+    response = await client.get("/api/v1/garmin/laps")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"items": [], "total": 0, "limit": 50, "offset": 0}
+
+    # Laps query must be skipped when no activities match.
+    assert mock_db.fetch.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_list_laps_batch_invalid_date(client: AsyncClient, mock_db):
+    response = await client.get("/api/v1/garmin/laps", params={"date_from": "not-a-date"})
+
+    assert response.status_code == 422
+
+
 class _FakeSyncResponse:
     def __init__(self, status_code: int, payload):
         self.status_code = status_code


### PR DESCRIPTION
## Summary
Adds **GET /api/v1/garmin/laps** — batch laps across activities powering the Lap Comparison feature (Refs #184):

- Returns `PaginatedResponse[GarminActivityLapsGroup]`: each item is an activity summary (`GarminLapsActivity`) plus its laps ordered by `lap_index`, so lap N can be compared across dates
- Only activities with at least one lap are included (EXISTS filter)
- Filters: `sport`, `date_from`, `date_to`; newest-first ordering; pagination applies to activities (default 50, max 500)
- Two-query fan-out (activity page, then laps via `ANY($1::text[])`) to stay DB-pool friendly

## Scope note (review feedback addressed)
- Branch rebased onto `master`; the previously included device-counts, climbs, and per-activity laps commits were dropped since they already merged via #177, #178, and #180. This PR now contains only the batch laps endpoint.
- `Closes #184` wording removed — #184 stays open until post-deploy validation.

## Testing
- 206 tests pass (`pytest -q`), including new tests for grouping, filters, empty result, and invalid dates
- Regenerated `docs/openapi.json` and `packages/otel-data-types/index.d.ts`

Refs #184
Part of the Garmin Lap Comparison & Segments project: https://github.com/users/stuartshay/projects/10