### PR TITLE
feat(garmin): add stateless segment-efforts endpoint (Phase 3 matching foundation)

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -511,3 +511,37 @@ class GarminActivityManualUpdate(BaseModel):
             ]
         },
     }
+
+
+class SegmentDefinition(BaseModel):
+    """The ad-hoc segment queried for efforts (a start→end corridor)."""
+
+    start_lat: float = Field(description="Segment start latitude")
+    start_lon: float = Field(description="Segment start longitude")
+    end_lat: float = Field(description="Segment end latitude")
+    end_lon: float = Field(description="Segment end longitude")
+    tolerance_meters: int = Field(description="Corridor radius around the start/end points in meters")
+
+
+class SegmentEffort(BaseModel):
+    """A single activity's best traversal of a segment, for cross-activity comparison."""
+
+    rank: int = Field(description="1-based rank by elapsed time (1 = fastest)")
+    activity_id: str = Field(description="Garmin activity identifier")
+    sport: str | None = Field(default=None, description="Sport type (e.g. cycling)")
+    activity_start_time: datetime | None = Field(default=None, description="UTC start time of the parent activity")
+    effort_start: datetime = Field(description="UTC timestamp entering the segment start corridor")
+    effort_end: datetime = Field(description="UTC timestamp reaching the segment end corridor")
+    elapsed_seconds: float = Field(description="Segment elapsed time in seconds")
+    distance_km: float | None = Field(default=None, description="Distance covered across the segment in km")
+    avg_speed_kmh: float | None = Field(default=None, description="Average speed across the segment in km/h")
+    avg_heart_rate: int | None = Field(default=None, description="Average heart rate across the segment in bpm")
+    max_heart_rate: int | None = Field(default=None, description="Maximum heart rate across the segment in bpm")
+
+
+class SegmentEffortsResponse(BaseModel):
+    """Ranked efforts for a segment across all matching activities."""
+
+    segment: SegmentDefinition = Field(description="The queried segment definition")
+    total: int = Field(description="Number of matching efforts returned")
+    items: list[SegmentEffort] = Field(description="Efforts ordered fastest-first")

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -28,6 +28,9 @@ from app.models.garmin import (
     GarminLapsActivity,
     GarminSyncResponse,
     GarminTrackPoint,
+    SegmentDefinition,
+    SegmentEffort,
+    SegmentEffortsResponse,
     SportInfo,
 )
 from app.models.geocoding import GarminActivityAddress, GeocodedAddressSummary
@@ -844,3 +847,129 @@ async def list_activity_addresses(
     )
 
     return [GarminActivityAddress(**dict(row)) for row in rows]
+
+
+@router.get("/segment-efforts", response_model=SegmentEffortsResponse)
+async def list_segment_efforts(
+    request: Request,
+    start_lat: float = Query(..., description="Segment start latitude", examples=[40.79366846]),
+    start_lon: float = Query(..., description="Segment start longitude", examples=[-73.96104321]),
+    end_lat: float = Query(..., description="Segment end latitude", examples=[40.79002409]),
+    end_lon: float = Query(..., description="Segment end longitude", examples=[-73.96422816]),
+    tolerance_meters: int = Query(
+        35, ge=5, le=200, description="Corridor radius around the start/end points in meters"
+    ),
+    sport: str | None = Query("cycling", description="Filter by sport type; pass an empty value to include all sports"),
+    date_from: str | None = Query(
+        None, description="Filter from date (YYYY-MM-DD) on activity start_time", examples=["2024-01-01"]
+    ),
+    date_to: str | None = Query(
+        None, description="Filter to date (YYYY-MM-DD) on activity start_time", examples=["2026-06-30"]
+    ),
+    max_effort_seconds: int = Query(
+        3600, ge=1, le=86400, description="Ignore traversals longer than this (filters loop/return mismatches)"
+    ),
+    limit: int = Query(100, ge=1, le=500, description="Maximum number of efforts to return"),
+) -> SegmentEffortsResponse:
+    """Rank activity efforts over an ad-hoc segment defined by start/end coordinates.
+
+    Matches raw GPS track points with PostGIS: an activity qualifies when its
+    route passes within ``tolerance_meters`` of the start point and, later in
+    time, within tolerance of the end point (same direction of travel). For each
+    activity the shortest such start→end traversal is used, and efforts are
+    ranked fastest-first. Stateless (no stored segment) — the coordinate pair can
+    be sourced from a detected climb or lap.
+    """
+    db = request.app.state.db
+
+    params: list[Any] = [start_lon, start_lat, end_lon, end_lat, tolerance_meters]
+    idx = 6
+
+    sport_clause = ""
+    if sport:
+        sport_clause = f" AND a.sport = ${idx}"
+        params.append(sport)
+        idx += 1
+
+    date_from_clause = ""
+    if date_from:
+        date_from_clause = f" AND a.start_time >= ${idx}::date"
+        params.append(_parse_date(date_from))
+        idx += 1
+
+    date_to_clause = ""
+    if date_to:
+        date_to_clause = f" AND a.start_time < (${idx}::date + INTERVAL '1 day')"
+        params.append(_parse_date(date_to))
+        idx += 1
+
+    max_effort_idx = idx
+    params.append(max_effort_seconds)
+    idx += 1
+    limit_idx = idx
+    params.append(limit)
+
+    query = f"""
+        WITH seg AS (
+            SELECT ST_MakePoint($1, $2)::geography AS start_pt,
+                   ST_MakePoint($3, $4)::geography AS end_pt,
+                   $5::double precision AS tol
+        ),
+        starts AS (
+            SELECT t.activity_id, t.timestamp AS s_ts
+            FROM public.garmin_track_points t CROSS JOIN seg
+            WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.start_pt, seg.tol)
+        ),
+        ends AS (
+            SELECT t.activity_id, t.timestamp AS e_ts
+            FROM public.garmin_track_points t CROSS JOIN seg
+            WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.end_pt, seg.tol)
+        ),
+        pairs AS (
+            SELECT s.activity_id, s.s_ts, MIN(e.e_ts) AS e_ts
+            FROM starts s
+            JOIN ends e ON e.activity_id = s.activity_id AND e.e_ts > s.s_ts
+            GROUP BY s.activity_id, s.s_ts
+        ),
+        best AS (
+            SELECT DISTINCT ON (activity_id) activity_id, s_ts, e_ts
+            FROM pairs
+            ORDER BY activity_id, (e_ts - s_ts) ASC
+        ),
+        metrics AS (
+            SELECT b.activity_id, b.s_ts, b.e_ts,
+                   EXTRACT(EPOCH FROM (b.e_ts - b.s_ts)) AS elapsed_seconds,
+                   AVG(t.speed_kmh) AS avg_speed_kmh,
+                   AVG(t.heart_rate) FILTER (WHERE t.heart_rate > 0) AS avg_hr,
+                   MAX(t.heart_rate) AS max_heart_rate,
+                   MAX(t.distance_from_start_km) - MIN(t.distance_from_start_km) AS distance_km
+            FROM best b
+            JOIN public.garmin_track_points t
+              ON t.activity_id = b.activity_id
+             AND t.timestamp BETWEEN b.s_ts AND b.e_ts
+            GROUP BY b.activity_id, b.s_ts, b.e_ts
+        )
+        SELECT m.activity_id, a.sport, a.start_time AS activity_start_time,
+               m.s_ts AS effort_start, m.e_ts AS effort_end,
+               m.elapsed_seconds, m.distance_km, m.avg_speed_kmh,
+               ROUND(m.avg_hr)::int AS avg_heart_rate, m.max_heart_rate
+        FROM metrics m
+        JOIN public.garmin_activities a ON a.activity_id = m.activity_id
+        WHERE m.elapsed_seconds <= ${max_effort_idx}{sport_clause}{date_from_clause}{date_to_clause}
+        ORDER BY m.elapsed_seconds ASC
+        LIMIT ${limit_idx}
+    """
+
+    rows = await db.fetch(query, *params)
+    items = [SegmentEffort(rank=i + 1, **dict(row)) for i, row in enumerate(rows)]
+    return SegmentEffortsResponse(
+        segment=SegmentDefinition(
+            start_lat=start_lat,
+            start_lon=start_lon,
+            end_lat=end_lat,
+            end_lon=end_lon,
+            tolerance_meters=tolerance_meters,
+        ),
+        total=len(items),
+        items=items,
+    )

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -915,14 +915,23 @@ async def list_segment_efforts(
                    ST_MakePoint($3, $4)::geography AS end_pt,
                    $5::double precision AS tol
         ),
+        filtered_activities AS (
+            SELECT a.activity_id
+            FROM public.garmin_activities a
+            WHERE TRUE{sport_clause}{date_from_clause}{date_to_clause}
+        ),
         starts AS (
             SELECT t.activity_id, t.timestamp AS s_ts
-            FROM public.garmin_track_points t CROSS JOIN seg
+            FROM public.garmin_track_points t
+            JOIN filtered_activities fa ON fa.activity_id = t.activity_id
+            CROSS JOIN seg
             WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.start_pt, seg.tol)
         ),
         ends AS (
             SELECT t.activity_id, t.timestamp AS e_ts
-            FROM public.garmin_track_points t CROSS JOIN seg
+            FROM public.garmin_track_points t
+            JOIN filtered_activities fa ON fa.activity_id = t.activity_id
+            CROSS JOIN seg
             WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.end_pt, seg.tol)
         ),
         pairs AS (
@@ -955,7 +964,7 @@ async def list_segment_efforts(
                ROUND(m.avg_hr)::int AS avg_heart_rate, m.max_heart_rate
         FROM metrics m
         JOIN public.garmin_activities a ON a.activity_id = m.activity_id
-        WHERE m.elapsed_seconds <= ${max_effort_idx}{sport_clause}{date_from_clause}{date_to_clause}
+        WHERE m.elapsed_seconds <= ${max_effort_idx}
         ORDER BY m.elapsed_seconds ASC
         LIMIT ${limit_idx}
     """

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,7 +1,7 @@
 """Tests for Garmin endpoints."""
 
 import dataclasses
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import fastapi
 import httpx
@@ -1432,12 +1432,13 @@ async def test_pending_cell_does_not_hide_waypoint_address(client: AsyncClient, 
 
 
 def _segment_effort_row(activity_id: str, elapsed: float) -> dict:
+    effort_start = datetime(2026, 7, 5, 10, 30, 0)
     return {
         "activity_id": activity_id,
         "sport": "cycling",
         "activity_start_time": datetime(2026, 7, 5, 10, 0, 0),
-        "effort_start": datetime(2026, 7, 5, 10, 30, 0),
-        "effort_end": datetime(2026, 7, 5, 10, 30, int(elapsed % 60)),
+        "effort_start": effort_start,
+        "effort_end": effort_start + timedelta(seconds=elapsed),
         "elapsed_seconds": elapsed,
         "distance_km": 0.51,
         "avg_speed_kmh": 18.2,

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,7 +1,7 @@
 """Tests for Garmin endpoints."""
 
 import dataclasses
-from datetime import date
+from datetime import date, datetime
 
 import fastapi
 import httpx
@@ -1429,3 +1429,117 @@ async def test_pending_cell_does_not_hide_waypoint_address(client: AsyncClient, 
     assert addr["display_address"] == row["display_address"]
     assert addr["waypoint_kind"] == "start"
     assert addr["status"] == "success"
+
+
+def _segment_effort_row(activity_id: str, elapsed: float) -> dict:
+    return {
+        "activity_id": activity_id,
+        "sport": "cycling",
+        "activity_start_time": datetime(2026, 7, 5, 10, 0, 0),
+        "effort_start": datetime(2026, 7, 5, 10, 30, 0),
+        "effort_end": datetime(2026, 7, 5, 10, 30, int(elapsed % 60)),
+        "elapsed_seconds": elapsed,
+        "distance_km": 0.51,
+        "avg_speed_kmh": 18.2,
+        "avg_heart_rate": 128,
+        "max_heart_rate": 150,
+    }
+
+
+@pytest.mark.asyncio
+async def test_segment_efforts_returns_ranked(client: AsyncClient, mock_db):
+    mock_db.fetch.return_value = [
+        _segment_effort_row("a-fast", 89.0),
+        _segment_effort_row("a-slow", 130.0),
+    ]
+
+    response = await client.get(
+        "/api/v1/garmin/segment-efforts"
+        "?start_lat=40.79366846&start_lon=-73.96104321"
+        "&end_lat=40.79002409&end_lon=-73.96422816"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert body["segment"] == {
+        "start_lat": 40.79366846,
+        "start_lon": -73.96104321,
+        "end_lat": 40.79002409,
+        "end_lon": -73.96422816,
+        "tolerance_meters": 35,
+    }
+    assert [e["rank"] for e in body["items"]] == [1, 2]
+    assert [e["activity_id"] for e in body["items"]] == ["a-fast", "a-slow"]
+    assert body["items"][0]["elapsed_seconds"] == 89.0
+
+
+@pytest.mark.asyncio
+async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
+    mock_db.fetch.return_value = []
+
+    response = await client.get(
+        "/api/v1/garmin/segment-efforts"
+        "?start_lat=40.79366846&start_lon=-73.96104321"
+        "&end_lat=40.79002409&end_lon=-73.96422816"
+        "&tolerance_meters=40&date_from=2024-01-01&date_to=2026-06-30&limit=25"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "segment": {
+            "start_lat": 40.79366846,
+            "start_lon": -73.96104321,
+            "end_lat": 40.79002409,
+            "end_lon": -73.96422816,
+            "tolerance_meters": 40,
+        },
+        "total": 0,
+        "items": [],
+    }
+
+    query, *params = mock_db.fetch.await_args.args
+    assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in query
+    assert "ST_DWithin(t.geog, seg.end_pt, seg.tol)" in query
+    assert "e.e_ts > s.s_ts" in query  # same-direction enforcement
+    assert "DISTINCT ON (activity_id)" in query  # shortest traversal per activity
+    assert "ORDER BY m.elapsed_seconds ASC" in query
+    # $1..$5 = start_lon, start_lat, end_lon, end_lat, tolerance
+    assert params[:5] == [-73.96104321, 40.79366846, -73.96422816, 40.79002409, 40]
+    # default sport filter applied, then date range, then max_effort + limit
+    assert "a.sport = $6" in query
+    assert params[5] == "cycling"
+    assert params[6] == date(2024, 1, 1)
+    assert params[7] == date(2026, 6, 30)
+    assert params[-1] == 25  # limit is the last bound parameter
+
+
+@pytest.mark.asyncio
+async def test_segment_efforts_all_sports_when_blank(client: AsyncClient, mock_db):
+    mock_db.fetch.return_value = []
+
+    response = await client.get(
+        "/api/v1/garmin/segment-efforts?start_lat=40.79&start_lon=-73.96&end_lat=40.79&end_lon=-73.964&sport="
+    )
+
+    assert response.status_code == 200
+    query, *params = mock_db.fetch.await_args.args
+    assert "a.sport =" not in query
+    assert "cycling" not in params
+
+
+@pytest.mark.asyncio
+async def test_segment_efforts_invalid_date(client: AsyncClient, mock_db):
+    response = await client.get(
+        "/api/v1/garmin/segment-efforts?start_lat=40.79&start_lon=-73.96&end_lat=40.79&end_lon=-73.964&date_from=nope"
+    )
+
+    assert response.status_code == 422
+    assert "Invalid date format" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_segment_efforts_requires_coordinates(client: AsyncClient, mock_db):
+    response = await client.get("/api/v1/garmin/segment-efforts?start_lat=40.79")
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

Adds a stateless **`GET /api/v1/garmin/segment-efforts`** endpoint that ranks
activity efforts over an ad-hoc segment defined by start/end coordinates — the
raw-track matching foundation for Phase 3 named segments.

Motivated by the concrete example: take **Climb 1 of activity `23493313338`**
(Central Park / Harlem Hill) and find every ride that traverses it, then compare.

Refs #186

## How it works

PostGIS raw-track matching over `garmin_track_points` (indexed `geog` column):

- An activity qualifies when its route passes within `tolerance_meters` of the
  **start** point and, **later in time**, within tolerance of the **end** point
  (same direction of travel).
- For each activity the **shortest** valid start→end traversal is used
  (`DISTINCT ON (activity_id)` by duration), so loops/return passes don't inflate
  the effort. `max_effort_seconds` further guards against mismatches.
- Per-effort metrics: elapsed time, distance, avg speed, avg/max HR — ranked
  **fastest-first**.
- **Stateless** (no DB migration). The coordinate pair can come from a detected
  climb or lap. Persisting named segments (`garmin_segments`) + gateway + UI are
  the follow-on Phase 3 steps.

### Parameters

`start_lat/lon`, `end_lat/lon` (required), `tolerance_meters` (default 35),
`sport` (default `cycling`, blank = all), `date_from/to`, `max_effort_seconds`
(default 3600), `limit` (default 100).

## Validation

- `ruff`, `mypy`, `pyright`, cspell (pre-commit) — all pass
- `pytest` — **211 passed** (5 new segment tests); coverage gate met
- **Live against production data** (Central Park climb from `23493313338`):
  - 489 plausible efforts traverse the segment
  - Fastest effort **79 s** (2025-07-04, 19.9 km/h); reference ride computes
    ~100 s, matching its detected climb duration (~101 s)
  - Endpoint responds in ~370 ms

## Follow-on (Phase 3)

- Persist segments (`garmin_segments` + `garmin_segment_efforts`) — migrations #56
- Gateway GraphQL (otel-data-gateway#156) + Segments UI (otel-data-ui#282):
  "create segment from this climb" + efforts leaderboard, reusing the Lap
  Comparison patterns.

Project: https://github.com/users/stuartshay/projects/10
