### PR TITLE
feat(garmin): cascade segment delete to Garmin Connect

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1038,10 +1038,10 @@ async def list_segments(
 ) -> list[GarminSegment]:
     """List saved segments (paths), newest first."""
     db = request.app.state.db
-    where = ""
+    where = "WHERE garmin_sync_status <> 'delete_pending'"
     params: list[Any] = []
     if sport:
-        where = "WHERE sport = $1"
+        where += " AND sport = $1"
         params.append(sport)
     rows = await db.fetch(
         f"SELECT {_SEGMENT_COLUMNS} FROM public.garmin_segments {where} ORDER BY created_at DESC",
@@ -1093,7 +1093,8 @@ async def get_segment(
     """Get a single saved segment by ID."""
     db = request.app.state.db
     row = await db.fetchrow(
-        f"SELECT {_SEGMENT_COLUMNS} FROM public.garmin_segments WHERE id = $1",
+        f"SELECT {_SEGMENT_COLUMNS} FROM public.garmin_segments "
+        "WHERE id = $1 AND garmin_sync_status <> 'delete_pending'",
         segment_id,
     )
     if not row:
@@ -1107,11 +1108,31 @@ async def delete_segment(
     segment_id: int = fastapi.Path(description="Saved segment ID"),
     _user: dict = Depends(require_auth),
 ) -> Response:
-    """Delete a saved segment (auth required)."""
+    """Delete a saved segment (auth required).
+
+    If the segment has been pushed to Garmin Connect (``garmin_segment_uuid`` is
+    set) it is marked ``delete_pending`` so the garmin-sync agent removes it from
+    Garmin and then deletes the row (end-to-end delete). Segments that were never
+    synced are removed immediately. Either way the segment stops appearing in the
+    read endpoints right away.
+    """
     db = request.app.state.db
-    result = await db.execute("DELETE FROM public.garmin_segments WHERE id = $1", segment_id)
-    if result == "DELETE 0":
+    row = await db.fetchrow(
+        "SELECT garmin_segment_uuid FROM public.garmin_segments "
+        "WHERE id = $1 AND garmin_sync_status <> 'delete_pending'",
+        segment_id,
+    )
+    if row is None:
         raise HTTPException(status_code=404, detail="Segment not found")
+    if row["garmin_segment_uuid"] is not None:
+        # Synced to Garmin: hand off to the agent for end-to-end deletion.
+        await db.execute(
+            "UPDATE public.garmin_segments SET garmin_sync_status = 'delete_pending', updated_at = NOW() WHERE id = $1",
+            segment_id,
+        )
+    else:
+        # Never synced to Garmin: remove immediately.
+        await db.execute("DELETE FROM public.garmin_segments WHERE id = $1", segment_id)
     return Response(status_code=204)
 
 
@@ -1133,7 +1154,7 @@ async def get_segment_efforts(
     seg = await db.fetchrow(
         "SELECT sport, start_latitude, start_longitude, end_latitude, end_longitude, "
         "match_tolerance_meters::double precision AS match_tolerance_meters "
-        "FROM public.garmin_segments WHERE id = $1",
+        "FROM public.garmin_segments WHERE id = $1 AND garmin_sync_status <> 'delete_pending'",
         segment_id,
     )
     if not seg:

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1038,7 +1038,7 @@ async def list_segments(
 ) -> list[GarminSegment]:
     """List saved segments (paths), newest first."""
     db = request.app.state.db
-    where = "WHERE garmin_sync_status <> 'delete_pending'"
+    where = "WHERE garmin_sync_status IS DISTINCT FROM 'delete_pending'"
     params: list[Any] = []
     if sport:
         where += " AND sport = $1"
@@ -1094,7 +1094,7 @@ async def get_segment(
     db = request.app.state.db
     row = await db.fetchrow(
         f"SELECT {_SEGMENT_COLUMNS} FROM public.garmin_segments "
-        "WHERE id = $1 AND garmin_sync_status <> 'delete_pending'",
+        "WHERE id = $1 AND garmin_sync_status IS DISTINCT FROM 'delete_pending'",
         segment_id,
     )
     if not row:
@@ -1119,7 +1119,7 @@ async def delete_segment(
     db = request.app.state.db
     row = await db.fetchrow(
         "SELECT garmin_segment_uuid FROM public.garmin_segments "
-        "WHERE id = $1 AND garmin_sync_status <> 'delete_pending'",
+        "WHERE id = $1 AND garmin_sync_status IS DISTINCT FROM 'delete_pending'",
         segment_id,
     )
     if row is None:
@@ -1154,7 +1154,7 @@ async def get_segment_efforts(
     seg = await db.fetchrow(
         "SELECT sport, start_latitude, start_longitude, end_latitude, end_longitude, "
         "match_tolerance_meters::double precision AS match_tolerance_meters "
-        "FROM public.garmin_segments WHERE id = $1 AND garmin_sync_status <> 'delete_pending'",
+        "FROM public.garmin_segments WHERE id = $1 AND garmin_sync_status IS DISTINCT FROM 'delete_pending'",
         segment_id,
     )
     if not seg:

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1602,7 +1602,8 @@ async def test_list_segments(client: AsyncClient, mock_db):
     assert len(response.json()) == 2
     query, *params = mock_db.fetch.await_args.args
     assert "FROM public.garmin_segments" in query
-    assert "WHERE sport = $1" in query
+    assert "garmin_sync_status <> 'delete_pending'" in query
+    assert "sport = $1" in query
     assert "ORDER BY created_at DESC" in query
     assert params == ["cycling"]
 
@@ -1627,17 +1628,32 @@ async def test_get_segment_not_found(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
-async def test_delete_segment_success(client: AsyncClient, mock_db):
-    mock_db.execute.return_value = "DELETE 1"
+async def test_delete_segment_never_synced_hard_deletes(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {"garmin_segment_uuid": None}
 
     response = await client.delete("/api/v1/garmin/segments/3")
 
     assert response.status_code == 204
+    executed = [call.args[0] for call in mock_db.execute.await_args_list]
+    assert any("DELETE FROM public.garmin_segments" in sql for sql in executed)
+    assert not any("delete_pending" in sql for sql in executed)
+
+
+@pytest.mark.asyncio
+async def test_delete_segment_synced_marks_delete_pending(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {"garmin_segment_uuid": "abc-uuid"}
+
+    response = await client.delete("/api/v1/garmin/segments/1")
+
+    assert response.status_code == 204
+    executed = [call.args[0] for call in mock_db.execute.await_args_list]
+    assert any("delete_pending" in sql for sql in executed)
+    assert not any("DELETE FROM public.garmin_segments" in sql for sql in executed)
 
 
 @pytest.mark.asyncio
 async def test_delete_segment_not_found(client: AsyncClient, mock_db):
-    mock_db.execute.return_value = "DELETE 0"
+    mock_db.fetchrow.return_value = None
 
     response = await client.delete("/api/v1/garmin/segments/999")
 

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1602,7 +1602,7 @@ async def test_list_segments(client: AsyncClient, mock_db):
     assert len(response.json()) == 2
     query, *params = mock_db.fetch.await_args.args
     assert "FROM public.garmin_segments" in query
-    assert "garmin_sync_status <> 'delete_pending'" in query
+    assert "garmin_sync_status IS DISTINCT FROM 'delete_pending'" in query
     assert "sport = $1" in query
     assert "ORDER BY created_at DESC" in query
     assert params == ["cycling"]


### PR DESCRIPTION
Completes end-to-end segment delete (stuartshay/otel-agents#137). Pairs with the garmin-sync reconciler (stuartshay/otel-agents#138, deployed).

## Change
`DELETE /garmin/segments/{id}`:
- **Synced to Garmin** (`garmin_segment_uuid` set) → set `garmin_sync_status='delete_pending'`; the garmin-sync agent removes it from Garmin (`DELETE /segment-service/segment/{uuid}`) then deletes the row.
- **Never synced** → hard-delete immediately.

Reads (`list`/`get`/`efforts`) exclude `delete_pending` rows (NULL-safe `IS DISTINCT FROM`), so a deleted segment disappears from the UI instantly while the agent finishes the Garmin removal.

## Validation
- 14 segment tests pass; pre-commit clean

## Note
Push side already live (Harlem Hill + Liberty State Park synced to Garmin). After deploy, deleting a segment also removes it from Garmin within the agent's reconcile interval. UI Delete button is the remaining follow-up.