### PR TITLE
feat(segments): return simplified route geometry in /segments responses

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -564,6 +564,14 @@ class GarminSegment(BaseModel):
     source_climb_index: int | None = Field(default=None, description="Climb split index the segment was created from")
     created_at: datetime | None = Field(default=None, description="UTC creation timestamp")
     updated_at: datetime | None = Field(default=None, description="UTC last-update timestamp")
+    route: list[list[float]] | None = Field(
+        default=None,
+        description=(
+            "Ordered [latitude, longitude] pairs tracing the segment path, recovered and "
+            "simplified from the source activity's GPS track. Null when no source activity "
+            "track can be matched."
+        ),
+    )
 
 
 class GarminSegmentCreate(BaseModel):

--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -564,7 +564,7 @@ class GarminSegment(BaseModel):
     source_climb_index: int | None = Field(default=None, description="Climb split index the segment was created from")
     created_at: datetime | None = Field(default=None, description="UTC creation timestamp")
     updated_at: datetime | None = Field(default=None, description="UTC last-update timestamp")
-    route: list[list[float]] | None = Field(
+    route: list[tuple[float, float]] | None = Field(
         default=None,
         description=(
             "Ordered [latitude, longitude] pairs tracing the segment path, recovered and "

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1030,6 +1030,70 @@ _SEGMENT_COLUMNS = (
     "source_activity_id, source_lap_index, source_climb_index, created_at, updated_at"
 )
 
+# Aliased column list (table alias ``s``) for the read endpoints, which join a
+# LATERAL subquery that recovers the segment route geometry.
+_SEGMENT_SELECT_COLUMNS = (
+    "s.id, s.name, s.sport, s.start_latitude, s.start_longitude, s.end_latitude, s.end_longitude, "
+    "s.distance_meters::double precision AS distance_meters, "
+    "s.match_tolerance_meters::double precision AS match_tolerance_meters, "
+    "s.source_activity_id, s.source_lap_index, s.source_climb_index, s.created_at, s.updated_at, "
+    "r.route"
+)
+
+# Recover each segment's real path from its source activity GPS track: snap the
+# stored start/end to the nearest in-corridor track points (same ST_DWithin
+# corridor used by segment efforts), slice the ordered track between them, and
+# return a PostGIS-simplified array of ordered [latitude, longitude] pairs.
+# Yields NULL route when the segment has no source activity or no matchable
+# corridor, in which case the client falls back to a straight start→end line.
+_SEGMENT_ROUTE_LATERAL = """
+    LEFT JOIN LATERAL (
+        WITH bounds AS (
+            SELECT
+                ST_MakePoint(s.start_longitude, s.start_latitude)::geography AS start_pt,
+                ST_MakePoint(s.end_longitude, s.end_latitude)::geography AS end_pt,
+                GREATEST(s.match_tolerance_meters, 5)::double precision AS tol
+        ),
+        start_ts AS (
+            SELECT MIN(t.timestamp) AS ts
+            FROM public.garmin_track_points t, bounds
+            WHERE t.activity_id = s.source_activity_id
+              AND t.geog IS NOT NULL
+              AND ST_DWithin(t.geog, bounds.start_pt, bounds.tol)
+        ),
+        end_ts AS (
+            SELECT MIN(t.timestamp) AS ts
+            FROM public.garmin_track_points t, bounds, start_ts
+            WHERE t.activity_id = s.source_activity_id
+              AND t.geog IS NOT NULL
+              AND ST_DWithin(t.geog, bounds.end_pt, bounds.tol)
+              AND start_ts.ts IS NOT NULL
+              AND t.timestamp > start_ts.ts
+        ),
+        line AS (
+            SELECT ST_Simplify(
+                       ST_MakeLine(ST_MakePoint(t.longitude, t.latitude) ORDER BY t.timestamp ASC),
+                       0.00005
+                   ) AS geom
+            FROM public.garmin_track_points t, start_ts, end_ts
+            WHERE t.activity_id = s.source_activity_id
+              AND t.latitude IS NOT NULL
+              AND t.longitude IS NOT NULL
+              AND start_ts.ts IS NOT NULL
+              AND end_ts.ts IS NOT NULL
+              AND t.timestamp BETWEEN start_ts.ts AND end_ts.ts
+        )
+        SELECT array_agg(
+                   ARRAY[ST_Y((dp).geom), ST_X((dp).geom)]
+                   ORDER BY (dp).path
+               ) AS route
+        FROM line
+        CROSS JOIN LATERAL ST_DumpPoints(line.geom) AS dp
+        WHERE line.geom IS NOT NULL
+          AND ST_NPoints(line.geom) >= 2
+    ) r ON s.source_activity_id IS NOT NULL
+"""
+
 
 @router.get("/segments", response_model=list[GarminSegment])
 async def list_segments(
@@ -1044,7 +1108,8 @@ async def list_segments(
         where += " AND sport = $1"
         params.append(sport)
     rows = await db.fetch(
-        f"SELECT {_SEGMENT_COLUMNS} FROM public.garmin_segments {where} ORDER BY created_at DESC",
+        f"SELECT {_SEGMENT_SELECT_COLUMNS} FROM public.garmin_segments s "
+        f"{_SEGMENT_ROUTE_LATERAL} {where} ORDER BY created_at DESC",
         *params,
     )
     return [GarminSegment(**dict(row)) for row in rows]
@@ -1093,7 +1158,8 @@ async def get_segment(
     """Get a single saved segment by ID."""
     db = request.app.state.db
     row = await db.fetchrow(
-        f"SELECT {_SEGMENT_COLUMNS} FROM public.garmin_segments "
+        f"SELECT {_SEGMENT_SELECT_COLUMNS} FROM public.garmin_segments s "
+        f"{_SEGMENT_ROUTE_LATERAL} "
         "WHERE id = $1 AND garmin_sync_status IS DISTINCT FROM 'delete_pending'",
         segment_id,
     )

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5790,10 +5790,17 @@
             "anyOf": [
               {
                 "items": {
-                  "items": {
-                    "type": "number"
-                  },
-                  "type": "array"
+                  "prefixItems": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ],
+                  "type": "array",
+                  "maxItems": 2,
+                  "minItems": 2
                 },
                 "type": "array"
               },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1471,6 +1471,504 @@
         }
       }
     },
+    "/api/v1/garmin/segment-efforts": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "List Segment Efforts",
+        "description": "Rank activity efforts over an ad-hoc segment defined by start/end coordinates.\n\nMatches raw GPS track points with PostGIS: an activity qualifies when its\nroute passes within ``tolerance_meters`` of the start point and, later in\ntime, within tolerance of the end point (same direction of travel). For each\nactivity the shortest such start\u2192end traversal is used, and efforts are\nranked fastest-first. Stateless (no stored segment) \u2014 the coordinate pair can\nbe sourced from a detected climb or lap.",
+        "operationId": "list_segment_efforts_api_v1_garmin_segment_efforts_get",
+        "parameters": [
+          {
+            "name": "start_lat",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "description": "Segment start latitude",
+              "examples": [
+                40.79366846
+              ],
+              "title": "Start Lat"
+            },
+            "description": "Segment start latitude"
+          },
+          {
+            "name": "start_lon",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "description": "Segment start longitude",
+              "examples": [
+                -73.96104321
+              ],
+              "title": "Start Lon"
+            },
+            "description": "Segment start longitude"
+          },
+          {
+            "name": "end_lat",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "description": "Segment end latitude",
+              "examples": [
+                40.79002409
+              ],
+              "title": "End Lat"
+            },
+            "description": "Segment end latitude"
+          },
+          {
+            "name": "end_lon",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "description": "Segment end longitude",
+              "examples": [
+                -73.96422816
+              ],
+              "title": "End Lon"
+            },
+            "description": "Segment end longitude"
+          },
+          {
+            "name": "tolerance_meters",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 5,
+              "description": "Corridor radius around the start/end points in meters",
+              "default": 35,
+              "title": "Tolerance Meters"
+            },
+            "description": "Corridor radius around the start/end points in meters"
+          },
+          {
+            "name": "sport",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by sport type; pass an empty value to include all sports",
+              "default": "cycling",
+              "title": "Sport"
+            },
+            "description": "Filter by sport type; pass an empty value to include all sports"
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter from date (YYYY-MM-DD) on activity start_time",
+              "examples": [
+                "2024-01-01"
+              ],
+              "title": "Date From"
+            },
+            "description": "Filter from date (YYYY-MM-DD) on activity start_time"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to date (YYYY-MM-DD) on activity start_time",
+              "examples": [
+                "2026-06-30"
+              ],
+              "title": "Date To"
+            },
+            "description": "Filter to date (YYYY-MM-DD) on activity start_time"
+          },
+          {
+            "name": "max_effort_seconds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 86400,
+              "minimum": 1,
+              "description": "Ignore traversals longer than this (filters loop/return mismatches)",
+              "default": 3600,
+              "title": "Max Effort Seconds"
+            },
+            "description": "Ignore traversals longer than this (filters loop/return mismatches)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Maximum number of efforts to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of efforts to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SegmentEffortsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/garmin/segments": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "List Segments",
+        "description": "List saved segments (paths), newest first.",
+        "operationId": "list_segments_api_v1_garmin_segments_get",
+        "parameters": [
+          {
+            "name": "sport",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by sport type",
+              "examples": [
+                "cycling"
+              ],
+              "title": "Sport"
+            },
+            "description": "Filter by sport type"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GarminSegment"
+                  },
+                  "title": "Response List Segments Api V1 Garmin Segments Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "Create Segment",
+        "description": "Save a new segment (path) from a climb, lap, or manual selection (auth required).",
+        "operationId": "create_segment_api_v1_garmin_segments_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GarminSegmentCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GarminSegment"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/garmin/segments/{segment_id}": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "Get Segment",
+        "description": "Get a single saved segment by ID.",
+        "operationId": "get_segment_api_v1_garmin_segments__segment_id__get",
+        "parameters": [
+          {
+            "name": "segment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Saved segment ID",
+              "title": "Segment Id"
+            },
+            "description": "Saved segment ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GarminSegment"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Segment not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "Delete Segment",
+        "description": "Delete a saved segment (auth required).\n\nIf the segment has been pushed to Garmin Connect (``garmin_segment_uuid`` is\nset) it is marked ``delete_pending`` so the garmin-sync agent removes it from\nGarmin and then deletes the row (end-to-end delete). Segments that were never\nsynced are removed immediately. Either way the segment stops appearing in the\nread endpoints right away.",
+        "operationId": "delete_segment_api_v1_garmin_segments__segment_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "segment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Saved segment ID",
+              "title": "Segment Id"
+            },
+            "description": "Saved segment ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/garmin/segments/{segment_id}/efforts": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "Get Segment Efforts",
+        "description": "Rank activity efforts over a saved segment (matches the saved start/end corridor).",
+        "operationId": "get_segment_efforts_api_v1_garmin_segments__segment_id__efforts_get",
+        "parameters": [
+          {
+            "name": "segment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Saved segment ID",
+              "title": "Segment Id"
+            },
+            "description": "Saved segment ID"
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter from date (YYYY-MM-DD) on activity start_time",
+              "title": "Date From"
+            },
+            "description": "Filter from date (YYYY-MM-DD) on activity start_time"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to date (YYYY-MM-DD) on activity start_time",
+              "title": "Date To"
+            },
+            "description": "Filter to date (YYYY-MM-DD) on activity start_time"
+          },
+          {
+            "name": "max_effort_seconds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 86400,
+              "minimum": 1,
+              "description": "Ignore traversals longer than this",
+              "default": 3600,
+              "title": "Max Effort Seconds"
+            },
+            "description": "Ignore traversals longer than this"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Maximum number of efforts to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of efforts to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SegmentEffortsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Segment not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/gps/unified": {
       "get": {
         "tags": [
@@ -5165,6 +5663,271 @@
         "title": "GarminLapsActivity",
         "description": "Activity summary metadata for a batch laps response item."
       },
+      "GarminSegment": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "Unique saved segment identifier"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Human-readable segment name"
+          },
+          "sport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sport",
+            "description": "Sport type (e.g. cycling)"
+          },
+          "start_latitude": {
+            "type": "number",
+            "title": "Start Latitude",
+            "description": "Segment start latitude"
+          },
+          "start_longitude": {
+            "type": "number",
+            "title": "Start Longitude",
+            "description": "Segment start longitude"
+          },
+          "end_latitude": {
+            "type": "number",
+            "title": "End Latitude",
+            "description": "Segment end latitude"
+          },
+          "end_longitude": {
+            "type": "number",
+            "title": "End Longitude",
+            "description": "Segment end longitude"
+          },
+          "distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Meters",
+            "description": "Segment distance in meters"
+          },
+          "match_tolerance_meters": {
+            "type": "number",
+            "title": "Match Tolerance Meters",
+            "description": "Corridor radius (m) used to match traversing activities"
+          },
+          "source_activity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Activity Id",
+            "description": "Activity the segment was created from"
+          },
+          "source_lap_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lap Index",
+            "description": "Lap index the segment was created from"
+          },
+          "source_climb_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Climb Index",
+            "description": "Climb split index the segment was created from"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "UTC creation timestamp"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "UTC last-update timestamp"
+          },
+          "route": {
+            "anyOf": [
+              {
+                "items": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route",
+            "description": "Ordered [latitude, longitude] pairs tracing the segment path, recovered and simplified from the source activity's GPS track. Null when no source activity track can be matched."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "start_latitude",
+          "start_longitude",
+          "end_latitude",
+          "end_longitude",
+          "match_tolerance_meters"
+        ],
+        "title": "GarminSegment",
+        "description": "A saved named segment (path) for cross-activity effort comparison."
+      },
+      "GarminSegmentCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "description": "Human-readable segment name"
+          },
+          "sport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sport",
+            "description": "Sport type; defaults to cycling",
+            "default": "cycling"
+          },
+          "start_latitude": {
+            "type": "number",
+            "title": "Start Latitude",
+            "description": "Segment start latitude"
+          },
+          "start_longitude": {
+            "type": "number",
+            "title": "Start Longitude",
+            "description": "Segment start longitude"
+          },
+          "end_latitude": {
+            "type": "number",
+            "title": "End Latitude",
+            "description": "Segment end latitude"
+          },
+          "end_longitude": {
+            "type": "number",
+            "title": "End Longitude",
+            "description": "Segment end longitude"
+          },
+          "distance_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Meters",
+            "description": "Segment distance in meters"
+          },
+          "match_tolerance_meters": {
+            "type": "number",
+            "maximum": 200.0,
+            "minimum": 5.0,
+            "title": "Match Tolerance Meters",
+            "description": "Corridor radius (m) used to match traversing activities",
+            "default": 35
+          },
+          "source_activity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Activity Id",
+            "description": "Activity the segment was created from"
+          },
+          "source_lap_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lap Index",
+            "description": "Lap index the segment was created from"
+          },
+          "source_climb_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Climb Index",
+            "description": "Climb split index the segment was created from"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "start_latitude",
+          "start_longitude",
+          "end_latitude",
+          "end_longitude"
+        ],
+        "title": "GarminSegmentCreate",
+        "description": "Request body to save a new segment (path)."
+      },
       "GarminSyncResponse": {
         "properties": {
           "status": {
@@ -6993,6 +7756,188 @@
             "radius_meters": 75
           }
         ]
+      },
+      "SegmentDefinition": {
+        "properties": {
+          "start_lat": {
+            "type": "number",
+            "title": "Start Lat",
+            "description": "Segment start latitude"
+          },
+          "start_lon": {
+            "type": "number",
+            "title": "Start Lon",
+            "description": "Segment start longitude"
+          },
+          "end_lat": {
+            "type": "number",
+            "title": "End Lat",
+            "description": "Segment end latitude"
+          },
+          "end_lon": {
+            "type": "number",
+            "title": "End Lon",
+            "description": "Segment end longitude"
+          },
+          "tolerance_meters": {
+            "type": "number",
+            "title": "Tolerance Meters",
+            "description": "Corridor radius around the start/end points in meters"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start_lat",
+          "start_lon",
+          "end_lat",
+          "end_lon",
+          "tolerance_meters"
+        ],
+        "title": "SegmentDefinition",
+        "description": "The ad-hoc segment queried for efforts (a start\u2192end corridor)."
+      },
+      "SegmentEffort": {
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "title": "Rank",
+            "description": "1-based rank by elapsed time (1 = fastest)"
+          },
+          "activity_id": {
+            "type": "string",
+            "title": "Activity Id",
+            "description": "Garmin activity identifier"
+          },
+          "sport": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sport",
+            "description": "Sport type (e.g. cycling)"
+          },
+          "activity_start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activity Start Time",
+            "description": "UTC start time of the parent activity"
+          },
+          "effort_start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Effort Start",
+            "description": "UTC timestamp entering the segment start corridor"
+          },
+          "effort_end": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Effort End",
+            "description": "UTC timestamp reaching the segment end corridor"
+          },
+          "elapsed_seconds": {
+            "type": "number",
+            "title": "Elapsed Seconds",
+            "description": "Segment elapsed time in seconds"
+          },
+          "distance_km": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Km",
+            "description": "Distance covered across the segment in km"
+          },
+          "avg_speed_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Speed Kmh",
+            "description": "Average speed across the segment in km/h"
+          },
+          "avg_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Heart Rate",
+            "description": "Average heart rate across the segment in bpm"
+          },
+          "max_heart_rate": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Heart Rate",
+            "description": "Maximum heart rate across the segment in bpm"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rank",
+          "activity_id",
+          "effort_start",
+          "effort_end",
+          "elapsed_seconds"
+        ],
+        "title": "SegmentEffort",
+        "description": "A single activity's best traversal of a segment, for cross-activity comparison."
+      },
+      "SegmentEffortsResponse": {
+        "properties": {
+          "segment": {
+            "$ref": "#/components/schemas/SegmentDefinition",
+            "description": "The queried segment definition"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Number of matching efforts returned"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SegmentEffort"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "Efforts ordered fastest-first"
+          }
+        },
+        "type": "object",
+        "required": [
+          "segment",
+          "total",
+          "items"
+        ],
+        "title": "SegmentEffortsResponse",
+        "description": "Ranked efforts for a segment across all matching activities."
       },
       "SportInfo": {
         "properties": {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -2207,7 +2207,10 @@ export type components = {
              * Route
              * @description Ordered [latitude, longitude] pairs tracing the segment path, recovered and simplified from the source activity's GPS track. Null when no source activity track can be matched.
              */
-            route?: number[][] | null;
+            route?: [
+                number,
+                number
+            ][] | null;
         };
         /**
          * GarminSegmentCreate

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -436,6 +436,107 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/garmin/segment-efforts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Segment Efforts
+         * @description Rank activity efforts over an ad-hoc segment defined by start/end coordinates.
+         *
+         *     Matches raw GPS track points with PostGIS: an activity qualifies when its
+         *     route passes within ``tolerance_meters`` of the start point and, later in
+         *     time, within tolerance of the end point (same direction of travel). For each
+         *     activity the shortest such start→end traversal is used, and efforts are
+         *     ranked fastest-first. Stateless (no stored segment) — the coordinate pair can
+         *     be sourced from a detected climb or lap.
+         */
+        get: operations["list_segment_efforts_api_v1_garmin_segment_efforts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/garmin/segments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Segments
+         * @description List saved segments (paths), newest first.
+         */
+        get: operations["list_segments_api_v1_garmin_segments_get"];
+        put?: never;
+        /**
+         * Create Segment
+         * @description Save a new segment (path) from a climb, lap, or manual selection (auth required).
+         */
+        post: operations["create_segment_api_v1_garmin_segments_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/garmin/segments/{segment_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Segment
+         * @description Get a single saved segment by ID.
+         */
+        get: operations["get_segment_api_v1_garmin_segments__segment_id__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Segment
+         * @description Delete a saved segment (auth required).
+         *
+         *     If the segment has been pushed to Garmin Connect (``garmin_segment_uuid`` is
+         *     set) it is marked ``delete_pending`` so the garmin-sync agent removes it from
+         *     Garmin and then deletes the row (end-to-end delete). Segments that were never
+         *     synced are removed immediately. Either way the segment stops appearing in the
+         *     read endpoints right away.
+         */
+        delete: operations["delete_segment_api_v1_garmin_segments__segment_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/garmin/segments/{segment_id}/efforts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Segment Efforts
+         * @description Rank activity efforts over a saved segment (matches the saved start/end corridor).
+         */
+        get: operations["get_segment_efforts_api_v1_garmin_segments__segment_id__efforts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/gps/unified": {
         parameters: {
             query?: never;
@@ -2028,6 +2129,150 @@ export type components = {
             total_ascent_m?: number | null;
         };
         /**
+         * GarminSegment
+         * @description A saved named segment (path) for cross-activity effort comparison.
+         */
+        GarminSegment: {
+            /**
+             * Id
+             * @description Unique saved segment identifier
+             */
+            id: number;
+            /**
+             * Name
+             * @description Human-readable segment name
+             */
+            name: string;
+            /**
+             * Sport
+             * @description Sport type (e.g. cycling)
+             */
+            sport?: string | null;
+            /**
+             * Start Latitude
+             * @description Segment start latitude
+             */
+            start_latitude: number;
+            /**
+             * Start Longitude
+             * @description Segment start longitude
+             */
+            start_longitude: number;
+            /**
+             * End Latitude
+             * @description Segment end latitude
+             */
+            end_latitude: number;
+            /**
+             * End Longitude
+             * @description Segment end longitude
+             */
+            end_longitude: number;
+            /**
+             * Distance Meters
+             * @description Segment distance in meters
+             */
+            distance_meters?: number | null;
+            /**
+             * Match Tolerance Meters
+             * @description Corridor radius (m) used to match traversing activities
+             */
+            match_tolerance_meters: number;
+            /**
+             * Source Activity Id
+             * @description Activity the segment was created from
+             */
+            source_activity_id?: string | null;
+            /**
+             * Source Lap Index
+             * @description Lap index the segment was created from
+             */
+            source_lap_index?: number | null;
+            /**
+             * Source Climb Index
+             * @description Climb split index the segment was created from
+             */
+            source_climb_index?: number | null;
+            /**
+             * Created At
+             * @description UTC creation timestamp
+             */
+            created_at?: string | null;
+            /**
+             * Updated At
+             * @description UTC last-update timestamp
+             */
+            updated_at?: string | null;
+            /**
+             * Route
+             * @description Ordered [latitude, longitude] pairs tracing the segment path, recovered and simplified from the source activity's GPS track. Null when no source activity track can be matched.
+             */
+            route?: number[][] | null;
+        };
+        /**
+         * GarminSegmentCreate
+         * @description Request body to save a new segment (path).
+         */
+        GarminSegmentCreate: {
+            /**
+             * Name
+             * @description Human-readable segment name
+             */
+            name: string;
+            /**
+             * Sport
+             * @description Sport type; defaults to cycling
+             * @default cycling
+             */
+            sport: string | null;
+            /**
+             * Start Latitude
+             * @description Segment start latitude
+             */
+            start_latitude: number;
+            /**
+             * Start Longitude
+             * @description Segment start longitude
+             */
+            start_longitude: number;
+            /**
+             * End Latitude
+             * @description Segment end latitude
+             */
+            end_latitude: number;
+            /**
+             * End Longitude
+             * @description Segment end longitude
+             */
+            end_longitude: number;
+            /**
+             * Distance Meters
+             * @description Segment distance in meters
+             */
+            distance_meters?: number | null;
+            /**
+             * Match Tolerance Meters
+             * @description Corridor radius (m) used to match traversing activities
+             * @default 35
+             */
+            match_tolerance_meters: number;
+            /**
+             * Source Activity Id
+             * @description Activity the segment was created from
+             */
+            source_activity_id?: string | null;
+            /**
+             * Source Lap Index
+             * @description Lap index the segment was created from
+             */
+            source_lap_index?: number | null;
+            /**
+             * Source Climb Index
+             * @description Climb split index the segment was created from
+             */
+            source_climb_index?: number | null;
+        };
+        /**
          * GarminSyncResponse
          * @description Response payload for Garmin on-demand sync trigger requests.
          * @example {
@@ -3118,6 +3363,118 @@ export type components = {
             description?: string | null;
         };
         /**
+         * SegmentDefinition
+         * @description The ad-hoc segment queried for efforts (a start→end corridor).
+         */
+        SegmentDefinition: {
+            /**
+             * Start Lat
+             * @description Segment start latitude
+             */
+            start_lat: number;
+            /**
+             * Start Lon
+             * @description Segment start longitude
+             */
+            start_lon: number;
+            /**
+             * End Lat
+             * @description Segment end latitude
+             */
+            end_lat: number;
+            /**
+             * End Lon
+             * @description Segment end longitude
+             */
+            end_lon: number;
+            /**
+             * Tolerance Meters
+             * @description Corridor radius around the start/end points in meters
+             */
+            tolerance_meters: number;
+        };
+        /**
+         * SegmentEffort
+         * @description A single activity's best traversal of a segment, for cross-activity comparison.
+         */
+        SegmentEffort: {
+            /**
+             * Rank
+             * @description 1-based rank by elapsed time (1 = fastest)
+             */
+            rank: number;
+            /**
+             * Activity Id
+             * @description Garmin activity identifier
+             */
+            activity_id: string;
+            /**
+             * Sport
+             * @description Sport type (e.g. cycling)
+             */
+            sport?: string | null;
+            /**
+             * Activity Start Time
+             * @description UTC start time of the parent activity
+             */
+            activity_start_time?: string | null;
+            /**
+             * Effort Start
+             * Format: date-time
+             * @description UTC timestamp entering the segment start corridor
+             */
+            effort_start: string;
+            /**
+             * Effort End
+             * Format: date-time
+             * @description UTC timestamp reaching the segment end corridor
+             */
+            effort_end: string;
+            /**
+             * Elapsed Seconds
+             * @description Segment elapsed time in seconds
+             */
+            elapsed_seconds: number;
+            /**
+             * Distance Km
+             * @description Distance covered across the segment in km
+             */
+            distance_km?: number | null;
+            /**
+             * Avg Speed Kmh
+             * @description Average speed across the segment in km/h
+             */
+            avg_speed_kmh?: number | null;
+            /**
+             * Avg Heart Rate
+             * @description Average heart rate across the segment in bpm
+             */
+            avg_heart_rate?: number | null;
+            /**
+             * Max Heart Rate
+             * @description Maximum heart rate across the segment in bpm
+             */
+            max_heart_rate?: number | null;
+        };
+        /**
+         * SegmentEffortsResponse
+         * @description Ranked efforts for a segment across all matching activities.
+         */
+        SegmentEffortsResponse: {
+            /** @description The queried segment definition */
+            segment: components["schemas"]["SegmentDefinition"];
+            /**
+             * Total
+             * @description Number of matching efforts returned
+             */
+            total: number;
+            /**
+             * Items
+             * @description Efforts ordered fastest-first
+             */
+            items: components["schemas"]["SegmentEffort"][];
+        };
+        /**
          * SportInfo
          * @description Sport type with its activity count.
          * @example {
@@ -4009,6 +4366,238 @@ export interface operations {
                 };
             };
             /** @description Activity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_segment_efforts_api_v1_garmin_segment_efforts_get: {
+        parameters: {
+            query: {
+                /** @description Segment start latitude */
+                start_lat: number;
+                /** @description Segment start longitude */
+                start_lon: number;
+                /** @description Segment end latitude */
+                end_lat: number;
+                /** @description Segment end longitude */
+                end_lon: number;
+                /** @description Corridor radius around the start/end points in meters */
+                tolerance_meters?: number;
+                /** @description Filter by sport type; pass an empty value to include all sports */
+                sport?: string | null;
+                /** @description Filter from date (YYYY-MM-DD) on activity start_time */
+                date_from?: string | null;
+                /** @description Filter to date (YYYY-MM-DD) on activity start_time */
+                date_to?: string | null;
+                /** @description Ignore traversals longer than this (filters loop/return mismatches) */
+                max_effort_seconds?: number;
+                /** @description Maximum number of efforts to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SegmentEffortsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_segments_api_v1_garmin_segments_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by sport type */
+                sport?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GarminSegment"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_segment_api_v1_garmin_segments_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GarminSegmentCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GarminSegment"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_segment_api_v1_garmin_segments__segment_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Saved segment ID */
+                segment_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GarminSegment"];
+                };
+            };
+            /** @description Segment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_segment_api_v1_garmin_segments__segment_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Saved segment ID */
+                segment_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_segment_efforts_api_v1_garmin_segments__segment_id__efforts_get: {
+        parameters: {
+            query?: {
+                /** @description Filter from date (YYYY-MM-DD) on activity start_time */
+                date_from?: string | null;
+                /** @description Filter to date (YYYY-MM-DD) on activity start_time */
+                date_to?: string | null;
+                /** @description Ignore traversals longer than this */
+                max_effort_seconds?: number;
+                /** @description Maximum number of efforts to return */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Saved segment ID */
+                segment_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SegmentEffortsResponse"];
+                };
+            };
+            /** @description Segment not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1546,7 +1546,7 @@ async def test_segment_efforts_requires_coordinates(client: AsyncClient, mock_db
     assert response.status_code == 422
 
 
-def _segment_row(segment_id: int = 1) -> dict:
+def _segment_row(segment_id: int = 1, route: list[list[float]] | None = None) -> dict:
     return {
         "id": segment_id,
         "name": "Harlem Hill",
@@ -1562,6 +1562,7 @@ def _segment_row(segment_id: int = 1) -> dict:
         "source_climb_index": 0,
         "created_at": datetime(2026, 7, 6, 12, 0, 0),
         "updated_at": datetime(2026, 7, 6, 12, 0, 0),
+        "route": route,
     }
 
 
@@ -1609,6 +1610,37 @@ async def test_list_segments(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_list_segments_returns_route(client: AsyncClient, mock_db):
+    route = [
+        [40.79366846, -73.96104321],
+        [40.79200000, -73.96250000],
+        [40.79002409, -73.96422816],
+    ]
+    mock_db.fetch.return_value = [_segment_row(1, route=route)]
+
+    response = await client.get("/api/v1/garmin/segments")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["route"] == route
+    query, *_ = mock_db.fetch.await_args.args
+    # Route is recovered server-side via a PostGIS LATERAL corridor slice.
+    assert "LEFT JOIN LATERAL" in query
+    assert "ST_DWithin" in query
+    assert "ST_Simplify" in query
+
+
+@pytest.mark.asyncio
+async def test_list_segments_null_route(client: AsyncClient, mock_db):
+    mock_db.fetch.return_value = [_segment_row(1, route=None)]
+
+    response = await client.get("/api/v1/garmin/segments")
+
+    assert response.status_code == 200
+    assert response.json()[0]["route"] is None
+
+
+@pytest.mark.asyncio
 async def test_get_segment_success(client: AsyncClient, mock_db):
     mock_db.fetchrow.return_value = _segment_row(3)
 
@@ -1616,6 +1648,19 @@ async def test_get_segment_success(client: AsyncClient, mock_db):
 
     assert response.status_code == 200
     assert response.json()["id"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_segment_returns_route(client: AsyncClient, mock_db):
+    route = [[40.79366846, -73.96104321], [40.79002409, -73.96422816]]
+    mock_db.fetchrow.return_value = _segment_row(3, route=route)
+
+    response = await client.get("/api/v1/garmin/segments/3")
+
+    assert response.status_code == 200
+    assert response.json()["route"] == route
+    query, *_ = mock_db.fetchrow.await_args.args
+    assert "LEFT JOIN LATERAL" in query
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Recovers each saved Garmin segment's **real path** server-side and returns it
inline in the `/segments` responses, so clients (via the gateway/UI) no longer
need a per-card chart-data fetch to draw the segment path. Follow-up to #305
(otel-data-ui segment list mini maps).

## Changes

- Add nullable `GarminSegment.route` — an ordered list of `[latitude, longitude]`
  pairs tracing the segment path.
- Compute `route` in `GET /api/v1/garmin/segments` and
  `GET /api/v1/garmin/segments/{id}` via a `LEFT JOIN LATERAL` PostGIS subquery
  that snaps the stored start/end to the nearest in-corridor track points
  (`ST_DWithin`, the same corridor used by segment efforts), slices the ordered
  track between them, and simplifies it with `ST_Simplify` (same construct as the
  track simplify endpoint).
- Returns `route: null` when the segment has no `source_activity_id` or no
  matchable corridor — the client falls back to a straight start→end line.
- No DB migration (derived purely from `garmin_track_points`).
- Regenerated `docs/openapi.json` and `packages/otel-data-types/index.d.ts`
  (`route?: number[][] | null`).

## Type of Change

- [x] New endpoint field / API response change
- [x] GraphQL query / mutation change (downstream)

## Testing

```bash
make test          # 223 passed, coverage gate green
pre-commit run -a  # all hooks pass
bash scripts/generate-types.sh
```

- Added `test_list_segments_returns_route`, `test_list_segments_null_route`, and
  `test_get_segment_returns_route`.

## Notes / risk

- No DB access in the dev sandbox, so the LATERAL SQL is not executed against a
  live PostGIS instance in unit tests (they mock the DB layer, matching existing
  segment tests). The SQL reuses the already-proven `ST_DWithin` corridor and
  `ST_Simplify(ST_MakeLine(... ORDER BY timestamp))` constructs from
  `_fetch_segment_efforts` and the track simplify endpoint. Worth a quick
  in-cluster `EXPLAIN`/timing sanity check during post-deploy validation.

## Downstream (tracked separately)

1. otel-data-gateway: expose `GarminSegment.route` in the GraphQL schema (blocked
   on the `@stuartshay/otel-data-types` publish from this PR).
2. otel-data-ui: consume `segment.route` in the list mini map and remove the
   per-card chart fetch.

Refs #194