### PR TITLE
Fix JWT signing key header handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,22 @@ git fetch origin master && git rebase origin/master
 This is especially important after squash merges, which cause develop to
 diverge from master.
 
+### Responding to PR Review Comments
+
+⚠️ **ALWAYS reply to each addressed PR review comment.**
+
+When making changes in response to GitHub PR review comments:
+
+1. Implement the requested code or documentation change.
+2. Run the relevant validation commands.
+3. Push the fix commit.
+4. Reply directly on every addressed review thread with:
+   - what changed,
+   - the commit SHA, and
+   - the validation commands that passed.
+5. Do not rely only on pushing code; leave the thread response so reviewers can
+   audit how each comment was handled.
+
 ### After Deployment (Required)
 
 ⚠️ **ALWAYS verify linked issue acceptance criteria after cluster deployment**

--- a/app/auth.py
+++ b/app/auth.py
@@ -67,9 +67,10 @@ def _decode_token_header(token: str) -> dict[str, Any]:
     header_segment = parts[0]
     padding = "=" * (-len(header_segment) % 4)
     try:
-        header_bytes = base64.urlsafe_b64decode(f"{header_segment}{padding}")
+        header_input = f"{header_segment}{padding}".encode("ascii")
+        header_bytes = base64.urlsafe_b64decode(header_input)
         header = json.loads(header_bytes.decode("utf-8"))
-    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError) as e:
+    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError, UnicodeEncodeError) as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=_JWT_INVALID_HEADER_DETAIL,
@@ -100,6 +101,9 @@ def _authentication_service_unavailable() -> HTTPException:
 def _get_signing_key(token_header: dict[str, Any], jwks_data: dict[str, Any]) -> dict[str, Any]:
     """Find the signing key for the given token from JWKS."""
     kid = token_header["kid"]
+    if not isinstance(jwks_data, dict):
+        raise _authentication_service_unavailable()
+
     keys = jwks_data.get("keys")
     if not isinstance(keys, list):
         raise _authentication_service_unavailable()

--- a/app/auth.py
+++ b/app/auth.py
@@ -25,6 +25,7 @@ _oauth2_enabled: bool = False
 _JWT_HEADER_SEGMENTS = 3
 _JWT_ALGORITHM = "RS256"
 _JWT_INVALID_HEADER_DETAIL = "Invalid token header"
+_AUTH_SERVICE_UNAVAILABLE_DETAIL = "Authentication service unavailable"
 
 
 def configure_auth(issuer: str, client_id: str, enabled: bool) -> None:
@@ -89,11 +90,23 @@ def _decode_token_header(token: str) -> dict[str, Any]:
     return header
 
 
-def _get_signing_key(token: str, jwks_data: dict[str, Any]) -> dict[str, Any]:
+def _authentication_service_unavailable() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=_AUTH_SERVICE_UNAVAILABLE_DETAIL,
+    )
+
+
+def _get_signing_key(token_header: dict[str, Any], jwks_data: dict[str, Any]) -> dict[str, Any]:
     """Find the signing key for the given token from JWKS."""
-    token_header = _decode_token_header(token)
     kid = token_header["kid"]
-    for key in jwks_data.get("keys", []):
+    keys = jwks_data.get("keys")
+    if not isinstance(keys, list):
+        raise _authentication_service_unavailable()
+
+    for key in keys:
+        if not isinstance(key, dict):
+            raise _authentication_service_unavailable()
         if key.get("kid") == kid:
             return dict(key)
     raise HTTPException(
@@ -117,8 +130,9 @@ async def get_current_user(
 
     token = credentials.credentials
     try:
+        token_header = _decode_token_header(token)
         jwks_data = await _get_jwks()
-        signing_key = _get_signing_key(token, jwks_data)
+        signing_key = _get_signing_key(token_header, jwks_data)
         public_key = jwk.construct(signing_key)
 
         claims = jwt.decode(
@@ -137,10 +151,7 @@ async def get_current_user(
         ) from e
     except httpx.HTTPError as e:
         logger.error("Failed to fetch JWKS: %s", e)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Authentication service unavailable",
-        ) from e
+        raise _authentication_service_unavailable() from e
 
 
 async def require_auth(

--- a/app/auth.py
+++ b/app/auth.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 from typing import Any
 
 import httpx
@@ -19,6 +22,9 @@ _jwks_cache: dict[str, Any] = {}
 _cognito_issuer: str = ""
 _cognito_client_id: str = ""
 _oauth2_enabled: bool = False
+_JWT_HEADER_SEGMENTS = 3
+_JWT_ALGORITHM = "RS256"
+_JWT_INVALID_HEADER_DETAIL = "Invalid token header"
 
 
 def configure_auth(issuer: str, client_id: str, enabled: bool) -> None:
@@ -43,10 +49,50 @@ async def _get_jwks() -> dict[str, Any]:
     return _jwks_cache
 
 
+def _decode_token_header(token: str) -> dict[str, Any]:
+    """Decode and validate the JWT header before signature verification.
+
+    The header is not trusted for authentication decisions; it is only used to
+    select the matching JWKS key. The token signature, audience, and issuer are
+    still verified by ``jwt.decode`` after the key is selected.
+    """
+    parts = token.split(".")
+    if len(parts) != _JWT_HEADER_SEGMENTS:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_JWT_INVALID_HEADER_DETAIL,
+        )
+
+    header_segment = parts[0]
+    padding = "=" * (-len(header_segment) % 4)
+    try:
+        header_bytes = base64.urlsafe_b64decode(f"{header_segment}{padding}")
+        header = json.loads(header_bytes.decode("utf-8"))
+    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_JWT_INVALID_HEADER_DETAIL,
+        ) from e
+
+    if not isinstance(header, dict):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_JWT_INVALID_HEADER_DETAIL,
+        )
+
+    if header.get("alg") != _JWT_ALGORITHM or not isinstance(header.get("kid"), str):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_JWT_INVALID_HEADER_DETAIL,
+        )
+
+    return header
+
+
 def _get_signing_key(token: str, jwks_data: dict[str, Any]) -> dict[str, Any]:
     """Find the signing key for the given token from JWKS."""
-    unverified_header: dict[str, Any] = jwt.get_unverified_header(token)
-    kid = unverified_header.get("kid")
+    token_header = _decode_token_header(token)
+    kid = token_header["kid"]
     for key in jwks_data.get("keys", []):
         if key.get("kid") == kid:
             return dict(key)
@@ -78,7 +124,7 @@ async def get_current_user(
         claims = jwt.decode(
             token,
             public_key.to_pem().decode("utf-8"),
-            algorithms=["RS256"],
+            algorithms=[_JWT_ALGORITHM],
             audience=_cognito_client_id,
             issuer=_cognito_issuer,
         )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -10,6 +12,11 @@ from fastapi import HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 
 from app import auth
+
+
+def _token_with_header(header: dict[str, object]) -> str:
+    encoded_header = base64.urlsafe_b64encode(json.dumps(header).encode("utf-8")).decode("ascii").rstrip("=")
+    return f"{encoded_header}.payload.signature"
 
 
 @pytest.fixture(autouse=True)
@@ -40,9 +47,10 @@ async def test_get_current_user_requires_header_when_enabled():
 async def test_get_current_user_missing_signing_key(monkeypatch: pytest.MonkeyPatch):
     auth.configure_auth("https://issuer", "client123", True)
 
-    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_token_with_header({"alg": "RS256", "kid": "missing"})
+    )
     monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": [{"kid": "other"}]}))
-    monkeypatch.setattr(auth.jwt, "get_unverified_header", lambda _token: {"kid": "missing"})
 
     with pytest.raises(HTTPException) as exc:
         await auth.get_current_user(credentials)
@@ -55,9 +63,9 @@ async def test_get_current_user_missing_signing_key(monkeypatch: pytest.MonkeyPa
 async def test_get_current_user_success(monkeypatch: pytest.MonkeyPatch):
     auth.configure_auth("https://issuer", "client123", True)
 
-    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token-abc")
+    token = _token_with_header({"alg": "RS256", "kid": "kid1"})
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
     monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": [{"kid": "kid1"}]}))
-    monkeypatch.setattr(auth.jwt, "get_unverified_header", lambda _token: {"kid": "kid1"})
 
     class DummyKey:
         def to_pem(self) -> bytes:
@@ -70,7 +78,7 @@ async def test_get_current_user_success(monkeypatch: pytest.MonkeyPatch):
     claims = await auth.get_current_user(credentials)
 
     decode_mock.assert_called_once_with(
-        "token-abc",
+        token,
         "pem-key",
         algorithms=["RS256"],
         audience="client123",
@@ -82,16 +90,47 @@ async def test_get_current_user_success(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.asyncio
 async def test_get_current_user_jwks_failure(monkeypatch: pytest.MonkeyPatch):
     auth.configure_auth("https://issuer", "client123", True)
-    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token-abc")
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials=_token_with_header({"alg": "RS256", "kid": "kid1"}),
+    )
 
     monkeypatch.setattr(auth, "_get_jwks", AsyncMock(side_effect=httpx.HTTPError("offline")))
-    monkeypatch.setattr(auth.jwt, "get_unverified_header", lambda _token: {"kid": "kid1"})
 
     with pytest.raises(HTTPException) as exc:
         await auth.get_current_user(credentials)
 
     assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert exc.value.detail == "Authentication service unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_malformed_jwt_header(monkeypatch: pytest.MonkeyPatch):
+    auth.configure_auth("https://issuer", "client123", True)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="not-a-jwt")
+    monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": [{"kid": "kid1"}]}))
+
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials)
+
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc.value.detail == "Invalid token header"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_unexpected_jwt_algorithm(monkeypatch: pytest.MonkeyPatch):
+    auth.configure_auth("https://issuer", "client123", True)
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials=_token_with_header({"alg": "none", "kid": "kid1"}),
+    )
+    monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": [{"kid": "kid1"}]}))
+
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials)
+
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc.value.detail == "Invalid token header"
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -105,16 +105,34 @@ async def test_get_current_user_jwks_failure(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.asyncio
+async def test_get_current_user_invalid_jwks_shape_returns_503(monkeypatch: pytest.MonkeyPatch):
+    auth.configure_auth("https://issuer", "client123", True)
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials=_token_with_header({"alg": "RS256", "kid": "kid1"}),
+    )
+    monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": ["not-a-key"]}))
+
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials)
+
+    assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert exc.value.detail == "Authentication service unavailable"
+
+
+@pytest.mark.asyncio
 async def test_get_current_user_rejects_malformed_jwt_header(monkeypatch: pytest.MonkeyPatch):
     auth.configure_auth("https://issuer", "client123", True)
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="not-a-jwt")
-    monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": [{"kid": "kid1"}]}))
+    get_jwks = AsyncMock(return_value={"keys": [{"kid": "kid1"}]})
+    monkeypatch.setattr(auth, "_get_jwks", get_jwks)
 
     with pytest.raises(HTTPException) as exc:
         await auth.get_current_user(credentials)
 
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert exc.value.detail == "Invalid token header"
+    get_jwks.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -124,13 +142,15 @@ async def test_get_current_user_rejects_unexpected_jwt_algorithm(monkeypatch: py
         scheme="Bearer",
         credentials=_token_with_header({"alg": "none", "kid": "kid1"}),
     )
-    monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value={"keys": [{"kid": "kid1"}]}))
+    get_jwks = AsyncMock(return_value={"keys": [{"kid": "kid1"}]})
+    monkeypatch.setattr(auth, "_get_jwks", get_jwks)
 
     with pytest.raises(HTTPException) as exc:
         await auth.get_current_user(credentials)
 
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert exc.value.detail == "Invalid token header"
+    get_jwks.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -121,9 +121,40 @@ async def test_get_current_user_invalid_jwks_shape_returns_503(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
+async def test_get_current_user_invalid_jwks_top_level_shape_returns_503(monkeypatch: pytest.MonkeyPatch):
+    auth.configure_auth("https://issuer", "client123", True)
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials=_token_with_header({"alg": "RS256", "kid": "kid1"}),
+    )
+    monkeypatch.setattr(auth, "_get_jwks", AsyncMock(return_value=[]))
+
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials)
+
+    assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert exc.value.detail == "Authentication service unavailable"
+
+
+@pytest.mark.asyncio
 async def test_get_current_user_rejects_malformed_jwt_header(monkeypatch: pytest.MonkeyPatch):
     auth.configure_auth("https://issuer", "client123", True)
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="not-a-jwt")
+    get_jwks = AsyncMock(return_value={"keys": [{"kid": "kid1"}]})
+    monkeypatch.setattr(auth, "_get_jwks", get_jwks)
+
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials)
+
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc.value.detail == "Invalid token header"
+    get_jwks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_rejects_non_ascii_jwt_header(monkeypatch: pytest.MonkeyPatch):
+    auth.configure_auth("https://issuer", "client123", True)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="é.payload.signature")
     get_jwks = AsyncMock(return_value={"keys": [{"kid": "kid1"}]})
     monkeypatch.setattr(auth, "_get_jwks", get_jwks)
 


### PR DESCRIPTION
## Summary

Addresses the SonarQube critical JWT finding in `app/auth.py` by removing use of `jwt.get_unverified_header()` for signing-key selection.

## Changes

- Decode only the JWT header segment with local base64url/json parsing to read `kid`.
- Validate the header shape and require `alg == RS256` before selecting a JWKS key.
- Keep actual authentication verification in `jwt.decode()` with signature, audience, and issuer checks.
- Add auth tests for malformed JWT headers and unexpected algorithms.

## Validation

- `. venv/bin/activate && pytest -o cache_dir=/tmp/.pytest_cache tests/test_auth.py -q`
- `make test`
- `pre-commit run -a`

## Notes

This PR is intentionally scoped to the first critical SonarQube issue batch: JWT signing-key header handling.
