### PR TITLE
Refactor request logging middleware

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -21,6 +21,86 @@ SPAN_ID_HEADER = "X-Span-Id"
 
 # Paths excluded from request logging (health probes generate too much noise)
 _EXCLUDED_PATHS: set[str] = {"/health", "/ready"}
+_HTTP_REQUEST_LOG_MESSAGE = "HTTP request"
+
+
+def _current_trace_ids() -> tuple[str | None, str | None]:
+    trace_id, span_id = _otel_trace_ids()
+    if trace_id:
+        return trace_id, span_id
+    return _new_relic_trace_ids()
+
+
+def _otel_trace_ids() -> tuple[str | None, str | None]:
+    try:
+        span = otel_trace.get_current_span()
+        ctx = span.get_span_context()
+        if ctx and ctx.trace_id:
+            return format(ctx.trace_id, "032x"), format(ctx.span_id, "016x")
+    except Exception:  # noqa: BLE001
+        pass
+    return None, None
+
+
+def _new_relic_trace_ids() -> tuple[str | None, str | None]:
+    try:
+        import newrelic.agent  # pyright: ignore[reportMissingImports]
+
+        return newrelic.agent.current_trace_id(), newrelic.agent.current_span_id()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def _set_trace_headers(response: Response, trace_id: str | None, span_id: str | None) -> None:
+    if trace_id:
+        response.headers[TRACE_ID_HEADER] = trace_id
+    if span_id:
+        response.headers[SPAN_ID_HEADER] = span_id
+
+
+def _request_url(request: Request, include_query_params: bool) -> str:
+    if include_query_params:
+        return str(request.url)
+    return f"{request.url.scheme}://{request.url.netloc}{request.url.path}"
+
+
+def _request_log_kwargs(
+    request: Request,
+    response: Response,
+    duration_ms: float,
+    trace_id: str | None,
+    span_id: str | None,
+    include_query_params: bool,
+) -> dict[str, Any]:
+    log_kwargs: dict[str, Any] = {
+        "http.method": request.method,
+        "http.route": request.url.path,
+        "http.status_code": response.status_code,
+        "http.url": _request_url(request, include_query_params),
+        "duration_ms": round(duration_ms, 2),
+        "client.address": request.client.host if request.client else None,
+    }
+
+    if include_query_params:
+        query_params = dict(request.query_params)
+        if query_params:
+            log_kwargs["http.query_params"] = query_params
+
+    if trace_id:
+        log_kwargs["trace.id"] = trace_id
+    if span_id:
+        log_kwargs["span.id"] = span_id
+
+    return log_kwargs
+
+
+def _log_request(status_code: int, log_kwargs: dict[str, Any]) -> None:
+    if status_code >= 500:
+        logger.error(_HTTP_REQUEST_LOG_MESSAGE, **log_kwargs)
+    elif status_code >= 400:
+        logger.warning(_HTTP_REQUEST_LOG_MESSAGE, **log_kwargs)
+    else:
+        logger.info(_HTTP_REQUEST_LOG_MESSAGE, **log_kwargs)
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
@@ -40,67 +120,19 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         duration_ms = (time.perf_counter() - start) * 1000.0
 
-        # --- Trace correlation headers (OTel-native with NR fallback) ---
-        trace_id: str | None = None
-        span_id: str | None = None
-        try:
-            span = otel_trace.get_current_span()
-            ctx = span.get_span_context()
-            if ctx and ctx.trace_id:
-                trace_id = format(ctx.trace_id, "032x")
-                span_id = format(ctx.span_id, "016x")
-        except Exception:  # noqa: BLE001
-            pass
+        trace_id, span_id = _current_trace_ids()
+        _set_trace_headers(response, trace_id, span_id)
 
-        # Fallback to New Relic agent if OTel didn't provide IDs
-        if not trace_id:
-            try:
-                import newrelic.agent  # pyright: ignore[reportMissingImports]
-
-                trace_id = newrelic.agent.current_trace_id()
-                span_id = newrelic.agent.current_span_id()
-            except Exception:  # noqa: BLE001
-                pass
-
-        if trace_id:
-            response.headers[TRACE_ID_HEADER] = trace_id
-        if span_id:
-            response.headers[SPAN_ID_HEADER] = span_id
-
-        # --- Request logging ---
         path = request.url.path
         if path not in _EXCLUDED_PATHS:
-            url = (
-                str(request.url)
-                if self._log_query_params
-                else f"{request.url.scheme}://{request.url.netloc}{request.url.path}"
+            log_kwargs = _request_log_kwargs(
+                request,
+                response,
+                duration_ms,
+                trace_id,
+                span_id,
+                self._log_query_params,
             )
-            log_kwargs: dict[str, Any] = {
-                "http.method": request.method,
-                "http.route": path,
-                "http.status_code": response.status_code,
-                "http.url": url,
-                "duration_ms": round(duration_ms, 2),
-                "client.address": request.client.host if request.client else None,
-            }
-
-            # Include query parameters when present and allowed by config
-            if self._log_query_params:
-                query_params = dict(request.query_params)
-                if query_params:
-                    log_kwargs["http.query_params"] = query_params
-
-            if trace_id:
-                log_kwargs["trace.id"] = trace_id
-            if span_id:
-                log_kwargs["span.id"] = span_id
-
-            status_code = response.status_code
-            if status_code >= 500:
-                logger.error("HTTP request", **log_kwargs)
-            elif status_code >= 400:
-                logger.warning("HTTP request", **log_kwargs)
-            else:
-                logger.info("HTTP request", **log_kwargs)
+            _log_request(response.status_code, log_kwargs)
 
         return response

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
+from app.middleware import _log_request, _request_log_kwargs
+
 
 @pytest.mark.asyncio
 async def test_trace_headers_from_otel(client: AsyncClient):
@@ -89,3 +91,57 @@ async def test_non_health_endpoint_produces_log(client: AsyncClient):
             mock_logger.info.call_args_list + mock_logger.warning.call_args_list + mock_logger.error.call_args_list
         )
         assert any(c.args[0] == "HTTP request" for c in all_calls if c.args)
+
+
+def test_log_request_uses_status_code_severity():
+    """Request log helper maps response status codes to expected levels."""
+    log_kwargs = {"http.method": "GET"}
+
+    with patch("app.middleware.logger") as mock_logger:
+        _log_request(200, log_kwargs)
+        _log_request(404, log_kwargs)
+        _log_request(500, log_kwargs)
+
+    mock_logger.info.assert_called_once_with("HTTP request", **log_kwargs)
+    mock_logger.warning.assert_called_once_with("HTTP request", **log_kwargs)
+    mock_logger.error.assert_called_once_with("HTTP request", **log_kwargs)
+
+
+def test_request_log_kwargs_includes_trace_and_query_params():
+    """Request log field helper includes trace context and query params."""
+    request = MagicMock()
+    request.method = "GET"
+    request.url.path = "/api/v1/locations/status"
+    request.url.__str__.return_value = "https://api.example.test/api/v1/locations/status?device_id=phone"
+    request.query_params = {"device_id": "phone"}
+    request.client.host = "127.0.0.1"
+
+    response = MagicMock()
+    response.status_code = 200
+
+    log_kwargs = _request_log_kwargs(request, response, 12.345, "trace-1", "span-1", True)
+
+    assert log_kwargs["http.url"] == "https://api.example.test/api/v1/locations/status?device_id=phone"
+    assert log_kwargs["http.query_params"] == {"device_id": "phone"}
+    assert log_kwargs["trace.id"] == "trace-1"
+    assert log_kwargs["span.id"] == "span-1"
+    assert log_kwargs["duration_ms"] == 12.35
+
+
+def test_request_log_kwargs_omits_query_params_when_disabled():
+    """Request log field helper omits query params when configured off."""
+    request = MagicMock()
+    request.method = "GET"
+    request.url.scheme = "https"
+    request.url.netloc = "api.example.test"
+    request.url.path = "/api/v1/locations/status"
+    request.query_params = {"device_id": "phone"}
+    request.client.host = "127.0.0.1"
+
+    response = MagicMock()
+    response.status_code = 200
+
+    log_kwargs = _request_log_kwargs(request, response, 1.0, None, None, False)
+
+    assert log_kwargs["http.url"] == "https://api.example.test/api/v1/locations/status"
+    assert "http.query_params" not in log_kwargs


### PR DESCRIPTION
## Summary

Refactors the request logging middleware to address the next critical Sonar batch by reducing cognitive complexity in `RequestLoggingMiddleware.dispatch()` and extracting the repeated HTTP request log message literal.

## Changes

- Extracts trace ID lookup into OpenTelemetry and New Relic helper functions.
- Extracts trace response header handling, request URL formatting, log field construction, and status-based log severity selection.
- Keeps the middleware behavior unchanged while making `dispatch()` responsible for orchestration only.
- Adds focused tests for request log field construction and status-code severity routing.

## Validation

- `pytest -o cache_dir=/tmp/.pytest_cache tests/test_middleware.py -q`
- `pre-commit run -a`
- `make test`