### PR TITLE
fix(sonar): document raised HTTPException status codes (S8415)

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -46,6 +46,12 @@ DESC_SAVED_SEGMENT_ID = "Saved segment ID"
 ACTIVITY_NOT_FOUND = "Activity not found"
 SEGMENT_NOT_FOUND = "Segment not found"
 INVALID_SYNC_RESPONSE = "Invalid response from Garmin sync service"
+
+# Auth-protected endpoints raise these via require_auth -> get_current_user().
+AUTH_RESPONSES: dict = {
+    401: {"description": "Authentication required or token invalid"},
+    503: {"description": "Authentication service unavailable"},
+}
 SQL_ACTIVITY_EXISTS = "SELECT 1 FROM public.garmin_activities WHERE activity_id = $1"
 logger = structlog.get_logger(__name__)
 
@@ -421,8 +427,8 @@ async def get_activity(
     "/activities/{activity_id}",
     response_model=GarminActivity,
     responses={
+        **AUTH_RESPONSES,
         400: {"description": "No fields to update"},
-        401: {"description": "Authentication required"},
         404: {"description": ACTIVITY_NOT_FOUND},
     },
 )
@@ -1202,7 +1208,7 @@ async def get_segment(
     "/segments/{segment_id}",
     status_code=204,
     response_class=Response,
-    responses={404: {"description": "Segment not found"}},
+    responses={**AUTH_RESPONSES, 404: {"description": SEGMENT_NOT_FOUND}},
 )
 async def delete_segment(
     request: Request,

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -195,7 +195,11 @@ async def trigger_sync(
     )
 
 
-@router.get("/date-range", response_model=GarminDateRange)
+@router.get(
+    "/date-range",
+    response_model=GarminDateRange,
+    responses={404: {"description": "No Garmin activity data found"}},
+)
 async def garmin_date_range(request: Request) -> GarminDateRange:
     """Get the earliest and latest Garmin activity timestamps."""
     db = request.app.state.db
@@ -207,7 +211,11 @@ async def garmin_date_range(request: Request) -> GarminDateRange:
     return GarminDateRange(min_date=row["min_date"], max_date=row["max_date"])
 
 
-@router.get("/activities", response_model=PaginatedResponse[GarminActivity])
+@router.get(
+    "/activities",
+    response_model=PaginatedResponse[GarminActivity],
+    responses={422: {"description": "Invalid date format"}},
+)
 async def list_activities(
     request: Request,
     sport: str | None = Query(None, description="Filter by sport type", examples=["cycling"]),
@@ -665,7 +673,11 @@ async def list_activity_laps(
     return [GarminActivityLap(**dict(row)) for row in rows]
 
 
-@router.get("/laps", response_model=PaginatedResponse[GarminActivityLapsGroup])
+@router.get(
+    "/laps",
+    response_model=PaginatedResponse[GarminActivityLapsGroup],
+    responses={422: {"description": "Invalid date format"}},
+)
 async def list_laps(
     request: Request,
     sport: str | None = Query(None, description="Filter by sport type", examples=["cycling"]),
@@ -964,7 +976,11 @@ async def _fetch_segment_efforts(
     return [SegmentEffort(rank=i + 1, **dict(row)) for i, row in enumerate(rows)]
 
 
-@router.get("/segment-efforts", response_model=SegmentEffortsResponse)
+@router.get(
+    "/segment-efforts",
+    response_model=SegmentEffortsResponse,
+    responses={422: {"description": "Invalid date format"}},
+)
 async def list_segment_efforts(
     request: Request,
     start_lat: float = Query(..., description="Segment start latitude", examples=[40.79366846]),
@@ -1115,7 +1131,12 @@ async def list_segments(
     return [GarminSegment(**dict(row)) for row in rows]
 
 
-@router.post("/segments", response_model=GarminSegment, status_code=201)
+@router.post(
+    "/segments",
+    response_model=GarminSegment,
+    status_code=201,
+    responses={500: {"description": "Failed to create segment"}},
+)
 async def create_segment(
     request: Request,
     body: GarminSegmentCreate,
@@ -1168,7 +1189,12 @@ async def get_segment(
     return GarminSegment(**dict(row))
 
 
-@router.delete("/segments/{segment_id}", status_code=204, response_class=Response)
+@router.delete(
+    "/segments/{segment_id}",
+    status_code=204,
+    response_class=Response,
+    responses={404: {"description": "Segment not found"}},
+)
 async def delete_segment(
     request: Request,
     segment_id: int = fastapi.Path(description="Saved segment ID"),

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -35,7 +35,11 @@ def _parse_date(value: str) -> date:
         raise HTTPException(status_code=422, detail=f"Invalid date format: {value!r}. Expected YYYY-MM-DD.") from None
 
 
-@router.get("", response_model=PaginatedResponse[Location])
+@router.get(
+    "",
+    response_model=PaginatedResponse[Location],
+    responses={422: {"description": "Invalid date format"}},
+)
 async def list_locations(
     request: Request,
     device_id: str | None = Query(None, description="Filter by device ID", examples=["iphone_stuart"]),
@@ -113,7 +117,11 @@ async def list_devices(request: Request) -> list[DeviceInfo]:
     return [DeviceInfo(device_id=row["device_id"]) for row in rows]
 
 
-@router.get("/date-range", response_model=LocationDateRange)
+@router.get(
+    "/date-range",
+    response_model=LocationDateRange,
+    responses={404: {"description": "No location data found"}},
+)
 async def location_date_range(request: Request) -> LocationDateRange:
     """Get the earliest and latest location timestamps."""
     db = request.app.state.db
@@ -123,7 +131,11 @@ async def location_date_range(request: Request) -> LocationDateRange:
     return LocationDateRange(min_date=row["min_date"], max_date=row["max_date"])
 
 
-@router.get("/count", response_model=LocationCount)
+@router.get(
+    "/count",
+    response_model=LocationCount,
+    responses={422: {"description": "Invalid date format"}},
+)
 async def location_count(
     request: Request,
     date: str | None = Query(None, description="Filter by date (YYYY-MM-DD)", examples=["2026-02-12"]),
@@ -151,7 +163,11 @@ async def location_count(
     return LocationCount(count=count, date=date, device_id=device_id)
 
 
-@router.get("/{location_id}", response_model=LocationDetail)
+@router.get(
+    "/{location_id}",
+    response_model=LocationDetail,
+    responses={404: {"description": "Location not found"}},
+)
 async def get_location(
     request: Request,
     location_id: int = fastapi.Path(description="Unique location record ID"),

--- a/app/routers/reference.py
+++ b/app/routers/reference.py
@@ -15,6 +15,12 @@ router = APIRouter(prefix="/api/v1/reference-locations", tags=["Reference Locati
 DESC_LOCATION_ID = "Unique reference location ID"
 LOCATION_NOT_FOUND = "Reference location not found"
 
+# Auth-protected endpoints raise these via require_auth -> get_current_user().
+AUTH_RESPONSES: dict = {
+    401: {"description": "Authentication required or token invalid"},
+    503: {"description": "Authentication service unavailable"},
+}
+
 
 @router.get("", response_model=list[ReferenceLocation])
 async def list_reference_locations(request: Request) -> list[ReferenceLocation]:
@@ -52,7 +58,7 @@ async def get_reference_location(
     "",
     response_model=ReferenceLocation,
     status_code=201,
-    responses={500: {"description": "Failed to create reference location"}},
+    responses={**AUTH_RESPONSES, 500: {"description": "Failed to create reference location"}},
 )
 async def create_reference_location(
     request: Request,
@@ -80,6 +86,7 @@ async def create_reference_location(
     "/{location_id}",
     response_model=ReferenceLocation,
     responses={
+        **AUTH_RESPONSES,
         400: {"description": "No fields to update"},
         404: {"description": "Reference location not found"},
     },
@@ -124,7 +131,7 @@ async def update_reference_location(
     "/{location_id}",
     status_code=204,
     response_class=Response,
-    responses={404: {"description": "Reference location not found"}},
+    responses={**AUTH_RESPONSES, 404: {"description": "Reference location not found"}},
 )
 async def delete_reference_location(
     request: Request,

--- a/app/routers/reference.py
+++ b/app/routers/reference.py
@@ -23,7 +23,11 @@ async def list_reference_locations(request: Request) -> list[ReferenceLocation]:
     return [ReferenceLocation(**dict(row)) for row in rows]
 
 
-@router.get("/{location_id}", response_model=ReferenceLocation)
+@router.get(
+    "/{location_id}",
+    response_model=ReferenceLocation,
+    responses={404: {"description": "Reference location not found"}},
+)
 async def get_reference_location(
     request: Request,
     location_id: int = fastapi.Path(description="Unique reference location ID"),
@@ -40,7 +44,12 @@ async def get_reference_location(
     return ReferenceLocation(**dict(row))
 
 
-@router.post("", response_model=ReferenceLocation, status_code=201)
+@router.post(
+    "",
+    response_model=ReferenceLocation,
+    status_code=201,
+    responses={500: {"description": "Failed to create reference location"}},
+)
 async def create_reference_location(
     request: Request,
     body: ReferenceLocationCreate,
@@ -63,7 +72,14 @@ async def create_reference_location(
     return ReferenceLocation(**dict(row))
 
 
-@router.put("/{location_id}", response_model=ReferenceLocation)
+@router.put(
+    "/{location_id}",
+    response_model=ReferenceLocation,
+    responses={
+        400: {"description": "No fields to update"},
+        404: {"description": "Reference location not found"},
+    },
+)
 async def update_reference_location(
     request: Request,
     location_id: int = fastapi.Path(description="Unique reference location ID"),
@@ -100,7 +116,12 @@ async def update_reference_location(
     return ReferenceLocation(**dict(row))
 
 
-@router.delete("/{location_id}", status_code=204, response_class=Response)
+@router.delete(
+    "/{location_id}",
+    status_code=204,
+    response_class=Response,
+    responses={404: {"description": "Reference location not found"}},
+)
 async def delete_reference_location(
     request: Request,
     location_id: int = fastapi.Path(description="Unique reference location ID"),

--- a/app/routers/unified.py
+++ b/app/routers/unified.py
@@ -25,7 +25,11 @@ def _parse_date(value: str) -> date:
         raise HTTPException(status_code=422, detail=f"Invalid date format: {value!r}. Expected YYYY-MM-DD.") from None
 
 
-@router.get("/unified", response_model=PaginatedResponse[UnifiedGpsPoint])
+@router.get(
+    "/unified",
+    response_model=PaginatedResponse[UnifiedGpsPoint],
+    responses={422: {"description": "Invalid date format"}},
+)
 async def list_unified_gps(
     request: Request,
     source: str | None = Query(None, description="Filter by source: owntracks or garmin", examples=["owntracks"]),
@@ -129,7 +133,11 @@ async def list_unified_gps(
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
-@router.get("/daily-summary", response_model=PaginatedResponse[DailyActivitySummary])
+@router.get(
+    "/daily-summary",
+    response_model=PaginatedResponse[DailyActivitySummary],
+    responses={422: {"description": "Invalid date format"}},
+)
 async def daily_summary(
     request: Request,
     date_from: str | None = Query(
@@ -191,7 +199,11 @@ async def daily_summary(
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
-@router.get("/daily-summary/date-range", response_model=DailySummaryDateRange)
+@router.get(
+    "/daily-summary/date-range",
+    response_model=DailySummaryDateRange,
+    responses={404: {"description": "No daily summary data found"}},
+)
 async def daily_summary_date_range(request: Request) -> DailySummaryDateRange:
     """Get the earliest and latest activity dates available in the daily summary view."""
     db = request.app.state.db


### PR DESCRIPTION
## Summary
Resolves SonarQube `python:S8415` (HIGH severity): every `HTTPException` a route can raise is now documented in the route decorator's `responses={}` parameter. This also enriches the generated OpenAPI/Swagger docs with the possible error responses.

## Changes
### `app/routers/garmin.py`
- `GET /date-range` → 404
- `GET /activities`, `GET /laps`, `GET /segment-efforts` → 422 (via `_parse_date`)
- `POST /segments` → 401/503/500
- `PATCH /activities/{id}` → 401/503/400/404
- `DELETE /segments/{segment_id}` → 401/503/404

### `app/routers/reference.py`
- `GET /{location_id}` → 404
- `POST` → 401/503/500
- `PUT` → 401/503/400/404
- `DELETE /{location_id}` → 401/503/404

### `app/routers/locations.py`
- `GET ""`, `GET /count` → 422 (via `_parse_date`)
- `GET /date-range` → 404, `GET /{location_id}` → 404

### `app/routers/unified.py`
- `GET /unified`, `GET /daily-summary` → 422 (via `_parse_date`)
- `GET /daily-summary/date-range` → 404

## Auth responses (Copilot review follow-up, commit d0fc1ff)
Endpoints guarded by `Depends(require_auth)` can raise `HTTPException` 401 (missing/invalid token) and 503 (auth service unavailable) via `get_current_user()`. A shared `AUTH_RESPONSES` constant now documents these on every auth-protected route decorator in `garmin.py` and `reference.py`.

## Testing
- `pre-commit run --files ...` → all passed
- `pytest tests/ -q` → 231 passed

Part of the multi-PR effort to address HIGH-severity SonarQube issues (follows #202, #203).