### PR TITLE
refactor(sonar): reduce cognitive complexity (S3776)

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -88,6 +88,28 @@ def _coerce_sync_payload(payload: dict) -> GarminSyncResponse:
     return GarminSyncResponse(**payload)
 
 
+def _build_sync_params(
+    lookback: int | None,
+    window_hours: int | None,
+    resync_existing: bool | None,
+    activity_id: list[str] | None,
+    activity_ids: list[str] | None,
+) -> dict[str, Any]:
+    """Build the query params forwarded to the in-cluster garmin-sync service."""
+    params: dict[str, Any] = {}
+    if lookback is not None:
+        params["lookback"] = lookback
+    if window_hours is not None:
+        params["window_hours"] = window_hours
+    if resync_existing is not None:
+        params["resync_existing"] = "true" if resync_existing else "false"
+    if activity_id:
+        params["activity_id"] = activity_id
+    if activity_ids:
+        params["activity_ids"] = activity_ids
+    return params
+
+
 @router.post(
     "/sync",
     response_model=GarminSyncResponse,
@@ -139,17 +161,7 @@ async def trigger_sync(
 
     config = request.app.state.config
     base_url = config.garmin_sync_base_url.rstrip("/")
-    params: dict[str, Any] = {}
-    if lookback is not None:
-        params["lookback"] = lookback
-    if window_hours is not None:
-        params["window_hours"] = window_hours
-    if resync_existing is not None:
-        params["resync_existing"] = "true" if resync_existing else "false"
-    if activity_id:
-        params["activity_id"] = activity_id
-    if activity_ids:
-        params["activity_ids"] = activity_ids
+    params = _build_sync_params(lookback, window_hours, resync_existing, activity_id, activity_ids)
 
     logger.info("garmin_sync_trigger", sync_id=sync_id, params=params)
 
@@ -176,10 +188,7 @@ async def trigger_sync(
     if upstream_response.status_code in {202, 409, 400}:
         try:
             sync_response = _coerce_sync_payload(payload)
-        except ValidationError:
-            response.status_code = 502
-            return GarminSyncResponse(status="error", message="Invalid response from Garmin sync service")
-        except ValueError:
+        except (ValidationError, ValueError):  # fmt: skip
             response.status_code = 502
             return GarminSyncResponse(status="error", message="Invalid response from Garmin sync service")
         response.status_code = upstream_response.status_code

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -165,23 +165,26 @@ async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
         round((covered_track_points / total_track_points * 100), 2) if total_track_points else 0.0
     )
 
+    # Note: every count below is already a non-null integer — dict.get() uses a
+    # 0 default, COUNT(*) never returns NULL, and the mv_metrics values are
+    # guarded above — so no additional ``or 0`` fallbacks are needed.
     by_source = GeocodingStatusBySource(
         owntracks=GeocodingSourceStatus(
-            success=ot_success or 0,
-            pending=ot_pending or 0,
-            no_coverage=ot_no_coverage or 0,
-            errors=ot_errors or 0,
-            total=geocoded or 0,
+            success=ot_success,
+            pending=ot_pending,
+            no_coverage=ot_no_coverage,
+            errors=ot_errors,
+            total=geocoded,
         ),
         garmin=GeocodingSourceStatus(
-            success=g_success or 0,
-            pending=g_pending or 0,
-            no_coverage=g_no_coverage or 0,
-            errors=g_errors or 0,
+            success=g_success,
+            pending=g_pending,
+            no_coverage=g_no_coverage,
+            errors=g_errors,
             total=g_total_rows,
         ),
-        garmin_activities_total=activities_total or 0,
-        garmin_activities_geocoded=activities_geocoded or 0,
+        garmin_activities_total=activities_total,
+        garmin_activities_geocoded=activities_geocoded,
         garmin_coverage_percent=garmin_coverage_percent,
         garmin_waypoint_success_percent=garmin_waypoint_success_percent,
     )
@@ -195,12 +198,12 @@ async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
         errors=ot_errors,
         coverage_percent=coverage_percent,
         by_source=by_source,
-        dense_cells_total=dense_total_cells or 0,
+        dense_cells_total=dense_total_cells,
         dense_cells_geocoded=dense_geocoded,
-        dense_cells_success=dense_success or 0,
-        dense_cells_pending=dense_pending or 0,
-        dense_cells_no_coverage=dense_no_coverage or 0,
-        dense_cells_errors=dense_errors or 0,
+        dense_cells_success=dense_success,
+        dense_cells_pending=dense_pending,
+        dense_cells_no_coverage=dense_no_coverage,
+        dense_cells_errors=dense_errors,
         dense_point_coverage_percent=dense_point_coverage_percent,
     )
 
@@ -834,6 +837,34 @@ async def _find_nearby_address(db: Any, lat: float, lon: float) -> dict[str, Any
     return {key: value for key, value in dict(nearest).items() if key != "_dist"}
 
 
+def _interpret_pelias_response(resp: httpx.Response) -> dict[str, Any] | None:
+    """Interpret a single Pelias HTTP response.
+
+    Returns the parsed JSON dict on a 2xx success, or ``None`` on a permanent
+    failure (invalid JSON body on a 2xx, or a 4xx client error). Raises
+    ``httpx.HTTPStatusError`` for 5xx (and any other non-2xx/4xx) responses so
+    the caller treats them as transient and retries.
+    """
+    status_code = resp.status_code
+    if 200 <= status_code < 300:
+        try:
+            data: dict[str, Any] = resp.json()
+            return data
+        except (ValueError, json.JSONDecodeError):  # fmt: skip
+            logger.warning("Pelias returned non-JSON body", exc_info=True)
+            # Treat invalid JSON on 2xx as permanent—no point retrying.
+            return None
+    if 400 <= status_code < 500:
+        logger.warning(
+            "Pelias permanent client error",
+            status_code=status_code,
+            body_preview=resp.text[:200],
+        )
+        return None
+    # 5xx and anything else (e.g. 1xx/3xx) — treat as transient.
+    raise httpx.HTTPStatusError(f"Pelias status {status_code}", request=resp.request, response=resp)
+
+
 async def _call_pelias(
     client: httpx.AsyncClient,
     pelias_base_url: str,
@@ -859,42 +890,16 @@ async def _call_pelias(
                 f"{pelias_base_url}{PELIAS_REVERSE_PATH}",
                 params={"point.lat": lat, "point.lon": lon, "size": 1},
             )
-        except httpx.TimeoutException as e:
-            last_err = e
-            logger.warning("Pelias timeout (attempt %d/%d)", attempt + 1, PELIAS_MAX_ATTEMPTS, exc_info=True)
-        except httpx.TransportError as e:
+            # Permanent outcomes (2xx success/invalid-JSON, 4xx) return directly;
+            # transient outcomes (5xx/other) raise HTTPStatusError, handled below.
+            return _interpret_pelias_response(resp)
+        except (httpx.TimeoutException, httpx.TransportError, httpx.HTTPStatusError) as e:
             last_err = e
             logger.warning(
-                "Pelias transport error (attempt %d/%d)",
+                "Pelias request failed (attempt %d/%d)",
                 attempt + 1,
                 PELIAS_MAX_ATTEMPTS,
                 exc_info=True,
-            )
-        else:
-            status_code = resp.status_code
-            if 200 <= status_code < 300:
-                try:
-                    data: dict[str, Any] = resp.json()
-                    return data
-                except (ValueError, json.JSONDecodeError) as e:
-                    logger.warning("Pelias returned non-JSON body", exc_info=True)
-                    last_err = e
-                    # Treat invalid JSON on 2xx as permanent—no point retrying.
-                    return None
-            if 400 <= status_code < 500:
-                logger.warning(
-                    "Pelias permanent client error",
-                    status_code=status_code,
-                    body_preview=resp.text[:200],
-                )
-                return None
-            # 5xx and anything else (e.g. 1xx/3xx) — treat as transient.
-            last_err = httpx.HTTPStatusError(f"Pelias status {status_code}", request=resp.request, response=resp)
-            logger.warning(
-                "Pelias server error (attempt %d/%d, status=%d)",
-                attempt + 1,
-                PELIAS_MAX_ATTEMPTS,
-                status_code,
             )
 
         if attempt < PELIAS_MAX_ATTEMPTS - 1:


### PR DESCRIPTION
## Summary

Fourth PR in the multi-PR SonarQube HIGH-severity remediation series (follows #202, #203, #204).

Addresses **python:S3776** (Cognitive Complexity greater than 15) by extracting helpers and removing dead defensive code.

## Changes

### `app/routers/garmin.py` — `trigger_sync`
- Extracted a new module-level helper `_build_sync_params(lookback, window_hours, resync_existing, activity_id, activity_ids) -> dict[str, Any]` and replaced the inline param-building block with a single `params = _build_sync_params(...)` call.
- Combined two redundant `except` branches into `except (ValidationError, ValueError):`.

### `app/routers/geocoding.py` — `_call_pelias`
- Extracted a new module-level helper `_interpret_pelias_response(resp) -> dict[str, Any] | None` that centralizes the 2xx/4xx/5xx branching (2xx → json or `None` on bad JSON; 4xx → `None`; 5xx/other → raise `httpx.HTTPStatusError`).
- Simplified the retry loop to call the helper and combined transient excepts into `except (httpx.TimeoutException, httpx.TransportError, httpx.HTTPStatusError) as e:`.

### `app/routers/geocoding.py` — `_compute_geocoding_status`
- Removed ~16 redundant `or 0` fallbacks on values already guaranteed non-None, added an explanatory comment.

## Note on `# fmt: skip`
Two lines carry a `# fmt: skip` comment to work around a bug in the local `ruff format` binary that strips the required parentheses from a bare multi-type `except (A, B):` clause (rewriting it into invalid `except A, B:`). The skip keeps the valid syntax intact; all other lines format cleanly.

## Validation
- `pre-commit run --files app/routers/garmin.py app/routers/geocoding.py` — all hooks pass.
- `python -m pytest tests/ -q` — 231 passed.