### PR TITLE
fix(sonar): reduce router response code smells

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -158,7 +158,7 @@ async def get_current_user(
         raise _authentication_service_unavailable() from e
 
 
-async def require_auth(
+def require_auth(
     user: dict[str, Any] | None = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Dependency that requires valid authentication when OAuth2 is enabled."""

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -37,7 +37,6 @@ def _parse_date(value: str) -> date:
 
 @router.get(
     "",
-    response_model=PaginatedResponse[Location],
     responses={422: {"description": "Invalid date format"}},
 )
 async def list_locations(
@@ -109,7 +108,7 @@ async def list_locations(
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
-@router.get("/devices", response_model=list[DeviceInfo])
+@router.get("/devices")
 async def list_devices(request: Request) -> list[DeviceInfo]:
     """List all distinct device IDs."""
     db = request.app.state.db
@@ -119,7 +118,6 @@ async def list_devices(request: Request) -> list[DeviceInfo]:
 
 @router.get(
     "/date-range",
-    response_model=LocationDateRange,
     responses={404: {"description": "No location data found"}},
 )
 async def location_date_range(request: Request) -> LocationDateRange:
@@ -133,7 +131,6 @@ async def location_date_range(request: Request) -> LocationDateRange:
 
 @router.get(
     "/count",
-    response_model=LocationCount,
     responses={422: {"description": "Invalid date format"}},
 )
 async def location_count(
@@ -165,7 +162,6 @@ async def location_count(
 
 @router.get(
     "/{location_id}",
-    response_model=LocationDetail,
     responses={404: {"description": "Location not found"}},
 )
 async def get_location(

--- a/app/routers/reference.py
+++ b/app/routers/reference.py
@@ -22,7 +22,7 @@ AUTH_RESPONSES: dict = {
 }
 
 
-@router.get("", response_model=list[ReferenceLocation])
+@router.get("")
 async def list_reference_locations(request: Request) -> list[ReferenceLocation]:
     """List all reference locations."""
     db = request.app.state.db
@@ -35,7 +35,6 @@ async def list_reference_locations(request: Request) -> list[ReferenceLocation]:
 
 @router.get(
     "/{location_id}",
-    response_model=ReferenceLocation,
     responses={404: {"description": "Reference location not found"}},
 )
 async def get_reference_location(
@@ -56,7 +55,6 @@ async def get_reference_location(
 
 @router.post(
     "",
-    response_model=ReferenceLocation,
     status_code=201,
     responses={**AUTH_RESPONSES, 500: {"description": "Failed to create reference location"}},
 )
@@ -84,7 +82,6 @@ async def create_reference_location(
 
 @router.put(
     "/{location_id}",
-    response_model=ReferenceLocation,
     responses={
         **AUTH_RESPONSES,
         400: {"description": "No fields to update"},

--- a/app/routers/unified.py
+++ b/app/routers/unified.py
@@ -27,7 +27,6 @@ def _parse_date(value: str) -> date:
 
 @router.get(
     "/unified",
-    response_model=PaginatedResponse[UnifiedGpsPoint],
     responses={422: {"description": "Invalid date format"}},
 )
 async def list_unified_gps(
@@ -135,7 +134,6 @@ async def list_unified_gps(
 
 @router.get(
     "/daily-summary",
-    response_model=PaginatedResponse[DailyActivitySummary],
     responses={422: {"description": "Invalid date format"}},
 )
 async def daily_summary(
@@ -201,7 +199,6 @@ async def daily_summary(
 
 @router.get(
     "/daily-summary/date-range",
-    response_model=DailySummaryDateRange,
     responses={404: {"description": "No daily summary data found"}},
 )
 async def daily_summary_date_range(request: Request) -> DailySummaryDateRange:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -188,7 +188,7 @@ async def test_get_current_user_rejects_unexpected_jwt_algorithm(monkeypatch: py
 async def test_require_auth_enforces_auth_flag():
     auth.configure_auth("https://issuer", "client123", True)
     with pytest.raises(HTTPException):
-        await auth.require_auth(None)
+        auth.require_auth(None)
 
     auth.configure_auth("https://issuer", "client123", False)
-    assert await auth.require_auth(None) == {}
+    assert auth.require_auth(None) == {}


### PR DESCRIPTION
## Summary
Addresses the next SonarQube minor-code-smell batches by removing redundant FastAPI response model declarations from smaller routers and simplifying an auth dependency helper.

## Changes
- Removes redundant `response_model` arguments where return annotations already provide the response schema in locations, reference, unified, geocoding, and spatial routers.
- Makes `require_auth` synchronous because it does not perform async work internally; FastAPI still resolves the async `get_current_user` dependency before calling it.
- Updates the direct auth unit test for the synchronous helper.

## SonarQube Verification
Before this PR, SonarQube reported 158 open code smells, all minor.
After the first batch, SonarQube reported 145 open code smells, all minor.
After the second batch and `make sonar`, SonarQube reports 134 open code smells, all minor.
`python:S7503` is cleared and `python:S8409` decreased from 42 to 19. The remaining `python:S8409` items are all in `app/routers/garmin.py`.

## Validation
- `pytest -o cache_dir=/tmp/.pytest_cache tests/test_auth.py tests/test_locations.py tests/test_reference.py tests/test_unified.py -q`
- `pytest -o cache_dir=/tmp/.pytest_cache tests/test_geocoding.py tests/test_spatial.py -q`
- `pre-commit run -a`
- `make test`
- `make sonar`
