### PR TITLE
fix(sonar): adopt annotated params in small routers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+DEFAULT_DB_HOST = "localhost"
+
 
 @dataclass(frozen=True)
 class Config:
@@ -17,7 +19,7 @@ class Config:
     port: int = 8080
 
     # Database (PgBouncer)
-    db_host: str = "192.168.1.175"
+    db_host: str = DEFAULT_DB_HOST
     db_port: int = 6432
     db_name: str = "owntracks"
     db_user: str | None = None
@@ -78,7 +80,7 @@ class Config:
         return cls(
             port=int(os.getenv("PORT", "8080")),
             # Database
-            db_host=os.getenv("PGBOUNCER_HOST", "192.168.1.175"),
+            db_host=os.getenv("PGBOUNCER_HOST", DEFAULT_DB_HOST),
             db_port=int(os.getenv("PGBOUNCER_PORT", "6432")),
             db_name=os.getenv("POSTGRES_DB", "owntracks"),
             db_user=os.getenv("POSTGRES_USER"),

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 import structlog
@@ -271,9 +271,9 @@ async def pelias_health(request: Request) -> PeliasHealth:
 @router.post("/trigger")
 async def trigger_geocoding(
     request: Request,
-    batch_size: int = Query(100, ge=1, le=500, description="Number of locations to geocode in this batch"),
-    retry_failed: bool = Query(False, description="Re-process records with statuses no_coverage or error"),
-    _user: dict = Depends(require_auth),
+    _user: Annotated[dict, Depends(require_auth)],
+    batch_size: Annotated[int, Query(ge=1, le=500, description="Number of locations to geocode in this batch")] = 100,
+    retry_failed: Annotated[bool, Query(description="Re-process records with statuses no_coverage or error")] = False,
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of OwnTracks location records (auth required)."""
     return await _trigger_geocoding_impl(request, batch_size, retry_failed)
@@ -282,8 +282,8 @@ async def trigger_geocoding(
 @internal_router.post("/trigger")
 async def internal_trigger_geocoding(
     request: Request,
-    batch_size: int = Query(100, ge=1, le=1000, description="Number of locations to geocode in this batch"),
-    retry_failed: bool = Query(False, description="Re-process records with statuses no_coverage or error"),
+    batch_size: Annotated[int, Query(ge=1, le=1000, description="Number of locations to geocode in this batch")] = 100,
+    retry_failed: Annotated[bool, Query(description="Re-process records with statuses no_coverage or error")] = False,
 ) -> GeocodingTriggerResponse:
     """Trigger batch OwnTracks reverse-geocoding (internal, no auth)."""
     return await _trigger_geocoding_impl(request, batch_size, retry_failed)
@@ -416,17 +416,18 @@ async def _process_location_inner(
 @internal_router.post("/trigger/garmin")
 async def internal_trigger_garmin_geocoding(
     request: Request,
-    batch_size: int = Query(10, ge=1, le=100, description="Number of Garmin activities to process in this batch"),
-    waypoint_spacing_km: float = Query(
-        DEFAULT_GARMIN_WAYPOINT_SPACING_KM,
-        ge=0.1,
-        le=50.0,
-        description="Approximate spacing between mid-route waypoints in kilometres",
-    ),
-    retry_failed: bool = Query(
-        False,
-        description="Re-process activities with at least one waypoint in statuses no_coverage or error",
-    ),
+    batch_size: Annotated[
+        int,
+        Query(ge=1, le=100, description="Number of Garmin activities to process in this batch"),
+    ] = 10,
+    waypoint_spacing_km: Annotated[
+        float,
+        Query(ge=0.1, le=50.0, description="Approximate spacing between mid-route waypoints in kilometres"),
+    ] = DEFAULT_GARMIN_WAYPOINT_SPACING_KM,
+    retry_failed: Annotated[
+        bool,
+        Query(description="Re-process activities with at least one waypoint in statuses no_coverage or error"),
+    ] = False,
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of Garmin activity waypoints (internal, no auth).
 
@@ -439,18 +440,19 @@ async def internal_trigger_garmin_geocoding(
 @router.post("/trigger/garmin")
 async def trigger_garmin_geocoding(
     request: Request,
-    batch_size: int = Query(10, ge=1, le=100, description="Number of Garmin activities to process in this batch"),
-    waypoint_spacing_km: float = Query(
-        DEFAULT_GARMIN_WAYPOINT_SPACING_KM,
-        ge=0.1,
-        le=50.0,
-        description="Approximate spacing between mid-route waypoints in kilometres",
-    ),
-    retry_failed: bool = Query(
-        False,
-        description="Re-process activities with at least one waypoint in statuses no_coverage or error",
-    ),
-    _user: dict = Depends(require_auth),
+    _user: Annotated[dict, Depends(require_auth)],
+    batch_size: Annotated[
+        int,
+        Query(ge=1, le=100, description="Number of Garmin activities to process in this batch"),
+    ] = 10,
+    waypoint_spacing_km: Annotated[
+        float,
+        Query(ge=0.1, le=50.0, description="Approximate spacing between mid-route waypoints in kilometres"),
+    ] = DEFAULT_GARMIN_WAYPOINT_SPACING_KM,
+    retry_failed: Annotated[
+        bool,
+        Query(description="Re-process activities with at least one waypoint in statuses no_coverage or error"),
+    ] = False,
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of Garmin activity waypoints (auth required)."""
     return await _trigger_garmin_geocoding_impl(request, batch_size, waypoint_spacing_km, retry_failed)
@@ -1108,11 +1110,13 @@ _CELL_CONFLICT = "ON CONFLICT (lat_4dp, lon_4dp)"
 @internal_router.post("/trigger/garmin-dense")
 async def internal_trigger_garmin_dense(
     request: Request,
-    batch_size: int = Query(100, ge=1, le=1000, description="Number of dense cells to process in this batch"),
-    retry_failed: bool = Query(
-        False,
-        description="Re-process cells whose status is no_coverage, error, or pending",
-    ),
+    batch_size: Annotated[
+        int, Query(ge=1, le=1000, description="Number of dense cells to process in this batch")
+    ] = 100,
+    retry_failed: Annotated[
+        bool,
+        Query(description="Re-process cells whose status is no_coverage, error, or pending"),
+    ] = False,
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of distinct 4dp GPS cells (internal, no auth)."""
     return await _trigger_garmin_dense_impl(request, batch_size, retry_failed)
@@ -1121,12 +1125,12 @@ async def internal_trigger_garmin_dense(
 @router.post("/trigger/garmin-dense")
 async def trigger_garmin_dense(
     request: Request,
-    batch_size: int = Query(100, ge=1, le=500, description="Number of dense cells to process in this batch"),
-    retry_failed: bool = Query(
-        False,
-        description="Re-process cells whose status is no_coverage, error, or pending",
-    ),
-    _user: dict = Depends(require_auth),
+    _user: Annotated[dict, Depends(require_auth)],
+    batch_size: Annotated[int, Query(ge=1, le=500, description="Number of dense cells to process in this batch")] = 100,
+    retry_failed: Annotated[
+        bool,
+        Query(description="Re-process cells whose status is no_coverage, error, or pending"),
+    ] = False,
 ) -> GeocodingTriggerResponse:
     """Trigger batch reverse-geocoding of distinct 4dp GPS cells (auth required)."""
     return await _trigger_garmin_dense_impl(request, batch_size, retry_failed)

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import date
-from typing import Literal
+from typing import Annotated, Literal
 
 import fastapi
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -41,18 +41,25 @@ def _parse_date(value: str) -> date:
 )
 async def list_locations(
     request: Request,
-    device_id: str | None = Query(None, description="Filter by device ID", examples=["iphone_stuart"]),
-    date_from: str | None = Query(None, description="Filter from date (YYYY-MM-DD)", examples=["2026-02-01"]),
-    date_to: str | None = Query(None, description="Filter to date (YYYY-MM-DD)", examples=["2026-02-12"]),
-    limit: int = Query(50, ge=1, le=1000, description="Maximum number of locations to return per page"),
-    offset: int = Query(0, ge=0, description="Number of locations to skip for pagination"),
-    sort: str = Query(
-        "created_at",
-        description="Sort column (id, device_id, timestamp, created_at, battery, accuracy)",
-    ),
-    order: Literal["asc", "desc"] = Query(
-        "desc", description="Sort direction: asc (oldest first) or desc (newest first)"
-    ),
+    device_id: Annotated[str | None, Query(description="Filter by device ID", examples=["iphone_stuart"])] = None,
+    date_from: Annotated[
+        str | None,
+        Query(description="Filter from date (YYYY-MM-DD)", examples=["2026-02-01"]),
+    ] = None,
+    date_to: Annotated[
+        str | None,
+        Query(description="Filter to date (YYYY-MM-DD)", examples=["2026-02-12"]),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of locations to return per page")] = 50,
+    offset: Annotated[int, Query(ge=0, description="Number of locations to skip for pagination")] = 0,
+    sort: Annotated[
+        str,
+        Query(description="Sort column (id, device_id, timestamp, created_at, battery, accuracy)"),
+    ] = "created_at",
+    order: Annotated[
+        Literal["asc", "desc"],
+        Query(description="Sort direction: asc (oldest first) or desc (newest first)"),
+    ] = "desc",
 ) -> PaginatedResponse[Location]:
     """List OwnTracks locations with filtering and pagination.
 
@@ -135,8 +142,11 @@ async def location_date_range(request: Request) -> LocationDateRange:
 )
 async def location_count(
     request: Request,
-    date: str | None = Query(None, description="Filter by date (YYYY-MM-DD)", examples=["2026-02-12"]),
-    device_id: str | None = Query(None, description="Filter by device ID", examples=["iphone_stuart"]),
+    date: Annotated[
+        str | None,
+        Query(description="Filter by date (YYYY-MM-DD)", examples=["2026-02-12"]),
+    ] = None,
+    device_id: Annotated[str | None, Query(description="Filter by device ID", examples=["iphone_stuart"])] = None,
 ) -> LocationCount:
     """Get total location count with optional filters."""
     db = request.app.state.db
@@ -166,7 +176,7 @@ async def location_count(
 )
 async def get_location(
     request: Request,
-    location_id: int = fastapi.Path(description="Unique location record ID"),
+    location_id: Annotated[int, fastapi.Path(description="Unique location record ID")],
 ) -> LocationDetail:
     """Get a single location by ID, including raw payload."""
     db = request.app.state.db

--- a/app/routers/reference.py
+++ b/app/routers/reference.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
@@ -39,7 +41,7 @@ async def list_reference_locations(request: Request) -> list[ReferenceLocation]:
 )
 async def get_reference_location(
     request: Request,
-    location_id: int = fastapi.Path(description=DESC_LOCATION_ID),
+    location_id: Annotated[int, fastapi.Path(description=DESC_LOCATION_ID)],
 ) -> ReferenceLocation:
     """Get a single reference location by ID."""
     db = request.app.state.db
@@ -61,7 +63,7 @@ async def get_reference_location(
 async def create_reference_location(
     request: Request,
     body: ReferenceLocationCreate,
-    _user: dict = Depends(require_auth),
+    _user: Annotated[dict, Depends(require_auth)],
 ) -> ReferenceLocation:
     """Create a new reference location (auth required)."""
     db = request.app.state.db
@@ -90,9 +92,9 @@ async def create_reference_location(
 )
 async def update_reference_location(
     request: Request,
-    location_id: int = fastapi.Path(description=DESC_LOCATION_ID),
-    body: ReferenceLocationUpdate = fastapi.Body(...),
-    _user: dict = Depends(require_auth),
+    location_id: Annotated[int, fastapi.Path(description=DESC_LOCATION_ID)],
+    body: Annotated[ReferenceLocationUpdate, fastapi.Body()],
+    _user: Annotated[dict, Depends(require_auth)],
 ) -> ReferenceLocation:
     """Update a reference location (auth required)."""
     db = request.app.state.db
@@ -132,8 +134,8 @@ async def update_reference_location(
 )
 async def delete_reference_location(
     request: Request,
-    location_id: int = fastapi.Path(description=DESC_LOCATION_ID),
-    _user: dict = Depends(require_auth),
+    location_id: Annotated[int, fastapi.Path(description=DESC_LOCATION_ID)],
+    _user: Annotated[dict, Depends(require_auth)],
 ) -> Response:
     """Delete a reference location (auth required)."""
     db = request.app.state.db

--- a/app/routers/spatial.py
+++ b/app/routers/spatial.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import fastapi
 from fastapi import APIRouter, HTTPException, Query, Request
 
@@ -13,11 +15,14 @@ router = APIRouter(prefix="/api/v1/spatial", tags=["Spatial"])
 @router.get("/nearby")
 async def find_nearby(
     request: Request,
-    lat: float = Query(..., description="Latitude of center point", examples=[40.7362]),
-    lon: float = Query(..., description="Longitude of center point", examples=[-74.0394]),
-    radius_meters: int = Query(1000, ge=1, le=100000, description="Search radius in meters"),
-    source: str | None = Query(None, description="Filter by source: owntracks or garmin", examples=["owntracks"]),
-    limit: int = Query(100, ge=1, le=5000, description="Maximum number of nearby points to return"),
+    lat: Annotated[float, Query(description="Latitude of center point", examples=[40.7362])],
+    lon: Annotated[float, Query(description="Longitude of center point", examples=[-74.0394])],
+    radius_meters: Annotated[int, Query(ge=1, le=100000, description="Search radius in meters")] = 1000,
+    source: Annotated[
+        str | None,
+        Query(description="Filter by source: owntracks or garmin", examples=["owntracks"]),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=5000, description="Maximum number of nearby points to return")] = 100,
 ) -> list[NearbyPoint]:
     """Find GPS points within a radius of a given lat/lon using PostGIS ST_DWithin.
 
@@ -59,10 +64,10 @@ async def find_nearby(
 @router.get("/distance")
 async def calculate_distance(
     request: Request,
-    from_lat: float = Query(..., description="From latitude (e.g. NYC)", examples=[40.7128]),
-    from_lon: float = Query(..., description="From longitude (e.g. NYC)", examples=[-74.006]),
-    to_lat: float = Query(..., description="To latitude (e.g. Times Square)", examples=[40.758]),
-    to_lon: float = Query(..., description="To longitude (e.g. Times Square)", examples=[-73.9855]),
+    from_lat: Annotated[float, Query(description="From latitude (e.g. NYC)", examples=[40.7128])],
+    from_lon: Annotated[float, Query(description="From longitude (e.g. NYC)", examples=[-74.006])],
+    to_lat: Annotated[float, Query(description="To latitude (e.g. Times Square)", examples=[40.758])],
+    to_lon: Annotated[float, Query(description="To longitude (e.g. Times Square)", examples=[-73.9855])],
 ) -> DistanceResult:
     """Calculate the distance in meters between two points using PostGIS ST_Distance.
 
@@ -91,9 +96,15 @@ async def calculate_distance(
 )
 async def within_reference(
     request: Request,
-    name: str = fastapi.Path(description="Reference location name", examples=["home"]),
-    source: str | None = Query(None, description="Filter by source: owntracks or garmin", examples=["owntracks"]),
-    limit: int = Query(100, ge=1, le=5000, description="Maximum number of points to return within the reference area"),
+    name: Annotated[str, fastapi.Path(description="Reference location name", examples=["home"])],
+    source: Annotated[
+        str | None,
+        Query(description="Filter by source: owntracks or garmin", examples=["owntracks"]),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=5000, description="Maximum number of points to return within the reference area"),
+    ] = 100,
 ) -> WithinReferenceResult:
     """Find all GPS points within a named reference location's radius.
 

--- a/app/routers/unified.py
+++ b/app/routers/unified.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
@@ -31,23 +31,33 @@ def _parse_date(value: str) -> date:
 )
 async def list_unified_gps(
     request: Request,
-    source: str | None = Query(None, description="Filter by source: owntracks or garmin", examples=["owntracks"]),
-    date_from: str | None = Query(
-        None,
-        description="Filter from date (YYYY-MM-DD). Defaults to 90 days ago when both date_from and date_to are omitted.",
-        examples=["2026-02-01"],
-    ),
-    date_to: str | None = Query(None, description="Filter to date (YYYY-MM-DD)", examples=["2026-02-12"]),
-    limit: int = Query(100, ge=1, le=5000, description="Maximum number of GPS points to return per page"),
-    offset: int = Query(0, ge=0, description="Number of GPS points to skip for pagination"),
-    order: Literal["asc", "desc"] = Query(
-        "desc", description="Sort direction: asc (oldest first) or desc (newest first)"
-    ),
-    exclude_stationary: bool = Query(False, description="Exclude stationary points where speed_kmh = 0"),
-    deduplicate: bool = Query(
-        False,
-        description="Remove points with duplicate coordinates (rounded to ~11m precision)",
-    ),
+    source: Annotated[
+        str | None,
+        Query(description="Filter by source: owntracks or garmin", examples=["owntracks"]),
+    ] = None,
+    date_from: Annotated[
+        str | None,
+        Query(
+            description="Filter from date (YYYY-MM-DD). "
+            "Defaults to 90 days ago when both date_from and date_to are omitted.",
+            examples=["2026-02-01"],
+        ),
+    ] = None,
+    date_to: Annotated[
+        str | None,
+        Query(description="Filter to date (YYYY-MM-DD)", examples=["2026-02-12"]),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=5000, description="Maximum number of GPS points to return per page")] = 100,
+    offset: Annotated[int, Query(ge=0, description="Number of GPS points to skip for pagination")] = 0,
+    order: Annotated[
+        Literal["asc", "desc"],
+        Query(description="Sort direction: asc (oldest first) or desc (newest first)"),
+    ] = "desc",
+    exclude_stationary: Annotated[bool, Query(description="Exclude stationary points where speed_kmh = 0")] = False,
+    deduplicate: Annotated[
+        bool,
+        Query(description="Remove points with duplicate coordinates (rounded to ~11m precision)"),
+    ] = False,
 ) -> PaginatedResponse[UnifiedGpsPoint]:
     """Query the unified_gps_points view combining OwnTracks + Garmin data.
 
@@ -138,14 +148,20 @@ async def list_unified_gps(
 )
 async def daily_summary(
     request: Request,
-    date_from: str | None = Query(
-        None,
-        description="Filter from date (YYYY-MM-DD). Defaults to 90 days ago when both date_from and date_to are omitted.",
-        examples=["2026-02-01"],
-    ),
-    date_to: str | None = Query(None, description="Filter to date (YYYY-MM-DD)", examples=["2026-02-12"]),
-    limit: int = Query(30, ge=1, le=365, description="Maximum number of daily summaries to return per page"),
-    offset: int = Query(0, ge=0, description="Number of daily summaries to skip for pagination"),
+    date_from: Annotated[
+        str | None,
+        Query(
+            description="Filter from date (YYYY-MM-DD). "
+            "Defaults to 90 days ago when both date_from and date_to are omitted.",
+            examples=["2026-02-01"],
+        ),
+    ] = None,
+    date_to: Annotated[
+        str | None,
+        Query(description="Filter to date (YYYY-MM-DD)", examples=["2026-02-12"]),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=365, description="Maximum number of daily summaries to return per page")] = 30,
+    offset: Annotated[int, Query(ge=0, description="Number of daily summaries to skip for pagination")] = 0,
 ) -> PaginatedResponse[DailyActivitySummary]:
     """Query the daily_activity_summary view for aggregated daily stats.
 


### PR DESCRIPTION
## Summary
Continues the SonarQube cleanup by migrating smaller FastAPI routers to `Annotated` parameter metadata and removing the hardcoded private database host default from application config.

## Changes
- Converts FastAPI `Query`, `Path`, `Body`, and `Depends` parameters to `Annotated[...]` style in smaller routers:
  - `locations`
  - `spatial`
  - `unified`
  - `reference`
  - selected `geocoding` trigger endpoints
- Replaces the hardcoded private PgBouncer IP fallback with `DEFAULT_DB_HOST = "localhost"`; deployment-specific hosts still come from `PGBOUNCER_HOST`.

## SonarQube Verification
Before this batch, SonarQube reported 115 open code smells, all minor.
After `make sonar`, SonarQube reports 55 open code smells, all minor.
`python:S1313` decreased from 2 to 0 and is now cleared.
Remaining issues are all `python:S8410` in the larger Garmin-focused path.

## Validation
- `python -m py_compile app/config.py app/routers/locations.py app/routers/spatial.py app/routers/unified.py app/routers/reference.py app/routers/geocoding.py`
- `pytest -o cache_dir=/tmp/.pytest_cache tests/test_config.py tests/test_locations.py tests/test_spatial.py tests/test_unified.py tests/test_reference.py tests/test_geocoding.py -q`
- `pre-commit run -a`
- `make test`
- `make sonar`
