### PR TITLE
fix(garmin): match real laps on loop segments, not adjacent GPS pings

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -959,11 +959,40 @@ async def _fetch_segment_efforts(
     params.append(limit)
     idx += 1
 
+    # Only computed when a reference bearing is supplied: for the stateless
+    # endpoint and saved segments without a source activity there's nothing to
+    # compare against, so this CTE (and its per-start LATERAL lookup) is
+    # omitted entirely rather than computed and then ignored.
+    start_bearings_cte = ""
+    bearings_join = ""
     bearing_clause = ""
     if ref_bearing_deg is not None:
         ref_bearing_idx = idx
         params.append(ref_bearing_deg)
         idx += 1
+        start_bearings_cte = """
+        start_bearings AS (
+            SELECT s.activity_id, s.s_ts,
+                   degrees(ST_Azimuth(
+                       ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326),
+                       ST_SetSRID(ST_MakePoint(nxt.longitude, nxt.latitude), 4326)
+                   )) AS bearing_deg
+            FROM starts s
+            CROSS JOIN seg
+            JOIN LATERAL (
+                SELECT t.longitude, t.latitude
+                FROM public.garmin_track_points t
+                WHERE t.activity_id = s.activity_id
+                  AND t.timestamp > s.s_ts
+                  AND t.geog IS NOT NULL
+                  AND NOT ST_DWithin(t.geog, seg.start_pt, seg.tol)
+                ORDER BY t.timestamp ASC
+                LIMIT 1
+            ) nxt ON TRUE
+        ),"""
+        bearings_join = """
+            LEFT JOIN start_bearings sb
+              ON sb.activity_id = s.activity_id AND sb.s_ts = s.s_ts"""
         bearing_clause = f"""
             AND (
                 sb.bearing_deg IS NULL
@@ -998,33 +1027,12 @@ async def _fetch_segment_efforts(
             JOIN filtered_activities fa ON fa.activity_id = t.activity_id
             CROSS JOIN seg
             WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.end_pt, seg.tol)
-        ),
-        start_bearings AS (
-            SELECT s.activity_id, s.s_ts,
-                   degrees(ST_Azimuth(
-                       ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326),
-                       ST_SetSRID(ST_MakePoint(nxt.longitude, nxt.latitude), 4326)
-                   )) AS bearing_deg
-            FROM starts s
-            CROSS JOIN seg
-            JOIN LATERAL (
-                SELECT t.longitude, t.latitude
-                FROM public.garmin_track_points t
-                WHERE t.activity_id = s.activity_id
-                  AND t.timestamp > s.s_ts
-                  AND t.geog IS NOT NULL
-                  AND NOT ST_DWithin(t.geog, seg.start_pt, seg.tol)
-                ORDER BY t.timestamp ASC
-                LIMIT 1
-            ) nxt ON TRUE
-        ),
+        ),{start_bearings_cte}
         pairs AS (
             SELECT s.activity_id, s.s_ts, MIN(e.e_ts) AS e_ts
             FROM starts s
             JOIN ends e ON e.activity_id = s.activity_id AND e.e_ts > s.s_ts
-            CROSS JOIN seg
-            LEFT JOIN start_bearings sb
-              ON sb.activity_id = s.activity_id AND sb.s_ts = s.s_ts
+            CROSS JOIN seg{bearings_join}
             WHERE EXISTS (
                 SELECT 1
                 FROM public.garmin_track_points tp

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -910,6 +910,7 @@ async def _fetch_segment_efforts(
     date_to: date | None,
     max_effort_seconds: int,
     limit: int,
+    ref_bearing_deg: float | None = None,
 ) -> list[SegmentEffort]:
     """Match GPS track points to a start→end corridor and rank efforts fastest-first.
 
@@ -918,6 +919,17 @@ async def _fetch_segment_efforts(
     passes within ``tolerance_meters`` of the start point and, later in time,
     within tolerance of the end point (same direction); the shortest such
     traversal per activity is used.
+
+    For loop segments the start and end corridors can overlap (they're the same
+    physical spot), so nearly every track point near the start/finish line would
+    otherwise satisfy both conditions a GPS tick apart. ``pairs`` therefore
+    requires the route to actually leave both corridors somewhere in between,
+    so a real lap is matched instead of two adjacent pings.
+
+    When ``ref_bearing_deg`` is given (the direction of travel through the start
+    corridor on the segment's defining activity), traversals whose own direction
+    differs by 90 degrees or more are discarded so a lap ridden backwards over
+    the same loop doesn't count as a match.
     """
     params: list[Any] = [start_lon, start_lat, end_lon, end_lat, tolerance_meters]
     idx = 6
@@ -945,6 +957,22 @@ async def _fetch_segment_efforts(
     idx += 1
     limit_idx = idx
     params.append(limit)
+    idx += 1
+
+    bearing_clause = ""
+    if ref_bearing_deg is not None:
+        ref_bearing_idx = idx
+        params.append(ref_bearing_deg)
+        idx += 1
+        bearing_clause = f"""
+            AND (
+                sb.bearing_deg IS NULL
+                OR LEAST(
+                    ABS(sb.bearing_deg - ${ref_bearing_idx}::double precision),
+                    360 - ABS(sb.bearing_deg - ${ref_bearing_idx}::double precision)
+                ) < 90
+            )
+        """
 
     query = f"""
         WITH seg AS (
@@ -958,7 +986,7 @@ async def _fetch_segment_efforts(
             WHERE TRUE{sport_clause}{date_from_clause}{date_to_clause}
         ),
         starts AS (
-            SELECT t.activity_id, t.timestamp AS s_ts
+            SELECT t.activity_id, t.timestamp AS s_ts, t.latitude, t.longitude
             FROM public.garmin_track_points t
             JOIN filtered_activities fa ON fa.activity_id = t.activity_id
             CROSS JOIN seg
@@ -971,10 +999,42 @@ async def _fetch_segment_efforts(
             CROSS JOIN seg
             WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.end_pt, seg.tol)
         ),
+        start_bearings AS (
+            SELECT s.activity_id, s.s_ts,
+                   degrees(ST_Azimuth(
+                       ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326),
+                       ST_SetSRID(ST_MakePoint(nxt.longitude, nxt.latitude), 4326)
+                   )) AS bearing_deg
+            FROM starts s
+            CROSS JOIN seg
+            JOIN LATERAL (
+                SELECT t.longitude, t.latitude
+                FROM public.garmin_track_points t
+                WHERE t.activity_id = s.activity_id
+                  AND t.timestamp > s.s_ts
+                  AND t.geog IS NOT NULL
+                  AND NOT ST_DWithin(t.geog, seg.start_pt, seg.tol)
+                ORDER BY t.timestamp ASC
+                LIMIT 1
+            ) nxt ON TRUE
+        ),
         pairs AS (
             SELECT s.activity_id, s.s_ts, MIN(e.e_ts) AS e_ts
             FROM starts s
             JOIN ends e ON e.activity_id = s.activity_id AND e.e_ts > s.s_ts
+            CROSS JOIN seg
+            LEFT JOIN start_bearings sb
+              ON sb.activity_id = s.activity_id AND sb.s_ts = s.s_ts
+            WHERE EXISTS (
+                SELECT 1
+                FROM public.garmin_track_points tp
+                WHERE tp.activity_id = s.activity_id
+                  AND tp.timestamp > s.s_ts
+                  AND tp.timestamp < e.e_ts
+                  AND tp.geog IS NOT NULL
+                  AND NOT ST_DWithin(tp.geog, seg.start_pt, seg.tol)
+                  AND NOT ST_DWithin(tp.geog, seg.end_pt, seg.tol)
+            ){bearing_clause}
             GROUP BY s.activity_id, s.s_ts
         ),
         best AS (
@@ -1008,6 +1068,63 @@ async def _fetch_segment_efforts(
 
     rows = await db.fetch(query, *params)
     return [SegmentEffort(rank=i + 1, **dict(row)) for i, row in enumerate(rows)]
+
+
+async def _segment_reference_bearing_deg(
+    db: Any,
+    *,
+    source_activity_id: str | None,
+    start_lat: float,
+    start_lon: float,
+    tolerance_meters: float,
+) -> float | None:
+    """Direction of travel through the start corridor on the segment's defining activity.
+
+    Used by ``_fetch_segment_efforts`` to reject efforts that traverse a loop
+    segment backwards. Returns ``None`` when there's no source activity, or it
+    never crosses its own corridor (so no direction filtering is applied).
+    """
+    if source_activity_id is None:
+        return None
+    row = await db.fetchrow(
+        """
+        WITH seg AS (
+            SELECT ST_MakePoint($2, $3)::geography AS start_pt,
+                   $4::double precision AS tol
+        ),
+        crossing AS (
+            SELECT t.timestamp, t.latitude, t.longitude
+            FROM public.garmin_track_points t
+            CROSS JOIN seg
+            WHERE t.activity_id = $1
+              AND t.geog IS NOT NULL
+              AND ST_DWithin(t.geog, seg.start_pt, seg.tol)
+            ORDER BY t.timestamp ASC
+            LIMIT 1
+        )
+        SELECT degrees(ST_Azimuth(
+                   ST_SetSRID(ST_MakePoint(c.longitude, c.latitude), 4326),
+                   ST_SetSRID(ST_MakePoint(nxt.longitude, nxt.latitude), 4326)
+               )) AS bearing_deg
+        FROM crossing c
+        CROSS JOIN seg
+        JOIN LATERAL (
+            SELECT t.longitude, t.latitude
+            FROM public.garmin_track_points t
+            WHERE t.activity_id = $1
+              AND t.timestamp > c.timestamp
+              AND t.geog IS NOT NULL
+              AND NOT ST_DWithin(t.geog, seg.start_pt, seg.tol)
+            ORDER BY t.timestamp ASC
+            LIMIT 1
+        ) nxt ON TRUE
+        """,
+        source_activity_id,
+        start_lon,
+        start_lat,
+        tolerance_meters,
+    )
+    return float(row["bearing_deg"]) if row and row["bearing_deg"] is not None else None
 
 
 @router.get(
@@ -1291,7 +1408,7 @@ async def get_segment_efforts(
     db = request.app.state.db
     seg = await db.fetchrow(
         "SELECT sport, start_latitude, start_longitude, end_latitude, end_longitude, "
-        "match_tolerance_meters::double precision AS match_tolerance_meters "
+        "match_tolerance_meters::double precision AS match_tolerance_meters, source_activity_id "
         "FROM public.garmin_segments WHERE id = $1 AND garmin_sync_status IS DISTINCT FROM 'delete_pending'",
         segment_id,
     )
@@ -1299,6 +1416,13 @@ async def get_segment_efforts(
         raise HTTPException(status_code=404, detail=SEGMENT_NOT_FOUND)
 
     tolerance = float(seg["match_tolerance_meters"])
+    ref_bearing_deg = await _segment_reference_bearing_deg(
+        db,
+        source_activity_id=seg["source_activity_id"],
+        start_lat=seg["start_latitude"],
+        start_lon=seg["start_longitude"],
+        tolerance_meters=tolerance,
+    )
     items = await _fetch_segment_efforts(
         db,
         start_lat=seg["start_latitude"],
@@ -1311,6 +1435,7 @@ async def get_segment_efforts(
         date_to=date_to,
         max_effort_seconds=max_effort_seconds,
         limit=limit,
+        ref_bearing_deg=ref_bearing_deg,
     )
     return SegmentEffortsResponse(
         segment=SegmentDefinition(

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1507,6 +1507,11 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
     assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in query
     assert "ST_DWithin(t.geog, seg.end_pt, seg.tol)" in query
     assert "e.e_ts > s.s_ts" in query  # same-direction enforcement
+    # a real traversal must leave both corridors, not just tick to an adjacent
+    # GPS point (this is what makes loop segments, where start ~= end, match
+    # the actual lap instead of a 1-second sliver at the start/finish line)
+    assert "NOT ST_DWithin(tp.geog, seg.start_pt, seg.tol)" in query
+    assert "NOT ST_DWithin(tp.geog, seg.end_pt, seg.tol)" in query
     assert "DISTINCT ON (activity_id)" in query  # shortest traversal per activity
     assert "ORDER BY m.elapsed_seconds ASC" in query
     # $1..$5 = start_lon, start_lat, end_lon, end_lat, tolerance
@@ -1720,6 +1725,7 @@ async def test_get_segment_efforts_uses_saved_coords(client: AsyncClient, mock_d
         "end_latitude": 40.79002409,
         "end_longitude": -73.96422816,
         "match_tolerance_meters": 40.0,
+        "source_activity_id": None,
     }
     mock_db.fetch.return_value = [
         _segment_effort_row("a-fast", 79.0),
@@ -1736,6 +1742,62 @@ async def test_get_segment_efforts_uses_saved_coords(client: AsyncClient, mock_d
     assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in efforts_query
     # matching used the saved segment's coordinates and tolerance
     assert efforts_params[:5] == [-73.96104321, 40.79366846, -73.96422816, 40.79002409, 40.0]
+
+
+@pytest.mark.asyncio
+async def test_get_segment_efforts_rejects_reverse_direction(client: AsyncClient, mock_db):
+    """Loop segments (start ~= end) must reject laps ridden the opposite way.
+
+    The segment's own source_activity_id supplies the canonical direction of
+    travel through the start corridor; efforts whose bearing differs by 90
+    degrees or more are filtered out in the SQL, not just deduped.
+    """
+    mock_db.fetchrow.side_effect = [
+        {
+            "sport": "cycling",
+            "start_latitude": 40.707439882680774,
+            "start_longitude": -74.03477042913437,
+            "end_latitude": 40.707470728084445,
+            "end_longitude": -74.03477034531534,
+            "match_tolerance_meters": 35.0,
+            "source_activity_id": "23541736805",
+        },
+        {"bearing_deg": 197.5},
+    ]
+    mock_db.fetch.return_value = []
+
+    response = await client.get("/api/v1/garmin/segments/7/efforts")
+
+    assert response.status_code == 200
+    bearing_query, *bearing_params = mock_db.fetchrow.await_args_list[1].args
+    assert bearing_params[0] == "23541736805"
+
+    efforts_query, *efforts_params = mock_db.fetch.await_args.args
+    assert "start_bearings" in efforts_query
+    assert "LEAST(" in efforts_query
+    assert efforts_params[-1] == 197.5
+
+
+@pytest.mark.asyncio
+async def test_get_segment_efforts_skips_bearing_lookup_without_source_activity(client: AsyncClient, mock_db):
+    mock_db.fetchrow.return_value = {
+        "sport": "cycling",
+        "start_latitude": 40.79366846,
+        "start_longitude": -73.96104321,
+        "end_latitude": 40.79002409,
+        "end_longitude": -73.96422816,
+        "match_tolerance_meters": 40.0,
+        "source_activity_id": None,
+    }
+    mock_db.fetch.return_value = []
+
+    response = await client.get("/api/v1/garmin/segments/5/efforts")
+
+    assert response.status_code == 200
+    assert mock_db.fetchrow.await_count == 1  # no reference-bearing lookup fired
+    efforts_query, *efforts_params = mock_db.fetch.await_args.args
+    assert "start_bearings" in efforts_query  # CTE always present
+    assert efforts_params[-1] == 100  # last param is still the limit, no bearing appended
 
 
 @pytest.mark.asyncio

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1512,6 +1512,9 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
     # the actual lap instead of a 1-second sliver at the start/finish line)
     assert "NOT ST_DWithin(tp.geog, seg.start_pt, seg.tol)" in query
     assert "NOT ST_DWithin(tp.geog, seg.end_pt, seg.tol)" in query
+    # stateless endpoint has no reference activity to compare direction
+    # against, so the bearing CTE/join is omitted rather than computed unused
+    assert "start_bearings" not in query
     assert "DISTINCT ON (activity_id)" in query  # shortest traversal per activity
     assert "ORDER BY m.elapsed_seconds ASC" in query
     # $1..$5 = start_lon, start_lat, end_lon, end_lat, tolerance
@@ -1796,7 +1799,9 @@ async def test_get_segment_efforts_skips_bearing_lookup_without_source_activity(
     assert response.status_code == 200
     assert mock_db.fetchrow.await_count == 1  # no reference-bearing lookup fired
     efforts_query, *efforts_params = mock_db.fetch.await_args.args
-    assert "start_bearings" in efforts_query  # CTE always present
+    # no reference bearing to compare against, so the CTE (and its per-start
+    # LATERAL lookup) is omitted rather than computed and ignored
+    assert "start_bearings" not in efforts_query
     assert efforts_params[-1] == 100  # last param is still the limit, no bearing appended
 
 


### PR DESCRIPTION
## Summary
- Segment 7 (Liberty State Park Loop) and other loop segments store start/end points only a few meters apart, well inside the match tolerance, so the segment-effort query treated almost every track point near the start/finish line as both a valid start and a valid end. It always locked onto the fastest possible pair per activity — two GPS pings a second apart — instead of the real lap, showing `0:01` / `0.00 mi` on the leaderboard.
- `_fetch_segment_efforts` now requires the route to actually leave both the start and end corridors somewhere between the matched timestamps, so a genuine lap is matched instead of an adjacent-ping fluke.
- For saved segments, a new reference bearing (derived from the segment's `source_activity_id`) rejects efforts whose direction of travel through the start corridor differs by 90°+ from the canonical direction, so riding the same loop backwards doesn't count as a match.

## Root cause / verification
Confirmed directly against production data: segment 7's start/end coordinates are ~3.4m apart (35m tolerance), and the buggy query matched consecutive 1-second-apart GPS pings. After the fix, the same activities resolve to realistic ~17-20 minute, ~3.7 mi laps (avg 18-22 km/h) consistent with the segment's stored 6.07 km distance. Also validated against several multi-lap activities (2-3 loop crossings in one ride).

## Test plan
- [x] `pytest tests/` — 233 passed
- [x] `ruff check` / `ruff format` / `mypy` — clean (pre-existing unrelated mypy warnings in `middleware.py`/`auth.py` only)
- [x] Added tests: corridor-exit requirement present in SQL, reference-bearing lookup wired for segments with a `source_activity_id`, and skipped when there isn't one
- [x] Verified query output against the live DB for segment 7 and several multi-lap activities

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>