### PR TITLE
fix(garmin): fix production 500 on segment efforts, add multi-lap support

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -912,24 +912,37 @@ async def _fetch_segment_efforts(
     limit: int,
     ref_bearing_deg: float | None = None,
 ) -> list[SegmentEffort]:
-    """Match GPS track points to a start→end corridor and rank efforts fastest-first.
+    """Match GPS track points to a start→end corridor and rank every qualifying lap.
 
     Shared by the stateless ``/segment-efforts`` endpoint and the saved-segment
-    ``/segments/{id}/efforts`` endpoint. An activity qualifies when its route
-    passes within ``tolerance_meters`` of the start point and, later in time,
-    within tolerance of the end point (same direction); the shortest such
-    traversal per activity is used.
+    ``/segments/{id}/efforts`` endpoint. An activity qualifies each time its
+    route passes within ``tolerance_meters`` of the start point and, later in
+    time, within tolerance of the end point (same direction) -- an activity
+    that laps the segment multiple times (e.g. repeats of a loop) yields one
+    effort per lap, not just its fastest.
 
-    For loop segments the start and end corridors can overlap (they're the same
-    physical spot), so nearly every track point near the start/finish line would
-    otherwise satisfy both conditions a GPS tick apart. ``pairs`` therefore
-    requires the route to actually leave both corridors somewhere in between,
-    so a real lap is matched instead of two adjacent pings.
+    Raw GPS pings near the start or end point arrive in bursts (many points a
+    few seconds apart per physical crossing), so ``crossings`` clusters
+    consecutive hits more than 2 minutes apart -- comfortably below real lap
+    durations but well above a single crossing's span -- into one
+    representative row per physical visit, tagged with whether that visit was
+    near the start point, the end point, or (for loop segments, where they're
+    the same physical spot) both. Without this, every point in a burst would
+    pair up separately and one lap would look like a dozen near-duplicate
+    efforts.
 
-    When ``ref_bearing_deg`` is given (the direction of travel through the start
-    corridor on the segment's defining activity), traversals whose own direction
-    differs by 90 degrees or more are discarded so a lap ridden backwards over
-    the same loop doesn't count as a match.
+    Because two *different* crossings are by definition separated by a gap
+    where the route was near neither point, pairing a start-tagged crossing
+    with the next later end-tagged crossing already guarantees the route left
+    both corridors in between -- no per-pair distance check against the full
+    track needed, which is what made the previous approach (a correlated
+    EXISTS re-scanning the track between every candidate start/end pair)
+    prohibitively slow.
+
+    When ``ref_bearing_deg`` is given (the direction of travel through the
+    start corridor on the segment's defining activity), traversals whose own
+    direction differs by 90 degrees or more are discarded so a lap ridden
+    backwards over the same loop doesn't count as a match.
     """
     params: list[Any] = [start_lon, start_lat, end_lon, end_lat, tolerance_meters]
     idx = 6
@@ -972,27 +985,28 @@ async def _fetch_segment_efforts(
         idx += 1
         start_bearings_cte = """
         start_bearings AS (
-            SELECT s.activity_id, s.s_ts,
+            SELECT s.activity_id, s.c_ts AS s_ts,
                    degrees(ST_Azimuth(
                        ST_SetSRID(ST_MakePoint(s.longitude, s.latitude), 4326),
                        ST_SetSRID(ST_MakePoint(nxt.longitude, nxt.latitude), 4326)
                    )) AS bearing_deg
-            FROM starts s
+            FROM crossings s
             CROSS JOIN seg
             JOIN LATERAL (
                 SELECT t.longitude, t.latitude
                 FROM public.garmin_track_points t
                 WHERE t.activity_id = s.activity_id
-                  AND t.timestamp > s.s_ts
+                  AND t.timestamp > s.c_ts
                   AND t.geog IS NOT NULL
                   AND NOT ST_DWithin(t.geog, seg.start_pt, seg.tol)
                 ORDER BY t.timestamp ASC
                 LIMIT 1
             ) nxt ON TRUE
+            WHERE s.is_start
         ),"""
         bearings_join = """
             LEFT JOIN start_bearings sb
-              ON sb.activity_id = s.activity_id AND sb.s_ts = s.s_ts"""
+              ON sb.activity_id = s.activity_id AND sb.s_ts = s.c_ts"""
         bearing_clause = f"""
             AND (
                 sb.bearing_deg IS NULL
@@ -1014,41 +1028,45 @@ async def _fetch_segment_efforts(
             FROM public.garmin_activities a
             WHERE TRUE{sport_clause}{date_from_clause}{date_to_clause}
         ),
-        starts AS (
-            SELECT t.activity_id, t.timestamp AS s_ts, t.latitude, t.longitude
+        crossing_hits AS (
+            SELECT t.activity_id, t.timestamp AS c_ts, t.latitude, t.longitude,
+                   ST_DWithin(t.geog, seg.start_pt, seg.tol) AS is_start,
+                   ST_DWithin(t.geog, seg.end_pt, seg.tol) AS is_end,
+                   LAG(t.timestamp) OVER (PARTITION BY t.activity_id ORDER BY t.timestamp) AS prev_ts
             FROM public.garmin_track_points t
             JOIN filtered_activities fa ON fa.activity_id = t.activity_id
             CROSS JOIN seg
-            WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.start_pt, seg.tol)
+            WHERE t.geog IS NOT NULL
+              AND (ST_DWithin(t.geog, seg.start_pt, seg.tol) OR ST_DWithin(t.geog, seg.end_pt, seg.tol))
         ),
-        ends AS (
-            SELECT t.activity_id, t.timestamp AS e_ts
-            FROM public.garmin_track_points t
-            JOIN filtered_activities fa ON fa.activity_id = t.activity_id
-            CROSS JOIN seg
-            WHERE t.geog IS NOT NULL AND ST_DWithin(t.geog, seg.end_pt, seg.tol)
+        crossing_grouped AS (
+            SELECT activity_id, c_ts, latitude, longitude, is_start, is_end,
+                   SUM(CASE WHEN prev_ts IS NULL OR c_ts - prev_ts > INTERVAL '2 minutes' THEN 1 ELSE 0 END)
+                     OVER (PARTITION BY activity_id ORDER BY c_ts) AS crossing
+            FROM crossing_hits
+        ),
+        crossing_repr AS (
+            SELECT DISTINCT ON (activity_id, crossing) activity_id, crossing, c_ts, latitude, longitude
+            FROM crossing_grouped
+            ORDER BY activity_id, crossing, c_ts ASC
+        ),
+        crossing_flags AS (
+            SELECT activity_id, crossing, bool_or(is_start) AS is_start, bool_or(is_end) AS is_end
+            FROM crossing_grouped
+            GROUP BY activity_id, crossing
+        ),
+        crossings AS (
+            SELECT r.activity_id, r.c_ts, r.latitude, r.longitude, f.is_start, f.is_end
+            FROM crossing_repr r
+            JOIN crossing_flags f ON f.activity_id = r.activity_id AND f.crossing = r.crossing
         ),{start_bearings_cte}
         pairs AS (
-            SELECT s.activity_id, s.s_ts, MIN(e.e_ts) AS e_ts
-            FROM starts s
-            JOIN ends e ON e.activity_id = s.activity_id AND e.e_ts > s.s_ts
-            CROSS JOIN seg{bearings_join}
-            WHERE EXISTS (
-                SELECT 1
-                FROM public.garmin_track_points tp
-                WHERE tp.activity_id = s.activity_id
-                  AND tp.timestamp > s.s_ts
-                  AND tp.timestamp < e.e_ts
-                  AND tp.geog IS NOT NULL
-                  AND NOT ST_DWithin(tp.geog, seg.start_pt, seg.tol)
-                  AND NOT ST_DWithin(tp.geog, seg.end_pt, seg.tol)
-            ){bearing_clause}
-            GROUP BY s.activity_id, s.s_ts
-        ),
-        best AS (
-            SELECT DISTINCT ON (activity_id) activity_id, s_ts, e_ts
-            FROM pairs
-            ORDER BY activity_id, (e_ts - s_ts) ASC
+            SELECT s.activity_id, s.c_ts AS s_ts, MIN(e.c_ts) AS e_ts
+            FROM crossings s
+            JOIN crossings e ON e.activity_id = s.activity_id AND e.c_ts > s.c_ts AND e.is_end
+            {bearings_join}
+            WHERE s.is_start{bearing_clause}
+            GROUP BY s.activity_id, s.c_ts
         ),
         metrics AS (
             SELECT b.activity_id, b.s_ts, b.e_ts,
@@ -1057,7 +1075,7 @@ async def _fetch_segment_efforts(
                    AVG(t.heart_rate) FILTER (WHERE t.heart_rate > 0) AS avg_hr,
                    MAX(t.heart_rate) AS max_heart_rate,
                    MAX(t.distance_from_start_km) - MIN(t.distance_from_start_km) AS distance_km
-            FROM best b
+            FROM pairs b
             JOIN public.garmin_track_points t
               ON t.activity_id = b.activity_id
              AND t.timestamp BETWEEN b.s_ts AND b.e_ts

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -922,22 +922,28 @@ async def _fetch_segment_efforts(
     effort per lap, not just its fastest.
 
     Raw GPS pings near the start or end point arrive in bursts (many points a
-    few seconds apart per physical crossing), so ``crossings`` clusters
-    consecutive hits more than 2 minutes apart -- comfortably below real lap
-    durations but well above a single crossing's span -- into one
-    representative row per physical visit, tagged with whether that visit was
-    near the start point, the end point, or (for loop segments, where they're
-    the same physical spot) both. Without this, every point in a burst would
-    pair up separately and one lap would look like a dozen near-duplicate
-    efforts.
+    few seconds apart per physical crossing), so ``crossings`` clusters them
+    into one representative row per physical visit, tagged with whether that
+    visit was near the start point, the end point, or (for loop segments,
+    where they're the same physical spot) both. Without this, every point in
+    a burst would pair up separately and one lap would look like a dozen
+    near-duplicate efforts. A new crossing starts on a gap of more than 2
+    minutes since the last hit (comfortably below real lap durations, well
+    above a single crossing's span) -- but also, regardless of timing, the
+    moment a start-only hit is directly followed by an end-only hit (or vice
+    versa) with no overlap hit in between, since that flip already means the
+    route left the start corridor and reached the end corridor. The latter
+    rule matters for short/fast point-to-point segments, where the start and
+    end corridors don't overlap and the whole traversal can take well under
+    2 minutes -- relying on the time gap alone would merge the start and end
+    hits into a single crossing and silently drop the effort entirely.
 
-    Because two *different* crossings are by definition separated by a gap
-    where the route was near neither point, pairing a start-tagged crossing
-    with the next later end-tagged crossing already guarantees the route left
-    both corridors in between -- no per-pair distance check against the full
-    track needed, which is what made the previous approach (a correlated
-    EXISTS re-scanning the track between every candidate start/end pair)
-    prohibitively slow.
+    Because two *different* crossings are (by one rule or the other)
+    guaranteed to be separated by the route leaving both corridors, pairing a
+    start-tagged crossing with the next later end-tagged crossing needs no
+    per-pair distance check against the full track -- which is what made the
+    previous approach (a correlated EXISTS re-scanning the track between
+    every candidate start/end pair) prohibitively slow.
 
     When ``ref_bearing_deg`` is given (the direction of travel through the
     start corridor on the segment's defining activity), traversals whose own
@@ -1032,7 +1038,11 @@ async def _fetch_segment_efforts(
             SELECT t.activity_id, t.timestamp AS c_ts, t.latitude, t.longitude,
                    ST_DWithin(t.geog, seg.start_pt, seg.tol) AS is_start,
                    ST_DWithin(t.geog, seg.end_pt, seg.tol) AS is_end,
-                   LAG(t.timestamp) OVER (PARTITION BY t.activity_id ORDER BY t.timestamp) AS prev_ts
+                   LAG(t.timestamp) OVER (PARTITION BY t.activity_id ORDER BY t.timestamp) AS prev_ts,
+                   LAG(ST_DWithin(t.geog, seg.start_pt, seg.tol))
+                     OVER (PARTITION BY t.activity_id ORDER BY t.timestamp) AS prev_is_start,
+                   LAG(ST_DWithin(t.geog, seg.end_pt, seg.tol))
+                     OVER (PARTITION BY t.activity_id ORDER BY t.timestamp) AS prev_is_end
             FROM public.garmin_track_points t
             JOIN filtered_activities fa ON fa.activity_id = t.activity_id
             CROSS JOIN seg
@@ -1041,7 +1051,18 @@ async def _fetch_segment_efforts(
         ),
         crossing_grouped AS (
             SELECT activity_id, c_ts, latitude, longitude, is_start, is_end,
-                   SUM(CASE WHEN prev_ts IS NULL OR c_ts - prev_ts > INTERVAL '2 minutes' THEN 1 ELSE 0 END)
+                   SUM(CASE
+                         WHEN prev_ts IS NULL OR c_ts - prev_ts > INTERVAL '2 minutes' THEN 1
+                         -- a direct start-only -> end-only (or reverse) flip, with no
+                         -- overlap hit in between, means the route left the start
+                         -- corridor and reached the end corridor -- a real traversal
+                         -- boundary regardless of how little time it took, which
+                         -- matters for short/fast point-to-point segments where the
+                         -- start and end corridors don't overlap
+                         WHEN prev_is_start AND NOT prev_is_end AND is_end AND NOT is_start THEN 1
+                         WHEN prev_is_end AND NOT prev_is_start AND is_start AND NOT is_end THEN 1
+                         ELSE 0
+                       END)
                      OVER (PARTITION BY activity_id ORDER BY c_ts) AS crossing
             FROM crossing_hits
         ),

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1536,6 +1536,14 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
     assert "e.c_ts > s.c_ts" in query  # same-direction enforcement
     assert "AND e.is_end" in query
     assert "WHERE s.is_start" in query
+    # a new crossing must start on a direct start-only -> end-only flip (and
+    # the reverse), not just a >2min time gap -- otherwise a short/fast
+    # point-to-point segment (start and end corridors far enough apart that
+    # they never overlap, but close enough to finish in well under 2 minutes)
+    # would have its start and end hits merged into one crossing, leaving no
+    # separate start/end row to pair and silently dropping the effort
+    assert "prev_is_start AND NOT prev_is_end AND is_end AND NOT is_start" in query
+    assert "prev_is_end AND NOT prev_is_start AND is_start AND NOT is_end" in query
     # the "left both corridors in between" guarantee comes from the >2min gap
     # used to cluster crossings, not a per-pair check against the full track
     # (a correlated EXISTS re-scanning track_points was too slow in production)

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1480,6 +1480,33 @@ async def test_segment_efforts_returns_ranked(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_segment_efforts_keeps_multiple_laps_from_one_activity(client: AsyncClient, mock_db):
+    """A single ride that laps the segment twice should surface as two efforts.
+
+    Guards against the response layer collapsing rows by activity_id -- the
+    SQL itself (not tested here, see live-DB verification) is what collapses
+    GPS-ping bursts down to one row per real crossing while still returning
+    every distinct lap.
+    """
+    mock_db.fetch.return_value = [
+        _segment_effort_row("multi-lap-ride", 1098.0),
+        _segment_effort_row("multi-lap-ride", 1199.0),
+    ]
+
+    response = await client.get(
+        "/api/v1/garmin/segment-efforts"
+        "?start_lat=40.79366846&start_lon=-73.96104321"
+        "&end_lat=40.79002409&end_lon=-73.96422816"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    assert [e["activity_id"] for e in body["items"]] == ["multi-lap-ride", "multi-lap-ride"]
+    assert [e["elapsed_seconds"] for e in body["items"]] == [1098.0, 1199.0]
+
+
+@pytest.mark.asyncio
 async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
     mock_db.fetch.return_value = []
 
@@ -1506,16 +1533,20 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
     query, *params = mock_db.fetch.await_args.args
     assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in query
     assert "ST_DWithin(t.geog, seg.end_pt, seg.tol)" in query
-    assert "e.e_ts > s.s_ts" in query  # same-direction enforcement
-    # a real traversal must leave both corridors, not just tick to an adjacent
-    # GPS point (this is what makes loop segments, where start ~= end, match
-    # the actual lap instead of a 1-second sliver at the start/finish line)
-    assert "NOT ST_DWithin(tp.geog, seg.start_pt, seg.tol)" in query
-    assert "NOT ST_DWithin(tp.geog, seg.end_pt, seg.tol)" in query
+    assert "e.c_ts > s.c_ts" in query  # same-direction enforcement
+    assert "AND e.is_end" in query
+    assert "WHERE s.is_start" in query
+    # the "left both corridors in between" guarantee comes from the >2min gap
+    # used to cluster crossings, not a per-pair check against the full track
+    # (a correlated EXISTS re-scanning track_points was too slow in production)
+    assert "EXISTS" not in query
     # stateless endpoint has no reference activity to compare direction
     # against, so the bearing CTE/join is omitted rather than computed unused
     assert "start_bearings" not in query
-    assert "DISTINCT ON (activity_id)" in query  # shortest traversal per activity
+    # every qualifying lap is returned (not just the fastest per activity), so
+    # repeated laps of a loop in one activity all show up
+    assert "DISTINCT ON (activity_id)" not in query
+    assert "DISTINCT ON (activity_id, crossing)" in query  # collapses GPS-ping bursts into one row per crossing
     assert "ORDER BY m.elapsed_seconds ASC" in query
     # $1..$5 = start_lon, start_lat, end_lon, end_lat, tolerance
     assert params[:5] == [-73.96104321, 40.79366846, -73.96422816, 40.79002409, 40]
@@ -1753,7 +1784,7 @@ async def test_get_segment_efforts_rejects_reverse_direction(client: AsyncClient
 
     The segment's own source_activity_id supplies the canonical direction of
     travel through the start corridor; efforts whose bearing differs by 90
-    degrees or more are filtered out in the SQL, not just deduped.
+    degrees or more are filtered out in the SQL, not merely deduplicated.
     """
     mock_db.fetchrow.side_effect = [
         {


### PR DESCRIPTION
## Summary

**This fixes a live production incident.** The site is currently returning `REST API error 500: Internal Server Error` on segment effort queries (e.g. Liberty State Park Loop, segment 7) -- reproduced directly against the gateway just now (15s before the 500).

### Root cause
The corridor-exit check merged in #214 used a correlated `EXISTS` re-scanning `garmin_track_points` between every candidate start/end pair. Verified directly against the production DB with `EXPLAIN ANALYZE`: Postgres planned this as a `Hash Semi Join` against the **entire 4.8M-row table** (~6s just to build the hash, `Rows Removed by Join Filter: 556390`), pushing total query time for this segment to **32 seconds** -- past the gateway's request timeout, which is exactly what surfaced as the 500.

### Fix
Replaced the separate `starts`/`ends` CTEs (raw, un-deduplicated GPS pings) + correlated `EXISTS` with a single clustering pass that tags each physical crossing as `is_start`/`is_end`. Two *different* crossings are, by construction, separated by a >2min gap where the route was near neither point -- so pairing a start-tagged crossing with the next end-tagged one already guarantees the route left both corridors in between. No per-pair distance check against the full track table needed.

This also gives correct **multi-lap support** "for free": an activity that laps a loop segment several times (e.g. activity `23541736805`, which rode Liberty State Park Loop 4 times back-to-back) now yields one effort per lap instead of only its single fastest lap.

### Verified against production data
- Segment 7: 32s -> ~215ms query execution (~2.4s wall time including Postgres JIT compilation overhead for this query shape -- a separate, non-blocking follow-up; forcing `jit=off` confirmed the real execution time is 215ms).
- All 4 laps of activity `23541736805` still correctly surface.
- Also verified against a non-loop, point-to-point segment (Hudson River Bike Path South, ~7.5km start/end) to confirm no regression there: 1.2s, correct ~27min/8km efforts.

## Test plan
- [x] `pytest tests/` -- 234 passed
- [x] `ruff` / `mypy` -- clean (pre-existing unrelated mypy warnings in `middleware.py`/`auth.py` only)
- [x] `EXPLAIN ANALYZE` against production DB confirming the query plan no longer touches the full track table
- [x] Re-verified segment 7's multi-lap output and a second, non-loop segment for regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>