### PR TITLE
fix(garmin): reconstruct loop segment routes from lap boundaries

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1260,12 +1260,19 @@ _SEGMENT_SELECT_COLUMNS = (
     "r.route"
 )
 
-# Recover each segment's real path from its source activity GPS track: snap the
-# stored start/end to the nearest in-corridor track points (same ST_DWithin
-# corridor used by segment efforts), slice the ordered track between them, and
+# Recover each segment's real path from its source activity GPS track and
 # return a PostGIS-simplified array of ordered [latitude, longitude] pairs.
 # Yields NULL route when the segment has no source activity or no matchable
-# corridor, in which case the client falls back to a straight start→end line.
+# slice, in which case the client falls back to a straight start->end line.
+#
+# When the segment was saved from a recorded lap (source_lap_index), that
+# lap's own start_time/duration_seconds give the exact slice boundaries --
+# no proximity matching involved, so there's no ambiguity for loop segments
+# (where the start and end points are the same physical spot). Otherwise
+# (climb- or manually-drawn segments), the boundaries are recovered by
+# clustering raw GPS proximity hits into physical crossings the same way
+# _fetch_segment_efforts does, so a loop's start/end corridor overlap can't
+# collapse the slice down to a same-instant sliver either.
 _SEGMENT_ROUTE_LATERAL = """
     LEFT JOIN LATERAL (
         WITH bounds AS (
@@ -1274,34 +1281,78 @@ _SEGMENT_ROUTE_LATERAL = """
                 ST_MakePoint(s.end_longitude, s.end_latitude)::geography AS end_pt,
                 GREATEST(s.match_tolerance_meters, 5)::double precision AS tol
         ),
-        start_ts AS (
-            SELECT MIN(t.timestamp) AS ts
+        lap_bounds AS (
+            SELECT al.start_time AS s_ts,
+                   al.start_time + make_interval(secs => al.duration_seconds::double precision) AS e_ts
+            FROM public.garmin_activity_laps al
+            WHERE s.source_lap_index IS NOT NULL
+              AND al.activity_id = s.source_activity_id
+              AND al.lap_index = s.source_lap_index + 1
+        ),
+        crossing_hits AS (
+            SELECT t.timestamp AS c_ts,
+                   ST_DWithin(t.geog, bounds.start_pt, bounds.tol) AS is_start,
+                   ST_DWithin(t.geog, bounds.end_pt, bounds.tol) AS is_end,
+                   LAG(t.timestamp) OVER (ORDER BY t.timestamp) AS prev_ts,
+                   LAG(ST_DWithin(t.geog, bounds.start_pt, bounds.tol)) OVER (ORDER BY t.timestamp) AS prev_is_start,
+                   LAG(ST_DWithin(t.geog, bounds.end_pt, bounds.tol)) OVER (ORDER BY t.timestamp) AS prev_is_end
             FROM public.garmin_track_points t, bounds
             WHERE t.activity_id = s.source_activity_id
               AND t.geog IS NOT NULL
-              AND ST_DWithin(t.geog, bounds.start_pt, bounds.tol)
+              AND (ST_DWithin(t.geog, bounds.start_pt, bounds.tol) OR ST_DWithin(t.geog, bounds.end_pt, bounds.tol))
         ),
-        end_ts AS (
-            SELECT MIN(t.timestamp) AS ts
-            FROM public.garmin_track_points t, bounds, start_ts
-            WHERE t.activity_id = s.source_activity_id
-              AND t.geog IS NOT NULL
-              AND ST_DWithin(t.geog, bounds.end_pt, bounds.tol)
-              AND start_ts.ts IS NOT NULL
-              AND t.timestamp > start_ts.ts
+        crossing_grouped AS (
+            SELECT c_ts, is_start, is_end,
+                   SUM(CASE
+                         WHEN prev_ts IS NULL OR c_ts - prev_ts > INTERVAL '2 minutes' THEN 1
+                         WHEN prev_is_start AND NOT prev_is_end AND is_end AND NOT is_start THEN 1
+                         WHEN prev_is_end AND NOT prev_is_start AND is_start AND NOT is_end THEN 1
+                         ELSE 0
+                       END) OVER (ORDER BY c_ts) AS crossing
+            FROM crossing_hits
+        ),
+        crossing_repr AS (
+            SELECT DISTINCT ON (crossing) crossing, c_ts
+            FROM crossing_grouped
+            ORDER BY crossing, c_ts ASC
+        ),
+        crossing_flags AS (
+            SELECT crossing, bool_or(is_start) AS is_start, bool_or(is_end) AS is_end
+            FROM crossing_grouped
+            GROUP BY crossing
+        ),
+        crossings AS (
+            SELECT r.c_ts, f.is_start, f.is_end
+            FROM crossing_repr r
+            JOIN crossing_flags f ON f.crossing = r.crossing
+        ),
+        proximity_bounds AS (
+            SELECT cs.c_ts AS s_ts, MIN(ce.c_ts) AS e_ts
+            FROM crossings cs
+            JOIN crossings ce ON ce.c_ts > cs.c_ts AND ce.is_end
+            WHERE cs.is_start
+            GROUP BY cs.c_ts
+            ORDER BY cs.c_ts ASC
+            LIMIT 1
+        ),
+        chosen_bounds AS (
+            SELECT COALESCE(lap_bounds.s_ts, proximity_bounds.s_ts) AS s_ts,
+                   COALESCE(lap_bounds.e_ts, proximity_bounds.e_ts) AS e_ts
+            FROM lap_bounds
+            FULL OUTER JOIN proximity_bounds ON TRUE
         ),
         line AS (
             SELECT ST_Simplify(
                        ST_MakeLine(ST_MakePoint(t.longitude, t.latitude) ORDER BY t.timestamp ASC),
                        0.00005
                    ) AS geom
-            FROM public.garmin_track_points t, start_ts, end_ts
+            FROM public.garmin_track_points t, chosen_bounds
             WHERE t.activity_id = s.source_activity_id
               AND t.latitude IS NOT NULL
               AND t.longitude IS NOT NULL
-              AND start_ts.ts IS NOT NULL
-              AND end_ts.ts IS NOT NULL
-              AND t.timestamp BETWEEN start_ts.ts AND end_ts.ts
+              AND chosen_bounds.s_ts IS NOT NULL
+              AND chosen_bounds.e_ts IS NOT NULL
+              AND t.timestamp BETWEEN chosen_bounds.s_ts AND chosen_bounds.e_ts
         )
         SELECT array_agg(
                    ARRAY[ST_Y((dp).geom), ST_X((dp).geom)]

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1282,14 +1282,25 @@ _SEGMENT_ROUTE_LATERAL = """
                 GREATEST(s.match_tolerance_meters, 5)::double precision AS tol
         ),
         lap_bounds AS (
+            -- duration_seconds (never NULL, cross-checked against start/end
+            -- timestamps) is used instead of end_time: end_time diverges from
+            -- start_time + duration_seconds by more than 5s in ~34% of rows in
+            -- this table, including cases where it's *before* start_time, so
+            -- it isn't a reliable slice boundary on its own.
             SELECT al.start_time AS s_ts,
                    al.start_time + make_interval(secs => al.duration_seconds::double precision) AS e_ts
             FROM public.garmin_activity_laps al
             WHERE s.source_lap_index IS NOT NULL
               AND al.activity_id = s.source_activity_id
               AND al.lap_index = s.source_lap_index + 1
+              AND al.start_time IS NOT NULL
+              AND al.duration_seconds IS NOT NULL
+            LIMIT 1
         ),
         crossing_hits AS (
+            -- Skipped entirely once lap_bounds has a usable row: proximity
+            -- matching is only a fallback for climb-/manually-derived
+            -- segments that have no recorded lap to anchor on.
             SELECT t.timestamp AS c_ts,
                    ST_DWithin(t.geog, bounds.start_pt, bounds.tol) AS is_start,
                    ST_DWithin(t.geog, bounds.end_pt, bounds.tol) AS is_end,
@@ -1297,7 +1308,8 @@ _SEGMENT_ROUTE_LATERAL = """
                    LAG(ST_DWithin(t.geog, bounds.start_pt, bounds.tol)) OVER (ORDER BY t.timestamp) AS prev_is_start,
                    LAG(ST_DWithin(t.geog, bounds.end_pt, bounds.tol)) OVER (ORDER BY t.timestamp) AS prev_is_end
             FROM public.garmin_track_points t, bounds
-            WHERE t.activity_id = s.source_activity_id
+            WHERE NOT EXISTS (SELECT 1 FROM lap_bounds)
+              AND t.activity_id = s.source_activity_id
               AND t.geog IS NOT NULL
               AND (ST_DWithin(t.geog, bounds.start_pt, bounds.tol) OR ST_DWithin(t.geog, bounds.end_pt, bounds.tol))
         ),

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1704,6 +1704,15 @@ async def test_segment_route_lateral_prefers_lap_boundaries(client: AsyncClient,
     assert "al.lap_index = s.source_lap_index + 1" in query
     assert "make_interval(secs => al.duration_seconds" in query
     assert "COALESCE(lap_bounds.s_ts, proximity_bounds.s_ts)" in query
+    # lap_bounds must not surface a row with a NULL boundary (which would
+    # otherwise mix an exact lap start with a proximity-derived end, or drop
+    # the slice even though the proximity fallback could have supplied one)
+    assert "al.start_time IS NOT NULL" in query
+    assert "al.duration_seconds IS NOT NULL" in query
+    # proximity matching only kicks in when there's no usable lap boundary,
+    # both for correctness (it's meant as a fallback, not a second opinion)
+    # and to avoid the ST_DWithin scan entirely for lap-derived segments
+    assert "WHERE NOT EXISTS (SELECT 1 FROM lap_bounds)" in query
     # the proximity fallback must cluster hits, not just take the first/MIN
     # start and MIN end proximity hit (that's what previously collapsed a
     # loop's start and end into a same-instant sliver)

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1684,6 +1684,33 @@ async def test_list_segments_returns_route(client: AsyncClient, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_segment_route_lateral_prefers_lap_boundaries(client: AsyncClient, mock_db):
+    """Loop segments (start ~= end) must not collapse the route to a sliver.
+
+    When the segment was saved from a recorded lap, the lap's own
+    start_time/duration_seconds give exact slice boundaries -- no proximity
+    matching, so no ambiguity for a loop where the start and end points are
+    the same physical spot. Falls back to proximity-based crossing detection
+    (clustered the same way _fetch_segment_efforts is) only when there's no
+    lap index.
+    """
+    mock_db.fetch.return_value = [_segment_row(1)]
+
+    response = await client.get("/api/v1/garmin/segments")
+
+    assert response.status_code == 200
+    query, *_ = mock_db.fetch.await_args.args
+    assert "garmin_activity_laps" in query
+    assert "al.lap_index = s.source_lap_index + 1" in query
+    assert "make_interval(secs => al.duration_seconds" in query
+    assert "COALESCE(lap_bounds.s_ts, proximity_bounds.s_ts)" in query
+    # the proximity fallback must cluster hits, not just take the first/MIN
+    # start and MIN end proximity hit (that's what previously collapsed a
+    # loop's start and end into a same-instant sliver)
+    assert "prev_is_start AND NOT prev_is_end AND is_end AND NOT is_start" in query
+
+
+@pytest.mark.asyncio
 async def test_list_segments_null_route(client: AsyncClient, mock_db):
     mock_db.fetch.return_value = [_segment_row(1, route=None)]
 


### PR DESCRIPTION
## Summary

Follow-up to #214/#215. The segments list page's map preview (`SegmentMiniMap`) showed a nearly-blank thumbnail for Liberty State Park Loop (segment 7) -- confirmed via the API, not just visually: `garminSegment(id: 7) { route }` returned only **2 points ~6m apart**, instead of a full loop shape. Every other (point-to-point) segment has a proper multi-point route (7-92 points).

### Root cause
Same pattern already fixed twice in the effort-matching code, but in a third, untouched place: `_SEGMENT_ROUTE_LATERAL` picked `start_ts = MIN(timestamp near start point)` and `end_ts = MIN(timestamp near end point, later than start_ts)`. For a loop (start ~= end, ~3.4m apart here), the very next GPS ping after the first start-corridor hit is *also* within tolerance of the end point, so the "route" collapsed to a same-instant sliver instead of the real ~18-minute lap.

The segment detail page's own map looked fine throughout this whole investigation because it doesn't use this field at all -- `SegmentStartEndMap`/`getSegmentRoutePoints` independently re-slices the full source-activity track by nearest-point snapping, sidestepping the bug entirely.

### Fix
- When the segment was saved from a recorded lap (`source_lap_index` is set), use that lap's own `start_time`/`duration_seconds` from `garmin_activity_laps` for the slice boundaries -- exact ground truth, no proximity matching or loop ambiguity at all.
- Falls back to proximity-based crossing detection (clustered the same way `_fetch_segment_efforts` already is, including the start-only/end-only flip rule from #215) only for climb-/manually-derived segments that have no lap index.

### Verified against production data
- Segment 7: route now has **47 points** tracing the full loop, with exact start/end coordinate match to the segment's stored coordinates.
- All other segments (non-loop, using the proximity fallback) unaffected: point counts within +/-1 of before (e.g. Harlem Hill 7->7, Hudson River 50->51, Central Park 2 92->93).
- All 8 current segments render via `list_segments` in 0.18s total.

## Test plan
- [x] `pytest tests/` -- 235 passed
- [x] `ruff` / `mypy` -- clean (pre-existing unrelated mypy warnings in `middleware.py`/`auth.py` only)
- [x] Added a query-shape regression test asserting the lap-boundary lookup and the crossing-clustering fallback (not a naive MIN/MIN) are both present
- [x] Re-verified live production data for the loop segment and all point-to-point segments

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>