### PR TITLE
feat(garmin): add GET /activities/{id}/weather-hourly endpoint

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -361,6 +361,37 @@ class GarminActivityWeather(BaseModel):
     updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
 
 
+class GarminActivityWeatherHourly(BaseModel):
+    """Route-sampled, hour-by-hour Open-Meteo weather for an activity.
+
+    Unlike GarminActivityWeather (a single "conditions at the start"
+    snapshot), this is one row per hour the activity spans, each sampled at
+    the GPS location the athlete was actually at during that hour.
+    """
+
+    activity_id: str = Field(description=DESC_PARENT_ACTIVITY_ID)
+    hour_index: int = Field(description="Zero-based hour offset from the activity start")
+    observed_at: datetime = Field(description="UTC hourly bucket the reading was taken from")
+    latitude: float = Field(description="Latitude sampled from the nearest track point for this hour")
+    longitude: float = Field(description="Longitude sampled from the nearest track point for this hour")
+    temperature_c: float | None = Field(default=None, description="Air temperature in degrees C")
+    apparent_temperature_c: float | None = Field(default=None, description="Feels-like temperature in degrees C")
+    relative_humidity_pct: float | None = Field(default=None, description="Relative humidity percent")
+    precipitation_mm: float | None = Field(default=None, description="Total precipitation in millimeters")
+    rain_mm: float | None = Field(default=None, description="Rainfall in millimeters")
+    snowfall_cm: float | None = Field(default=None, description="Snowfall in centimeters")
+    cloud_cover_pct: float | None = Field(default=None, description="Total cloud cover percent")
+    wind_speed_kmh: float | None = Field(default=None, description="Wind speed in km/h")
+    wind_gusts_kmh: float | None = Field(default=None, description="Wind gust speed in km/h")
+    wind_direction_deg: float | None = Field(default=None, description="Wind direction in degrees")
+    surface_pressure_hpa: float | None = Field(default=None, description="Surface pressure in hPa")
+    weather_code: int | None = Field(default=None, description="WMO weather interpretation code")
+    source: str = Field(description="Open-Meteo API the row came from: archive or forecast")
+    is_provisional: bool = Field(description="True when sourced from the forecast API pending ERA5 archive settlement")
+    created_at: datetime | None = Field(default=None, description="UTC timestamp when the row was inserted")
+    updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
+
+
 class GarminLapsActivity(BaseModel):
     """Activity summary metadata for a batch laps response item."""
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -23,6 +23,7 @@ from app.models.garmin import (
     GarminActivityManualUpdate,
     GarminActivityTotal,
     GarminActivityWeather,
+    GarminActivityWeatherHourly,
     GarminChartPoint,
     GarminDateRange,
     GarminDeviceCount,
@@ -735,6 +736,41 @@ async def get_activity_weather(
     )
 
     return GarminActivityWeather(**dict(row)) if row else None
+
+
+@router.get(
+    "/activities/{activity_id}/weather-hourly",
+    responses={404: {"description": ACTIVITY_NOT_FOUND}},
+)
+async def list_activity_weather_hourly(
+    request: Request,
+    activity_id: Annotated[str, fastapi.Path(description=DESC_ACTIVITY_ID, examples=["20932993811"])],
+) -> list[GarminActivityWeatherHourly]:
+    """Return route-sampled, hour-by-hour Open-Meteo weather for an activity.
+
+    Unlike ``/weather`` (a single "conditions at the start" snapshot), each
+    row here is sampled at the GPS location the athlete was actually at
+    during that hour. Returns an empty list (not 404) when the activity
+    exists but hasn't been hourly-backfilled yet.
+    """
+    db = request.app.state.db
+
+    exists = await db.fetchval(SQL_ACTIVITY_EXISTS, activity_id)
+    if not exists:
+        raise HTTPException(status_code=404, detail=ACTIVITY_NOT_FOUND)
+
+    rows = await db.fetch(
+        "SELECT activity_id, hour_index, observed_at, latitude, longitude, "
+        "temperature_c, apparent_temperature_c, relative_humidity_pct, "
+        "precipitation_mm, rain_mm, snowfall_cm, cloud_cover_pct, "
+        "wind_speed_kmh, wind_gusts_kmh, wind_direction_deg, surface_pressure_hpa, "
+        "weather_code, source, is_provisional, created_at, updated_at "
+        "FROM public.garmin_activity_weather_hourly WHERE activity_id = $1 "
+        "ORDER BY hour_index ASC",
+        activity_id,
+    )
+
+    return [GarminActivityWeatherHourly(**dict(row)) for row in rows]
 
 
 @router.get(

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -139,6 +139,32 @@ def _weather_row(activity_id: str = "20932993811", *, is_provisional: bool = Fal
     }
 
 
+def _weather_hourly_row(activity_id: str = "20932993811", hour_index: int = 0, *, is_provisional: bool = False) -> dict:
+    return {
+        "activity_id": activity_id,
+        "hour_index": hour_index,
+        "observed_at": "2026-03-08T20:00:00+00:00",
+        "latitude": 40.7937,
+        "longitude": -73.961,
+        "temperature_c": 18.4,
+        "apparent_temperature_c": 17.0,
+        "relative_humidity_pct": 55.0,
+        "precipitation_mm": 0.0,
+        "rain_mm": 0.0,
+        "snowfall_cm": 0.0,
+        "cloud_cover_pct": 20.0,
+        "wind_speed_kmh": 12.0,
+        "wind_gusts_kmh": 20.0,
+        "wind_direction_deg": 270.0,
+        "surface_pressure_hpa": 1013.0,
+        "weather_code": 1,
+        "source": "forecast" if is_provisional else "archive",
+        "is_provisional": is_provisional,
+        "created_at": "2026-03-09T03:00:00+00:00",
+        "updated_at": "2026-03-09T03:00:00+00:00",
+    }
+
+
 def _lap_row(activity_id: str = "20932993811", lap_index: int = 1) -> dict:
     return {
         "id": lap_index,
@@ -779,6 +805,50 @@ async def test_get_activity_weather_not_found(client: AsyncClient, mock_db):
     mock_db.fetchval.return_value = None
 
     response = await client.get("/api/v1/garmin/activities/nonexistent/weather")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+@pytest.mark.asyncio
+async def test_list_activity_weather_hourly_success(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = [
+        _weather_hourly_row(hour_index=0),
+        _weather_hourly_row(hour_index=1, is_provisional=True),
+    ]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/weather-hourly")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["hour_index"] == 0
+    assert data[0]["source"] == "archive"
+    assert data[1]["hour_index"] == 1
+    assert data[1]["is_provisional"] is True
+
+    query = mock_db.fetch.await_args.args[0]
+    assert "public.garmin_activity_weather_hourly" in query
+    assert "ORDER BY hour_index ASC" in query
+
+
+@pytest.mark.asyncio
+async def test_list_activity_weather_hourly_empty_for_existing_activity(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = []
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/weather-hourly")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_activity_weather_hourly_not_found(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = None
+
+    response = await client.get("/api/v1/garmin/activities/nonexistent/weather-hourly")
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Activity not found"}


### PR DESCRIPTION
## Summary

Phase 3 of the hourly weather feature (round 2 of the weather feature overall):
- Phase 1: [homelab-database-migrations#62](https://github.com/stuartshay/homelab-database-migrations/pull/62) — `garmin_activity_weather_hourly` table
- Phase 2: [otel-agents#158](https://github.com/stuartshay/otel-agents/pull/158) — route-sampled hourly weather sync, HTTP endpoints, Airflow DAGs

Adds:
- `GarminActivityWeatherHourly` pydantic model (`app/models/garmin.py`)
- `GET /api/v1/garmin/activities/{activity_id}/weather-hourly` (`app/routers/garmin.py`)

Unlike `GET /weather` (a single "conditions at the start" snapshot), this returns a **list** — one row per hour the activity spans, each sampled at the GPS location the athlete was actually at during that hour instead of the activity's start point repeated for the whole duration. 404 if the activity doesn't exist; empty list (not 404) if it exists but hasn't been hourly-backfilled yet — matches the existing `climbs`/`laps` list-endpoint convention.

## Test plan
- [x] `pytest tests/` — 242 passed (3 new tests: success with mixed provisional/archive rows, empty-list-for-existing-activity, not-found)
- [x] `ruff check` / `ruff format` clean
- [x] pre-commit (mypy, pyright, cspell, etc.) clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)