### PR TITLE
feat(geocoding): resolve addresses from dense cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ flowchart LR
 | GET | `/api/v1/garmin/activities/{id}/tracks` | Track points |
 | GET | `/api/v1/garmin/activities/{id}/laps` | Activity laps |
 | POST | `/api/v1/garmin/sync` | Trigger on-demand Garmin sync |
+| GET | `/api/v1/geocoding/reverse` | Resolve a point from the dense address cache with Pelias fallback (auth required) |
 | GET | `/api/v1/gps/unified` | Unified GPS points (view) |
 | GET | `/api/v1/gps/daily-summary` | Daily activity summary |
 | GET | `/api/v1/reference-locations` | List reference locations |

--- a/app/models/geocoding.py
+++ b/app/models/geocoding.py
@@ -8,6 +8,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 WaypointKind = Literal["start", "end", "waypoint"]
+PointAddressSource = Literal["database", "pelias"]
 
 # Shared field-description constants (reused across address models to avoid
 # duplicating the same literal in multiple Field(...) definitions).
@@ -58,6 +59,16 @@ class GeocodedAddress(BaseModel):
             ]
         }
     }
+
+
+class GeocodedPointAddress(GeocodedAddress):
+    """Address resolved for a rounded GPS coordinate cell."""
+
+    latitude: float = Field(description="Resolved 4-decimal cell latitude")
+    longitude: float = Field(description="Resolved 4-decimal cell longitude")
+    resolution_source: PointAddressSource = Field(
+        description="Whether the response came from the database cache or a Pelias fallback",
+    )
 
 
 class GeocodingStatus(BaseModel):

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from app.auth import require_auth
 from app.models.geocoding import (
@@ -128,7 +128,13 @@ def _point_address_response(
     )
 
 
-@router.get("/reverse", responses=AUTH_RESPONSES)
+@router.get(
+    "/reverse",
+    responses={
+        **AUTH_RESPONSES,
+        502: {"description": "Pelias fallback result could not be persisted"},
+    },
+)
 async def reverse_geocode_point(
     request: Request,
     latitude: Annotated[float, Query(ge=-90, le=90, description="Latitude in decimal degrees")],
@@ -149,12 +155,17 @@ async def reverse_geocode_point(
 
     config = request.app.state.config
     async with httpx.AsyncClient(timeout=config.pelias_timeout_seconds) as client:
-        await _process_cell(
+        processed = await _process_cell(
             db,
             client,
             config.pelias_base_url,
             cell["lat_4dp"],
             cell["lon_4dp"],
+        )
+    if processed == 0:
+        raise HTTPException(
+            status_code=502,
+            detail="Pelias fallback result could not be persisted",
         )
 
     refreshed = await _fetch_point_cell(db, latitude, longitude)

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -28,6 +28,12 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/v1/geocoding", tags=["Geocoding"])
 internal_router = APIRouter(prefix="/internal/geocoding", tags=["Internal"])
 
+# Auth-protected endpoints raise these via require_auth -> get_current_user().
+AUTH_RESPONSES: dict = {
+    401: {"description": "Authentication required or token invalid"},
+    503: {"description": "Authentication service unavailable"},
+}
+
 PELIAS_REVERSE_PATH = "/v1/reverse"
 # Per-request cap on concurrent waypoint geocoding tasks (end-to-end:
 # neighbour lookup + Pelias call + upsert). Raised from 5 to 20 in #129
@@ -122,7 +128,7 @@ def _point_address_response(
     )
 
 
-@router.get("/reverse")
+@router.get("/reverse", responses=AUTH_RESPONSES)
 async def reverse_geocode_point(
     request: Request,
     latitude: Annotated[float, Query(ge=-90, le=90, description="Latitude in decimal degrees")],

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -14,11 +14,13 @@ from fastapi import APIRouter, Depends, Query, Request
 
 from app.auth import require_auth
 from app.models.geocoding import (
+    GeocodedPointAddress,
     GeocodingSourceStatus,
     GeocodingStatus,
     GeocodingStatusBySource,
     GeocodingTriggerResponse,
     PeliasHealth,
+    PointAddressSource,
 )
 
 logger = structlog.get_logger(__name__)
@@ -73,6 +75,84 @@ class _StatusCache:
 
 class PeliasTransientError(Exception):
     """Raised by ``_call_pelias`` after all retry attempts have failed transiently."""
+
+
+_POINT_CELL_LOOKUP_SQL = (
+    "WITH cell AS ("
+    "  SELECT ROUND($1::double precision * 10000)::INTEGER AS lat_4dp, "
+    "         ROUND($2::double precision * 10000)::INTEGER AS lon_4dp"
+    ") "
+    "SELECT cell.lat_4dp, cell.lon_4dp, gpc.display_address, gpc.street, "
+    "gpc.housenumber, gpc.neighbourhood, gpc.locality, gpc.region, "
+    "gpc.country, gpc.postalcode, gpc.confidence, gpc.status, gpc.geocoded_at "
+    "FROM cell LEFT JOIN public.geocoded_point_cells gpc "
+    "ON gpc.lat_4dp = cell.lat_4dp AND gpc.lon_4dp = cell.lon_4dp"
+)
+
+
+async def _fetch_point_cell(db: Any, latitude: float, longitude: float) -> dict[str, Any]:
+    """Return the rounded cell key and its cached address, when present."""
+    row = await db.fetchrow(_POINT_CELL_LOOKUP_SQL, latitude, longitude)
+    if row is None:  # The single-row CTE should always return a row.
+        raise RuntimeError("Point cell lookup returned no row")
+    return dict(row)
+
+
+def _point_address_response(
+    row: dict[str, Any],
+    *,
+    resolution_source: PointAddressSource,
+) -> GeocodedPointAddress:
+    """Map a dense-cell row to the public point-address response."""
+    return GeocodedPointAddress(
+        latitude=row["lat_4dp"] / 10_000,
+        longitude=row["lon_4dp"] / 10_000,
+        display_address=row.get("display_address"),
+        street=row.get("street"),
+        housenumber=row.get("housenumber"),
+        neighbourhood=row.get("neighbourhood"),
+        locality=row.get("locality"),
+        region=row.get("region"),
+        country=row.get("country"),
+        postalcode=row.get("postalcode"),
+        confidence=row.get("confidence"),
+        status=row.get("status") or "error",
+        geocoded_at=row.get("geocoded_at"),
+        resolution_source=resolution_source,
+    )
+
+
+@router.get("/reverse")
+async def reverse_geocode_point(
+    request: Request,
+    latitude: Annotated[float, Query(ge=-90, le=90, description="Latitude in decimal degrees")],
+    longitude: Annotated[float, Query(ge=-180, le=180, description="Longitude in decimal degrees")],
+    _user: Annotated[dict, Depends(require_auth)],
+) -> GeocodedPointAddress:
+    """Resolve a point from the dense cell cache, falling back to Pelias.
+
+    Coordinates use the same indexed 4-decimal (~11 m) cell key as the Garmin
+    dense-geocoding pipeline. A successful cached row avoids a Pelias request;
+    misses and non-success rows are refreshed through Pelias and persisted.
+    Authentication is required because a fallback can mutate the cell cache.
+    """
+    db = request.app.state.db
+    cell = await _fetch_point_cell(db, latitude, longitude)
+    if cell.get("status") == "success" and cell.get("display_address"):
+        return _point_address_response(cell, resolution_source="database")
+
+    config = request.app.state.config
+    async with httpx.AsyncClient(timeout=config.pelias_timeout_seconds) as client:
+        await _process_cell(
+            db,
+            client,
+            config.pelias_base_url,
+            cell["lat_4dp"],
+            cell["lon_4dp"],
+        )
+
+    refreshed = await _fetch_point_cell(db, latitude, longitude)
+    return _point_address_response(refreshed, resolution_source="pelias")
 
 
 @router.get("/status")

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2957,6 +2957,9 @@
           "503": {
             "description": "Authentication service unavailable"
           },
+          "502": {
+            "description": "Pelias fallback result could not be persisted"
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -190,14 +190,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -246,6 +239,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "No location data found"
           }
         }
       }
@@ -314,14 +310,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -357,6 +346,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Location not found"
           },
           "422": {
             "description": "Validation Error",
@@ -571,6 +563,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "No Garmin activity data found"
           }
         }
       }
@@ -612,7 +607,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -633,7 +629,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -715,14 +712,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -829,7 +819,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -847,7 +838,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -979,11 +971,14 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required or token invalid"
+          },
+          "503": {
+            "description": "Authentication service unavailable"
+          },
           "400": {
             "description": "No fields to update"
-          },
-          "401": {
-            "description": "Authentication required"
           },
           "404": {
             "description": "Activity not found"
@@ -1292,6 +1287,120 @@
         }
       }
     },
+    "/api/v1/garmin/activities/{activity_id}/weather": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "Get Activity Weather",
+        "description": "Return Open-Meteo weather conditions for an activity's start location/time.\n\nReturns ``null`` (not 404) when the activity exists but hasn't been\nbackfilled with weather yet \u2014 garmin-sync's weather backfill job fills\nthis in asynchronously.",
+        "operationId": "get_activity_weather_api_v1_garmin_activities__activity_id__weather_get",
+        "parameters": [
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Garmin activity ID",
+              "examples": [
+                "20932993811"
+              ],
+              "title": "Activity Id"
+            },
+            "description": "Garmin activity ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/GarminActivityWeather"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get Activity Weather Api V1 Garmin Activities  Activity Id  Weather Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Activity not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/garmin/activities/{activity_id}/weather-hourly": {
+      "get": {
+        "tags": [
+          "Garmin"
+        ],
+        "summary": "List Activity Weather Hourly",
+        "description": "Return route-sampled, hour-by-hour Open-Meteo weather for an activity.\n\nUnlike ``/weather`` (a single \"conditions at the start\" snapshot), each\nrow here is sampled at the GPS location the athlete was actually at\nduring that hour. Returns an empty list (not 404) when the activity\nexists but hasn't been hourly-backfilled yet.",
+        "operationId": "list_activity_weather_hourly_api_v1_garmin_activities__activity_id__weather_hourly_get",
+        "parameters": [
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Garmin activity ID",
+              "examples": [
+                "20932993811"
+              ],
+              "title": "Activity Id"
+            },
+            "description": "Garmin activity ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GarminActivityWeatherHourly"
+                  },
+                  "title": "Response List Activity Weather Hourly Api V1 Garmin Activities  Activity Id  Weather Hourly Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Activity not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/garmin/laps": {
       "get": {
         "tags": [
@@ -1329,7 +1438,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -1350,7 +1460,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -1404,14 +1515,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -1576,7 +1680,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -1597,7 +1702,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -1652,14 +1758,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -1755,6 +1854,9 @@
               }
             }
           },
+          "500": {
+            "description": "Failed to create segment"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1844,6 +1946,15 @@
           "204": {
             "description": "Successful Response"
           },
+          "401": {
+            "description": "Authentication required or token invalid"
+          },
+          "503": {
+            "description": "Authentication service unavailable"
+          },
+          "404": {
+            "description": "Segment not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1884,7 +1995,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -1902,7 +2014,8 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "format": "date"
                 },
                 {
                   "type": "null"
@@ -2121,14 +2234,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -2224,14 +2330,7 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "description": "Invalid date format"
           }
         }
       }
@@ -2254,6 +2353,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "No daily summary data found"
           }
         }
       }
@@ -2311,6 +2413,15 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required or token invalid"
+          },
+          "503": {
+            "description": "Authentication service unavailable"
+          },
+          "500": {
+            "description": "Failed to create reference location"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -2360,6 +2471,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Reference location not found"
           },
           "422": {
             "description": "Validation Error",
@@ -2419,6 +2533,18 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required or token invalid"
+          },
+          "503": {
+            "description": "Authentication service unavailable"
+          },
+          "400": {
+            "description": "No fields to update"
+          },
+          "404": {
+            "description": "Reference location not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -2459,6 +2585,15 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "401": {
+            "description": "Authentication required or token invalid"
+          },
+          "503": {
+            "description": "Authentication service unavailable"
+          },
+          "404": {
+            "description": "Reference location not found"
           },
           "422": {
             "description": "Validation Error",
@@ -2750,6 +2885,71 @@
           },
           "404": {
             "description": "Reference location not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/geocoding/reverse": {
+      "get": {
+        "tags": [
+          "Geocoding"
+        ],
+        "summary": "Reverse Geocode Point",
+        "description": "Resolve a point from the dense cell cache, falling back to Pelias.\n\nCoordinates use the same indexed 4-decimal (~11 m) cell key as the Garmin\ndense-geocoding pipeline. A successful cached row avoids a Pelias request;\nmisses and non-success rows are refreshed through Pelias and persisted.\nAuthentication is required because a fallback can mutate the cell cache.",
+        "operationId": "reverse_geocode_point_api_v1_geocoding_reverse_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "maximum": 90,
+              "minimum": -90,
+              "description": "Latitude in decimal degrees",
+              "title": "Latitude"
+            },
+            "description": "Latitude in decimal degrees"
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "maximum": 180,
+              "minimum": -180,
+              "description": "Longitude in decimal degrees",
+              "title": "Longitude"
+            },
+            "description": "Longitude in decimal degrees"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodedPointAddress"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -5243,6 +5443,444 @@
           }
         ]
       },
+      "GarminActivityWeather": {
+        "properties": {
+          "activity_id": {
+            "type": "string",
+            "title": "Activity Id",
+            "description": "Parent Garmin activity identifier"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Observed At",
+            "description": "UTC hourly bucket the reading was taken from"
+          },
+          "latitude": {
+            "type": "number",
+            "title": "Latitude",
+            "description": "Latitude the weather was looked up for"
+          },
+          "longitude": {
+            "type": "number",
+            "title": "Longitude",
+            "description": "Longitude the weather was looked up for"
+          },
+          "temperature_c": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temperature C",
+            "description": "Air temperature in degrees C"
+          },
+          "apparent_temperature_c": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apparent Temperature C",
+            "description": "Feels-like temperature in degrees C"
+          },
+          "relative_humidity_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relative Humidity Pct",
+            "description": "Relative humidity percent"
+          },
+          "precipitation_mm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Precipitation Mm",
+            "description": "Total precipitation in millimeters"
+          },
+          "rain_mm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rain Mm",
+            "description": "Rainfall in millimeters"
+          },
+          "snowfall_cm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snowfall Cm",
+            "description": "Snowfall in centimeters"
+          },
+          "cloud_cover_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cloud Cover Pct",
+            "description": "Total cloud cover percent"
+          },
+          "wind_speed_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wind Speed Kmh",
+            "description": "Wind speed in km/h"
+          },
+          "wind_gusts_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wind Gusts Kmh",
+            "description": "Wind gust speed in km/h"
+          },
+          "wind_direction_deg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wind Direction Deg",
+            "description": "Wind direction in degrees"
+          },
+          "surface_pressure_hpa": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Pressure Hpa",
+            "description": "Surface pressure in hPa"
+          },
+          "weather_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weather Code",
+            "description": "WMO weather interpretation code"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "Open-Meteo API the row came from: archive or forecast"
+          },
+          "is_provisional": {
+            "type": "boolean",
+            "title": "Is Provisional",
+            "description": "True when sourced from the forecast API pending ERA5 archive settlement"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "UTC timestamp when the row was inserted"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "UTC timestamp when the row was last updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "activity_id",
+          "observed_at",
+          "latitude",
+          "longitude",
+          "source",
+          "is_provisional"
+        ],
+        "title": "GarminActivityWeather",
+        "description": "Open-Meteo weather conditions matched to an activity's start location/time."
+      },
+      "GarminActivityWeatherHourly": {
+        "properties": {
+          "activity_id": {
+            "type": "string",
+            "title": "Activity Id",
+            "description": "Parent Garmin activity identifier"
+          },
+          "hour_index": {
+            "type": "integer",
+            "title": "Hour Index",
+            "description": "Zero-based hour offset from the activity start"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Observed At",
+            "description": "UTC hourly bucket the reading was taken from"
+          },
+          "latitude": {
+            "type": "number",
+            "title": "Latitude",
+            "description": "Latitude sampled from the nearest track point for this hour"
+          },
+          "longitude": {
+            "type": "number",
+            "title": "Longitude",
+            "description": "Longitude sampled from the nearest track point for this hour"
+          },
+          "temperature_c": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temperature C",
+            "description": "Air temperature in degrees C"
+          },
+          "apparent_temperature_c": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apparent Temperature C",
+            "description": "Feels-like temperature in degrees C"
+          },
+          "relative_humidity_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relative Humidity Pct",
+            "description": "Relative humidity percent"
+          },
+          "precipitation_mm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Precipitation Mm",
+            "description": "Total precipitation in millimeters"
+          },
+          "rain_mm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rain Mm",
+            "description": "Rainfall in millimeters"
+          },
+          "snowfall_cm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snowfall Cm",
+            "description": "Snowfall in centimeters"
+          },
+          "cloud_cover_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cloud Cover Pct",
+            "description": "Total cloud cover percent"
+          },
+          "wind_speed_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wind Speed Kmh",
+            "description": "Wind speed in km/h"
+          },
+          "wind_gusts_kmh": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wind Gusts Kmh",
+            "description": "Wind gust speed in km/h"
+          },
+          "wind_direction_deg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wind Direction Deg",
+            "description": "Wind direction in degrees"
+          },
+          "surface_pressure_hpa": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Pressure Hpa",
+            "description": "Surface pressure in hPa"
+          },
+          "weather_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weather Code",
+            "description": "WMO weather interpretation code"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "Open-Meteo API the row came from: archive or forecast"
+          },
+          "is_provisional": {
+            "type": "boolean",
+            "title": "Is Provisional",
+            "description": "True when sourced from the forecast API pending ERA5 archive settlement"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "UTC timestamp when the row was inserted"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "UTC timestamp when the row was last updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "activity_id",
+          "hour_index",
+          "observed_at",
+          "latitude",
+          "longitude",
+          "source",
+          "is_provisional"
+        ],
+        "title": "GarminActivityWeatherHourly",
+        "description": "Route-sampled, hour-by-hour Open-Meteo weather for an activity.\n\nUnlike GarminActivityWeather (a single \"conditions at the start\"\nsnapshot), this is one row per hour the activity spans, each sampled at\nthe GPS location the athlete was actually at during that hour."
+      },
       "GarminChartPoint": {
         "properties": {
           "timestamp": {
@@ -6541,6 +7179,179 @@
         ],
         "title": "GeocodedAddressSummary",
         "description": "Compact address summary embedded in track-point payloads."
+      },
+      "GeocodedPointAddress": {
+        "properties": {
+          "display_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Address",
+            "description": "Full formatted address label from Pelias"
+          },
+          "street": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Street",
+            "description": "Street name"
+          },
+          "housenumber": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Housenumber",
+            "description": "House or building number"
+          },
+          "neighbourhood": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Neighbourhood",
+            "description": "Neighbourhood name"
+          },
+          "locality": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locality",
+            "description": "City or town"
+          },
+          "region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Region",
+            "description": "State or province"
+          },
+          "country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Country",
+            "description": "Country name"
+          },
+          "postalcode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Postalcode",
+            "description": "Postal or ZIP code"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence",
+            "description": "Pelias confidence score (0-1)"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Geocoding status: success, no_coverage, error, pending"
+          },
+          "geocoded_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Geocoded At",
+            "description": "UTC timestamp when geocoding was performed"
+          },
+          "latitude": {
+            "type": "number",
+            "title": "Latitude",
+            "description": "Resolved 4-decimal cell latitude"
+          },
+          "longitude": {
+            "type": "number",
+            "title": "Longitude",
+            "description": "Resolved 4-decimal cell longitude"
+          },
+          "resolution_source": {
+            "type": "string",
+            "enum": [
+              "database",
+              "pelias"
+            ],
+            "title": "Resolution Source",
+            "description": "Whether the response came from the database cache or a Pelias fallback"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "latitude",
+          "longitude",
+          "resolution_source"
+        ],
+        "title": "GeocodedPointAddress",
+        "description": "Address resolved for a rounded GPS coordinate cell.",
+        "examples": [
+          {
+            "confidence": 0.95,
+            "country": "United States",
+            "display_address": "123 Main St, Hoboken, NJ 07030",
+            "geocoded_at": "2026-02-12T08:10:55+00:00",
+            "housenumber": "123",
+            "locality": "Hoboken",
+            "neighbourhood": "Downtown",
+            "postalcode": "07030",
+            "region": "New Jersey",
+            "status": "success",
+            "street": "Main St"
+          }
+        ]
       },
       "GeocodingSourceStatus": {
         "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2951,6 +2951,12 @@
               }
             }
           },
+          "401": {
+            "description": "Authentication required or token invalid"
+          },
+          "503": {
+            "description": "Authentication service unavailable"
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -5625,6 +5625,13 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
+            /** @description Pelias fallback result could not be persisted */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Authentication service unavailable */
             503: {
                 headers: {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -389,6 +389,55 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/garmin/activities/{activity_id}/weather": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Activity Weather
+         * @description Return Open-Meteo weather conditions for an activity's start location/time.
+         *
+         *     Returns ``null`` (not 404) when the activity exists but hasn't been
+         *     backfilled with weather yet — garmin-sync's weather backfill job fills
+         *     this in asynchronously.
+         */
+        get: operations["get_activity_weather_api_v1_garmin_activities__activity_id__weather_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/garmin/activities/{activity_id}/weather-hourly": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Activity Weather Hourly
+         * @description Return route-sampled, hour-by-hour Open-Meteo weather for an activity.
+         *
+         *     Unlike ``/weather`` (a single "conditions at the start" snapshot), each
+         *     row here is sampled at the GPS location the athlete was actually at
+         *     during that hour. Returns an empty list (not 404) when the activity
+         *     exists but hasn't been hourly-backfilled yet.
+         */
+        get: operations["list_activity_weather_hourly_api_v1_garmin_activities__activity_id__weather_hourly_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/garmin/laps": {
         parameters: {
             query?: never;
@@ -722,6 +771,31 @@ export type paths = {
          *     from OwnTracks and/or Garmin data within its configured radius.
          */
         get: operations["within_reference_api_v1_spatial_within_reference__name__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/geocoding/reverse": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Reverse Geocode Point
+         * @description Resolve a point from the dense cell cache, falling back to Pelias.
+         *
+         *     Coordinates use the same indexed 4-decimal (~11 m) cell key as the Garmin
+         *     dense-geocoding pipeline. A successful cached row avoids a Pelias request;
+         *     misses and non-success rows are refreshed through Pelias and persisted.
+         *     Authentication is required because a fallback can mutate the cell cache.
+         */
+        get: operations["reverse_geocode_point_api_v1_geocoding_reverse_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1905,6 +1979,229 @@ export type components = {
             total_calories?: number | null;
         };
         /**
+         * GarminActivityWeather
+         * @description Open-Meteo weather conditions matched to an activity's start location/time.
+         */
+        GarminActivityWeather: {
+            /**
+             * Activity Id
+             * @description Parent Garmin activity identifier
+             */
+            activity_id: string;
+            /**
+             * Observed At
+             * Format: date-time
+             * @description UTC hourly bucket the reading was taken from
+             */
+            observed_at: string;
+            /**
+             * Latitude
+             * @description Latitude the weather was looked up for
+             */
+            latitude: number;
+            /**
+             * Longitude
+             * @description Longitude the weather was looked up for
+             */
+            longitude: number;
+            /**
+             * Temperature C
+             * @description Air temperature in degrees C
+             */
+            temperature_c?: number | null;
+            /**
+             * Apparent Temperature C
+             * @description Feels-like temperature in degrees C
+             */
+            apparent_temperature_c?: number | null;
+            /**
+             * Relative Humidity Pct
+             * @description Relative humidity percent
+             */
+            relative_humidity_pct?: number | null;
+            /**
+             * Precipitation Mm
+             * @description Total precipitation in millimeters
+             */
+            precipitation_mm?: number | null;
+            /**
+             * Rain Mm
+             * @description Rainfall in millimeters
+             */
+            rain_mm?: number | null;
+            /**
+             * Snowfall Cm
+             * @description Snowfall in centimeters
+             */
+            snowfall_cm?: number | null;
+            /**
+             * Cloud Cover Pct
+             * @description Total cloud cover percent
+             */
+            cloud_cover_pct?: number | null;
+            /**
+             * Wind Speed Kmh
+             * @description Wind speed in km/h
+             */
+            wind_speed_kmh?: number | null;
+            /**
+             * Wind Gusts Kmh
+             * @description Wind gust speed in km/h
+             */
+            wind_gusts_kmh?: number | null;
+            /**
+             * Wind Direction Deg
+             * @description Wind direction in degrees
+             */
+            wind_direction_deg?: number | null;
+            /**
+             * Surface Pressure Hpa
+             * @description Surface pressure in hPa
+             */
+            surface_pressure_hpa?: number | null;
+            /**
+             * Weather Code
+             * @description WMO weather interpretation code
+             */
+            weather_code?: number | null;
+            /**
+             * Source
+             * @description Open-Meteo API the row came from: archive or forecast
+             */
+            source: string;
+            /**
+             * Is Provisional
+             * @description True when sourced from the forecast API pending ERA5 archive settlement
+             */
+            is_provisional: boolean;
+            /**
+             * Created At
+             * @description UTC timestamp when the row was inserted
+             */
+            created_at?: string | null;
+            /**
+             * Updated At
+             * @description UTC timestamp when the row was last updated
+             */
+            updated_at?: string | null;
+        };
+        /**
+         * GarminActivityWeatherHourly
+         * @description Route-sampled, hour-by-hour Open-Meteo weather for an activity.
+         *
+         *     Unlike GarminActivityWeather (a single "conditions at the start"
+         *     snapshot), this is one row per hour the activity spans, each sampled at
+         *     the GPS location the athlete was actually at during that hour.
+         */
+        GarminActivityWeatherHourly: {
+            /**
+             * Activity Id
+             * @description Parent Garmin activity identifier
+             */
+            activity_id: string;
+            /**
+             * Hour Index
+             * @description Zero-based hour offset from the activity start
+             */
+            hour_index: number;
+            /**
+             * Observed At
+             * Format: date-time
+             * @description UTC hourly bucket the reading was taken from
+             */
+            observed_at: string;
+            /**
+             * Latitude
+             * @description Latitude sampled from the nearest track point for this hour
+             */
+            latitude: number;
+            /**
+             * Longitude
+             * @description Longitude sampled from the nearest track point for this hour
+             */
+            longitude: number;
+            /**
+             * Temperature C
+             * @description Air temperature in degrees C
+             */
+            temperature_c?: number | null;
+            /**
+             * Apparent Temperature C
+             * @description Feels-like temperature in degrees C
+             */
+            apparent_temperature_c?: number | null;
+            /**
+             * Relative Humidity Pct
+             * @description Relative humidity percent
+             */
+            relative_humidity_pct?: number | null;
+            /**
+             * Precipitation Mm
+             * @description Total precipitation in millimeters
+             */
+            precipitation_mm?: number | null;
+            /**
+             * Rain Mm
+             * @description Rainfall in millimeters
+             */
+            rain_mm?: number | null;
+            /**
+             * Snowfall Cm
+             * @description Snowfall in centimeters
+             */
+            snowfall_cm?: number | null;
+            /**
+             * Cloud Cover Pct
+             * @description Total cloud cover percent
+             */
+            cloud_cover_pct?: number | null;
+            /**
+             * Wind Speed Kmh
+             * @description Wind speed in km/h
+             */
+            wind_speed_kmh?: number | null;
+            /**
+             * Wind Gusts Kmh
+             * @description Wind gust speed in km/h
+             */
+            wind_gusts_kmh?: number | null;
+            /**
+             * Wind Direction Deg
+             * @description Wind direction in degrees
+             */
+            wind_direction_deg?: number | null;
+            /**
+             * Surface Pressure Hpa
+             * @description Surface pressure in hPa
+             */
+            surface_pressure_hpa?: number | null;
+            /**
+             * Weather Code
+             * @description WMO weather interpretation code
+             */
+            weather_code?: number | null;
+            /**
+             * Source
+             * @description Open-Meteo API the row came from: archive or forecast
+             */
+            source: string;
+            /**
+             * Is Provisional
+             * @description True when sourced from the forecast API pending ERA5 archive settlement
+             */
+            is_provisional: boolean;
+            /**
+             * Created At
+             * @description UTC timestamp when the row was inserted
+             */
+            created_at?: string | null;
+            /**
+             * Updated At
+             * @description UTC timestamp when the row was last updated
+             */
+            updated_at?: string | null;
+        };
+        /**
          * GarminChartPoint
          * @description Lightweight track point optimised for time-series chart rendering.
          * @example {
@@ -2576,6 +2873,96 @@ export type components = {
              * @description UTC timestamp when geocoding was performed
              */
             geocoded_at?: string | null;
+        };
+        /**
+         * GeocodedPointAddress
+         * @description Address resolved for a rounded GPS coordinate cell.
+         * @example {
+         *       "confidence": 0.95,
+         *       "country": "United States",
+         *       "display_address": "123 Main St, Hoboken, NJ 07030",
+         *       "geocoded_at": "2026-02-12T08:10:55+00:00",
+         *       "housenumber": "123",
+         *       "locality": "Hoboken",
+         *       "neighbourhood": "Downtown",
+         *       "postalcode": "07030",
+         *       "region": "New Jersey",
+         *       "status": "success",
+         *       "street": "Main St"
+         *     }
+         */
+        GeocodedPointAddress: {
+            /**
+             * Display Address
+             * @description Full formatted address label from Pelias
+             */
+            display_address?: string | null;
+            /**
+             * Street
+             * @description Street name
+             */
+            street?: string | null;
+            /**
+             * Housenumber
+             * @description House or building number
+             */
+            housenumber?: string | null;
+            /**
+             * Neighbourhood
+             * @description Neighbourhood name
+             */
+            neighbourhood?: string | null;
+            /**
+             * Locality
+             * @description City or town
+             */
+            locality?: string | null;
+            /**
+             * Region
+             * @description State or province
+             */
+            region?: string | null;
+            /**
+             * Country
+             * @description Country name
+             */
+            country?: string | null;
+            /**
+             * Postalcode
+             * @description Postal or ZIP code
+             */
+            postalcode?: string | null;
+            /**
+             * Confidence
+             * @description Pelias confidence score (0-1)
+             */
+            confidence?: number | null;
+            /**
+             * Status
+             * @description Geocoding status: success, no_coverage, error, pending
+             */
+            status: string;
+            /**
+             * Geocoded At
+             * @description UTC timestamp when geocoding was performed
+             */
+            geocoded_at?: string | null;
+            /**
+             * Latitude
+             * @description Resolved 4-decimal cell latitude
+             */
+            latitude: number;
+            /**
+             * Longitude
+             * @description Resolved 4-decimal cell longitude
+             */
+            longitude: number;
+            /**
+             * Resolution Source
+             * @description Whether the response came from the database cache or a Pelias fallback
+             * @enum {string}
+             */
+            resolution_source: "database" | "pelias";
         };
         /**
          * GeocodingSourceStatus
@@ -3702,14 +4089,12 @@ export interface operations {
                     "application/json": components["schemas"]["PaginatedResponse_Location_"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -3751,6 +4136,13 @@ export interface operations {
                     "application/json": components["schemas"]["LocationDateRange"];
                 };
             };
+            /** @description No location data found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     location_count_api_v1_locations_count_get: {
@@ -3776,14 +4168,12 @@ export interface operations {
                     "application/json": components["schemas"]["LocationCount"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -3807,6 +4197,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["LocationDetail"];
                 };
+            };
+            /** @description Location not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -3922,6 +4319,13 @@ export interface operations {
                     "application/json": components["schemas"]["GarminDateRange"];
                 };
             };
+            /** @description No Garmin activity data found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     list_activities_api_v1_garmin_activities_get: {
@@ -3957,14 +4361,12 @@ export interface operations {
                     "application/json": components["schemas"]["PaginatedResponse_GarminActivity_"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -4115,7 +4517,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Authentication required */
+            /** @description Authentication required or token invalid */
             401: {
                 headers: {
                     [name: string]: unknown;
@@ -4137,6 +4539,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Authentication service unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4307,6 +4716,84 @@ export interface operations {
             };
         };
     };
+    get_activity_weather_api_v1_garmin_activities__activity_id__weather_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Garmin activity ID */
+                activity_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GarminActivityWeather"] | null;
+                };
+            };
+            /** @description Activity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_activity_weather_hourly_api_v1_garmin_activities__activity_id__weather_hourly_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Garmin activity ID */
+                activity_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GarminActivityWeatherHourly"][];
+                };
+            };
+            /** @description Activity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_laps_api_v1_garmin_laps_get: {
         parameters: {
             query?: {
@@ -4336,14 +4823,12 @@ export interface operations {
                     "application/json": components["schemas"]["PaginatedResponse_GarminActivityLapsGroup_"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -4425,14 +4910,12 @@ export interface operations {
                     "application/json": components["schemas"]["SegmentEffortsResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -4499,6 +4982,13 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
+            /** @description Failed to create segment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     get_segment_api_v1_garmin_segments__segment_id__get: {
@@ -4559,6 +5049,20 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Authentication required or token invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Segment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4567,6 +5071,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Authentication service unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4653,14 +5164,12 @@ export interface operations {
                     "application/json": components["schemas"]["PaginatedResponse_UnifiedGpsPoint_"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -4691,14 +5200,12 @@ export interface operations {
                     "application/json": components["schemas"]["PaginatedResponse_DailyActivitySummary_"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Invalid date format */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+                content?: never;
             };
         };
     };
@@ -4719,6 +5226,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["DailySummaryDateRange"];
                 };
+            };
+            /** @description No daily summary data found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4764,6 +5278,13 @@ export interface operations {
                     "application/json": components["schemas"]["ReferenceLocation"];
                 };
             };
+            /** @description Authentication required or token invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4772,6 +5293,20 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Failed to create reference location */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication service unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4795,6 +5330,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ReferenceLocation"];
                 };
+            };
+            /** @description Reference location not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -4832,6 +5374,27 @@ export interface operations {
                     "application/json": components["schemas"]["ReferenceLocation"];
                 };
             };
+            /** @description No fields to update */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required or token invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Reference location not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4840,6 +5403,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Authentication service unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4862,6 +5432,20 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Authentication required or token invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Reference location not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -4870,6 +5454,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Authentication service unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -4983,6 +5574,40 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reverse_geocode_point_api_v1_geocoding_reverse_get: {
+        parameters: {
+            query: {
+                /** @description Latitude in decimal degrees */
+                latitude: number;
+                /** @description Longitude in decimal degrees */
+                longitude: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GeocodedPointAddress"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/packages/otel-data-types/index.d.ts
+++ b/packages/otel-data-types/index.d.ts
@@ -5609,6 +5609,13 @@ export interface operations {
                     "application/json": components["schemas"]["GeocodedPointAddress"];
                 };
             };
+            /** @description Authentication required or token invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -5617,6 +5624,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Authentication service unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -12,6 +12,150 @@ from app.auth import require_auth
 from app.config import Config
 
 
+def _point_cell_row(
+    *,
+    status: str | None = "success",
+    display_address: str | None = "5th Ave, New York, NY, USA",
+) -> dict[str, object]:
+    return {
+        "lat_4dp": 407306,
+        "lon_4dp": -739352,
+        "display_address": display_address,
+        "street": "5th Ave" if display_address else None,
+        "housenumber": None,
+        "neighbourhood": "Greenwich Village" if display_address else None,
+        "locality": "New York" if display_address else None,
+        "region": "New York" if display_address else None,
+        "country": "United States" if display_address else None,
+        "postalcode": "10003" if display_address else None,
+        "confidence": 0.9 if display_address else None,
+        "status": status,
+        "geocoded_at": "2026-07-19T12:00:00Z" if status else None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_point_returns_successful_cached_cell(
+    client: AsyncClient,
+    mock_db: AsyncMock,
+):
+    mock_db.fetchrow.return_value = _point_cell_row()
+
+    with patch("app.routers.geocoding._process_cell", new=AsyncMock()) as process_cell:
+        response = await client.get("/api/v1/geocoding/reverse?latitude=40.73061&longitude=-73.93524")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "latitude": 40.7306,
+        "longitude": -73.9352,
+        "display_address": "5th Ave, New York, NY, USA",
+        "street": "5th Ave",
+        "housenumber": None,
+        "neighbourhood": "Greenwich Village",
+        "locality": "New York",
+        "region": "New York",
+        "country": "United States",
+        "postalcode": "10003",
+        "confidence": 0.9,
+        "status": "success",
+        "geocoded_at": "2026-07-19T12:00:00Z",
+        "resolution_source": "database",
+    }
+    process_cell.assert_not_awaited()
+    lookup_call = mock_db.fetchrow.await_args
+    assert lookup_call is not None
+    lookup_sql = lookup_call.args[0]
+    assert "public.geocoded_point_cells" in lookup_sql
+    assert "gpc.lat_4dp = cell.lat_4dp" in lookup_sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cached_status", [None, "pending", "no_coverage", "error"])
+async def test_reverse_geocode_point_falls_back_and_returns_persisted_cell(
+    client: AsyncClient,
+    mock_db: AsyncMock,
+    cached_status: str | None,
+):
+    missing = _point_cell_row(status=cached_status, display_address=None)
+    refreshed = _point_cell_row()
+    mock_db.fetchrow.side_effect = [missing, refreshed]
+
+    with patch("app.routers.geocoding._process_cell", new=AsyncMock(return_value=1)) as process_cell:
+        response = await client.get("/api/v1/geocoding/reverse?latitude=40.73061&longitude=-73.93524")
+
+    assert response.status_code == 200
+    assert response.json()["display_address"] == "5th Ave, New York, NY, USA"
+    assert response.json()["resolution_source"] == "pelias"
+    process_cell.assert_awaited_once()
+    process_call = process_cell.await_args
+    assert process_call is not None
+    call = process_call.args
+    assert call[0] is mock_db
+    assert call[3:] == (407306, -739352)
+    assert mock_db.fetchrow.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_point_returns_persisted_fallback_failure(
+    client: AsyncClient,
+    mock_db: AsyncMock,
+):
+    missing = _point_cell_row(status=None, display_address=None)
+    pending = _point_cell_row(status="pending", display_address=None)
+    mock_db.fetchrow.side_effect = [missing, pending]
+
+    with patch("app.routers.geocoding._process_cell", new=AsyncMock(return_value=1)):
+        response = await client.get("/api/v1/geocoding/reverse?latitude=40.73061&longitude=-73.93524")
+
+    assert response.status_code == 200
+    assert response.json()["display_address"] is None
+    assert response.json()["status"] == "pending"
+    assert response.json()["resolution_source"] == "pelias"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "latitude=91&longitude=0",
+        "latitude=-91&longitude=0",
+        "latitude=0&longitude=181",
+        "latitude=0&longitude=-181",
+    ],
+)
+async def test_reverse_geocode_point_validates_coordinates(
+    client: AsyncClient,
+    mock_db: AsyncMock,
+    query: str,
+):
+    response = await client.get(f"/api/v1/geocoding/reverse?{query}")
+
+    assert response.status_code == 422
+    mock_db.fetchrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_point_requires_auth(
+    app: FastAPI,
+    client: AsyncClient,
+    mock_db: AsyncMock,
+):
+    async def _deny_auth() -> dict:
+        raise HTTPException(
+            status_code=http_status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    app.dependency_overrides[require_auth] = _deny_auth
+    try:
+        response = await client.get("/api/v1/geocoding/reverse?latitude=40.73061&longitude=-73.93524")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 401
+    mock_db.fetchrow.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_geocoding_status(client: AsyncClient, mock_db: AsyncMock):
     # geocoded_addresses and geocoded_point_cells status counts come from two

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -114,6 +114,23 @@ async def test_reverse_geocode_point_returns_persisted_fallback_failure(
 
 
 @pytest.mark.asyncio
+async def test_reverse_geocode_point_rejects_unpersisted_fallback(
+    client: AsyncClient,
+    mock_db: AsyncMock,
+):
+    mock_db.fetchrow.return_value = _point_cell_row(status=None, display_address=None)
+
+    with patch("app.routers.geocoding._process_cell", new=AsyncMock(return_value=0)):
+        response = await client.get("/api/v1/geocoding/reverse?latitude=40.73061&longitude=-73.93524")
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "detail": "Pelias fallback result could not be persisted",
+    }
+    assert mock_db.fetchrow.await_count == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query",
     [
@@ -150,7 +167,7 @@ async def test_reverse_geocode_point_requires_auth(
     try:
         response = await client.get("/api/v1/geocoding/reverse?latitude=40.73061&longitude=-73.93524")
     finally:
-        app.dependency_overrides.clear()
+        app.dependency_overrides.pop(require_auth, None)
 
     assert response.status_code == 401
     mock_db.fetchrow.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/v1/geocoding/reverse` using the indexed 4-decimal `public.geocoded_point_cells` key
- return successful cached rows without contacting Pelias
- fall back through the existing Pelias retry/persistence pipeline for missing or unsuccessful cells
- expose whether the result came from `database` or `pelias`
- regenerate the complete OpenAPI and `@stuartshay/otel-data-types` declarations from current source

## Why authentication is required
The database-hit path is read-only, but a Pelias fallback can populate or update a cache row. Requiring authentication prevents anonymous callers from creating unbounded coordinate cells.

## Validation
- `pre-commit run --all-files`
- `make test` (253 passed)
- focused geocoding suite (65 passed)
- `bash scripts/generate-types.sh`
- live read-only database-backed request returned HTTP 200, the expected stored address, and `resolution_source: database`
- production dense coverage observed before implementation: 555,550 successful cells and 99.97% point coverage
- `git diff --check`

## Contract propagation
This is the REST producer gate. After merge and the reviewed `@stuartshay/otel-data-types` publication, verify the generated gateway dependency PR before implementing the GraphQL/UI consumer gates.

Refs #222
Related: stuartshay/otel-data-ui#455
