### PR TITLE
feat(garmin): add GET /activities/{id}/sensors endpoint

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -336,6 +336,32 @@ class GarminActivityLap(BaseModel):
     updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
 
 
+class GarminActivitySensor(BaseModel):
+    """A FIT device_info record (head unit or paired sensor) for an activity."""
+
+    id: int = Field(description="Unique sensor row identifier")
+    activity_id: str = Field(description=DESC_PARENT_ACTIVITY_ID)
+    device_index: int = Field(description="FIT device_index: 0 for the head unit, 1+ for each paired sensor")
+    is_primary: bool = Field(description="True for the recording device (head unit / FIT creator record)")
+    device_type: str | None = Field(default=None, description="FIT antplus_device_type (e.g. heart_rate, bike_power)")
+    manufacturer: str | None = Field(default=None, description="Sensor manufacturer (e.g. garmin)")
+    garmin_product: int | None = Field(default=None, description="Raw Garmin product enum id from the FIT file")
+    product_name: str | None = Field(default=None, description="Friendly product name (e.g. Edge 540 Solar, HRM-Pro)")
+    serial_number: int | None = Field(default=None, description="Sensor serial number, when reported")
+    software_version: str | None = Field(default=None, description="Sensor firmware/software version")
+    hardware_version: int | None = Field(default=None, description="Sensor hardware revision")
+    battery_status: str | None = Field(
+        default=None, description="FIT battery_status: new, good, ok, low, critical, charging, unknown"
+    )
+    battery_voltage: float | None = Field(default=None, description="Sensor battery voltage")
+    ant_network: str | None = Field(default=None, description="ANT network the sensor was paired on")
+    source_type: str | None = Field(
+        default=None, description="Sensor connection type (ant, antplus, bluetooth_low_energy, ...)"
+    )
+    created_at: datetime | None = Field(default=None, description="UTC timestamp when the row was inserted")
+    updated_at: datetime | None = Field(default=None, description="UTC timestamp when the row was last updated")
+
+
 class GarminActivityWeather(BaseModel):
     """Open-Meteo weather conditions matched to an activity's start location/time."""
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -21,6 +21,7 @@ from app.models.garmin import (
     GarminActivityLap,
     GarminActivityLapsGroup,
     GarminActivityManualUpdate,
+    GarminActivitySensor,
     GarminActivityTotal,
     GarminActivityWeather,
     GarminActivityWeatherHourly,
@@ -703,6 +704,34 @@ async def list_activity_laps(
     )
 
     return [GarminActivityLap(**dict(row)) for row in rows]
+
+
+@router.get(
+    "/activities/{activity_id}/sensors",
+    responses={404: {"description": ACTIVITY_NOT_FOUND}},
+)
+async def list_activity_sensors(
+    request: Request,
+    activity_id: Annotated[str, fastapi.Path(description=DESC_ACTIVITY_ID, examples=["20932993811"])],
+) -> list[GarminActivitySensor]:
+    """Return the FIT device_info rows (head unit + paired sensors) for an activity."""
+    db = request.app.state.db
+
+    exists = await db.fetchval(SQL_ACTIVITY_EXISTS, activity_id)
+    if not exists:
+        raise HTTPException(status_code=404, detail=ACTIVITY_NOT_FOUND)
+
+    rows = await db.fetch(
+        "SELECT id, activity_id, device_index, is_primary, device_type, "
+        "manufacturer, garmin_product, product_name, serial_number, "
+        "software_version, hardware_version, battery_status, battery_voltage, "
+        "ant_network, source_type, created_at, updated_at "
+        "FROM public.garmin_activity_sensors WHERE activity_id = $1 "
+        "ORDER BY device_index ASC",
+        activity_id,
+    )
+
+    return [GarminActivitySensor(**dict(row)) for row in rows]
 
 
 @router.get(

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
         "actionlint",
         "addopts",
         "aioboto",
+        "antplus",
         "appuser",
         "ASGI",
         "asyncio",

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -189,6 +189,28 @@ def _lap_row(activity_id: str = "20932993811", lap_index: int = 1) -> dict:
     }
 
 
+def _sensor_row(activity_id: str = "20932993811", device_index: int = 0) -> dict:
+    return {
+        "id": device_index + 1,
+        "activity_id": activity_id,
+        "device_index": device_index,
+        "is_primary": device_index == 0,
+        "device_type": "heart_rate" if device_index else None,
+        "manufacturer": "garmin",
+        "garmin_product": 4061 if device_index == 0 else None,
+        "product_name": "Edge 540 Solar" if device_index == 0 else None,
+        "serial_number": 3444454776 if device_index == 0 else 123456,
+        "software_version": "27.14" if device_index == 0 else None,
+        "hardware_version": None,
+        "battery_status": "low" if device_index else None,
+        "battery_voltage": 2.95 if device_index else None,
+        "ant_network": "antplus" if device_index else None,
+        "source_type": "antplus" if device_index else None,
+        "created_at": "2026-07-19T03:00:00+00:00",
+        "updated_at": "2026-07-19T03:00:00+00:00",
+    }
+
+
 @pytest.mark.asyncio
 async def test_list_activities_empty(client: AsyncClient, mock_db):
     mock_db.fetch.return_value = []
@@ -751,6 +773,51 @@ async def test_list_activity_laps_not_found(client: AsyncClient, mock_db):
     mock_db.fetchval.return_value = None
 
     response = await client.get("/api/v1/garmin/activities/nonexistent/laps")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+@pytest.mark.asyncio
+async def test_list_activity_sensors_success(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = [_sensor_row(device_index=0), _sensor_row(device_index=1)]
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/sensors")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["activity_id"] == "20932993811"
+    assert data[0]["device_index"] == 0
+    assert data[0]["is_primary"] is True
+    assert data[0]["product_name"] == "Edge 540 Solar"
+    assert data[1]["is_primary"] is False
+    assert data[1]["device_type"] == "heart_rate"
+    assert data[1]["battery_status"] == "low"
+    assert data[1]["battery_voltage"] == 2.95
+
+    query = mock_db.fetch.await_args.args[0]
+    assert "public.garmin_activity_sensors" in query
+    assert "ORDER BY device_index ASC" in query
+
+
+@pytest.mark.asyncio
+async def test_list_activity_sensors_empty_for_existing_activity(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = []
+
+    response = await client.get("/api/v1/garmin/activities/20932993811/sensors")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_activity_sensors_not_found(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = None
+
+    response = await client.get("/api/v1/garmin/activities/nonexistent/sensors")
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Activity not found"}


### PR DESCRIPTION
## Summary
Part of a cross-repo feature to show "Sensors used" + battery life on the Activity Stats tab (homelab-database-migrations #63 → otel-agents #162 → otel-data-api (this PR) → otel-data-gateway → otel-data-ui to follow).

- New `GarminActivitySensor` Pydantic model mirroring the `garmin_activity_sensors` table (device_index, is_primary, device_type, battery_status/battery_voltage, etc.).
- New `GET /activities/{activity_id}/sensors` endpoint, structurally identical to the existing `/activities/{id}/laps` endpoint (404 check, ordered by `device_index`).

Depends on `homelab-database-migrations` #000032 and `otel-agents` #162 being deployed before this endpoint has any data to return.

## Test plan
- [x] `pytest tests/test_garmin.py` — 92 passed (3 new sensor endpoint tests)
- [x] Full pre-commit suite (ruff, mypy, pyright, cspell) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)