### PR TITLE
feat(garmin): add segment effort speed/HR series endpoint

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -643,7 +643,7 @@ class SegmentEffortSeriesBin(BaseModel):
     """One distance bin of an effort's speed/heart-rate series along a segment."""
 
     index: int = Field(description="0-based bin index from segment start")
-    fraction: float = Field(description="Bin midpoint as a 0..1 fraction of the effort's traversal distance")
+    fraction: float = Field(description="Bin midpoint strictly within (0, 1) of the effort's traversal distance")
     speed_kmh: float | None = Field(default=None, description="Average speed within the bin in km/h")
     heart_rate: int | None = Field(default=None, description="Average heart rate within the bin in bpm")
 

--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -639,6 +639,29 @@ class SegmentEffortsResponse(BaseModel):
     items: list[SegmentEffort] = Field(description="Efforts ordered fastest-first")
 
 
+class SegmentEffortSeriesBin(BaseModel):
+    """One distance bin of an effort's speed/heart-rate series along a segment."""
+
+    index: int = Field(description="0-based bin index from segment start")
+    fraction: float = Field(description="Bin midpoint as a 0..1 fraction of the effort's traversal distance")
+    speed_kmh: float | None = Field(default=None, description="Average speed within the bin in km/h")
+    heart_rate: int | None = Field(default=None, description="Average heart rate within the bin in bpm")
+
+
+class SegmentEffortSeriesResponse(BaseModel):
+    """A single effort's speed/HR series, binned by normalized distance along the segment.
+
+    ``bins`` always contains exactly ``bin_count`` entries ordered by index;
+    bins with no samples (GPS gaps, degenerate traversals) carry null metrics.
+    """
+
+    activity_id: str = Field(description="Garmin activity identifier")
+    effort_start: datetime = Field(description="UTC timestamp entering the segment start corridor")
+    effort_end: datetime = Field(description="UTC timestamp reaching the segment end corridor")
+    bin_count: int = Field(description="Number of distance bins in the series")
+    bins: list[SegmentEffortSeriesBin] = Field(description="Distance-ordered bins spanning the traversal")
+
+
 class GarminSegment(BaseModel):
     """A saved named segment (path) for cross-activity effort comparison."""
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import Annotated, Any, Literal
 
 import fastapi
@@ -35,6 +35,8 @@ from app.models.garmin import (
     GarminTrackPoint,
     SegmentDefinition,
     SegmentEffort,
+    SegmentEffortSeriesBin,
+    SegmentEffortSeriesResponse,
     SegmentEffortsResponse,
     SportInfo,
 )
@@ -1683,4 +1685,104 @@ async def get_segment_efforts(
         ),
         total=len(items),
         items=items,
+    )
+
+
+def _aware_utc(value: datetime) -> datetime:
+    """Normalize a datetime to timezone-aware UTC.
+
+    garmin_track_points.timestamp is TIMESTAMPTZ in the live database, and
+    asyncpg interprets *naive* datetimes against the server session timezone,
+    silently shifting the query window. Clients may echo effort boundaries
+    with or without a Z suffix; naive values are UTC by convention.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+SEGMENT_EFFORT_SERIES_SQL = """
+WITH pts AS (
+    SELECT distance_from_start_km, speed_kmh, heart_rate
+    FROM public.garmin_track_points
+    WHERE activity_id = $1
+      AND timestamp BETWEEN $2 AND $3
+      AND distance_from_start_km IS NOT NULL
+),
+bounds AS (
+    SELECT MIN(distance_from_start_km) AS d0,
+           MAX(distance_from_start_km) AS d1
+    FROM pts
+),
+binned AS (
+    SELECT LEAST(GREATEST(WIDTH_BUCKET(p.distance_from_start_km, b.d0, b.d1, $4), 1), $4) AS bucket,
+           AVG(p.speed_kmh) AS speed_kmh,
+           AVG(p.heart_rate) FILTER (WHERE p.heart_rate > 0) AS avg_hr
+    FROM pts p CROSS JOIN bounds b
+    WHERE b.d1 > b.d0
+    GROUP BY 1
+)
+SELECT gs.i AS index,
+       (gs.i + 0.5) / $4::double precision AS fraction,
+       bn.speed_kmh::double precision AS speed_kmh,
+       ROUND(bn.avg_hr)::int AS heart_rate
+FROM GENERATE_SERIES(0, $4 - 1) AS gs (i)
+LEFT JOIN binned bn ON bn.bucket = gs.i + 1
+ORDER BY gs.i
+"""
+
+
+@router.get(
+    "/segments/{segment_id}/effort-series",
+    responses={404: {"description": SEGMENT_NOT_FOUND}},
+)
+async def get_segment_effort_series(
+    request: Request,
+    segment_id: Annotated[int, fastapi.Path(description=DESC_SAVED_SEGMENT_ID)],
+    activity_id: Annotated[str, Query(description=DESC_ACTIVITY_ID)],
+    effort_start: Annotated[
+        datetime,
+        Query(description="Effort start timestamp, exactly as returned by the efforts endpoint"),
+    ],
+    effort_end: Annotated[
+        datetime,
+        Query(description="Effort end timestamp, exactly as returned by the efforts endpoint"),
+    ],
+    bins: Annotated[int, Query(ge=10, le=400, description="Number of distance bins in the series")] = 100,
+) -> SegmentEffortSeriesResponse:
+    """Return one effort's speed/HR series binned by distance along the segment.
+
+    Bins are normalized to the effort's own traversal (fraction 0 = start
+    corridor, 1 = end corridor), so series from different activities are
+    directly comparable at the same fraction despite GPS odometer drift.
+    The effort window is trusted client input echoed from the efforts
+    endpoint; an arbitrary window merely aggregates the caller's own
+    read-only track data.
+    """
+    start = _aware_utc(effort_start)
+    end = _aware_utc(effort_end)
+    if end <= start:
+        raise HTTPException(status_code=422, detail="effort_end must be after effort_start")
+
+    db = request.app.state.db
+    seg_exists = await db.fetchval(
+        "SELECT 1 FROM public.garmin_segments WHERE id = $1 AND garmin_sync_status IS DISTINCT FROM 'delete_pending'",
+        segment_id,
+    )
+    if not seg_exists:
+        raise HTTPException(status_code=404, detail=SEGMENT_NOT_FOUND)
+
+    rows = await db.fetch(
+        SEGMENT_EFFORT_SERIES_SQL,
+        activity_id,
+        start,
+        end,
+        bins,
+    )
+    return SegmentEffortSeriesResponse(
+        activity_id=activity_id,
+        effort_start=effort_start,
+        effort_end=effort_end,
+        bin_count=bins,
+        bins=[SegmentEffortSeriesBin(**dict(row)) for row in rows],
     )

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1752,12 +1752,13 @@ async def get_segment_effort_series(
 ) -> SegmentEffortSeriesResponse:
     """Return one effort's speed/HR series binned by distance along the segment.
 
-    Bins are normalized to the effort's own traversal (fraction 0 = start
-    corridor, 1 = end corridor), so series from different activities are
-    directly comparable at the same fraction despite GPS odometer drift.
-    The effort window is trusted client input echoed from the efforts
-    endpoint; an arbitrary window merely aggregates the caller's own
-    read-only track data.
+    Bins are normalized to the effort's own traversal; each fraction is the
+    bin midpoint in the open interval between the start and end corridors.
+    Series from different activities are therefore directly comparable at the
+    same fraction despite GPS odometer drift.
+    The effort window is trusted client input from the efforts endpoint and is
+    returned normalized to UTC; an arbitrary window merely aggregates the
+    caller's own read-only track data.
     """
     start = _aware_utc(effort_start)
     end = _aware_utc(effort_end)
@@ -1781,8 +1782,8 @@ async def get_segment_effort_series(
     )
     return SegmentEffortSeriesResponse(
         activity_id=activity_id,
-        effort_start=effort_start,
-        effort_end=effort_end,
+        effort_start=start,
+        effort_end=end,
         bin_count=bins,
         bins=[SegmentEffortSeriesBin(**dict(row)) for row in rows],
     )

--- a/cspell.json
+++ b/cspell.json
@@ -111,6 +111,7 @@
         "stuartshay",
         "tablename",
         "testpaths",
+        "timestamptz",
         "timonwong",
         "trailhead",
         "upsert",

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -2170,11 +2170,10 @@ def _effort_series_bin_row(index: int, bins: int = 100, speed: float | None = 18
 @pytest.mark.asyncio
 async def test_effort_series_returns_gap_filled_bins(client: AsyncClient, mock_db):
     mock_db.fetchval.return_value = 1
-    mock_db.fetch.return_value = [
-        _effort_series_bin_row(0),
-        _effort_series_bin_row(1, speed=None, hr=None),  # GPS gap bin survives as nulls
-        _effort_series_bin_row(2, speed=19.1, hr=140),
-    ]
+    rows = [_effort_series_bin_row(index) for index in range(100)]
+    rows[1] = _effort_series_bin_row(1, speed=None, hr=None)  # GPS gap bin survives as nulls
+    rows[2] = _effort_series_bin_row(2, speed=19.1, hr=140)
+    mock_db.fetch.return_value = rows
 
     response = await client.get(
         "/api/v1/garmin/segments/5/effort-series"
@@ -2188,7 +2187,10 @@ async def test_effort_series_returns_gap_filled_bins(client: AsyncClient, mock_d
     body = response.json()
     assert body["activity_id"] == "20932993811"
     assert body["bin_count"] == 100
-    assert [b["index"] for b in body["bins"]] == [0, 1, 2]
+    assert len(body["bins"]) == body["bin_count"]
+    assert [b["index"] for b in body["bins"]] == list(range(100))
+    assert body["bins"][0]["fraction"] == 0.005
+    assert body["bins"][-1]["fraction"] == 0.995
     assert body["bins"][1]["speed_kmh"] is None
     assert body["bins"][1]["heart_rate"] is None
     assert body["bins"][2]["heart_rate"] == 140
@@ -2224,6 +2226,9 @@ async def test_effort_series_normalizes_timestamps_to_aware_utc(client: AsyncCli
     )
 
     assert response.status_code == 200
+    body = response.json()
+    assert body["effort_start"] == "2026-07-05T10:30:00Z"
+    assert body["effort_end"] == "2026-07-05T10:32:00Z"
     _, _, bound_start, bound_end, _ = mock_db.fetch.await_args.args
     assert bound_start == datetime(2026, 7, 5, 10, 30, 0, tzinfo=UTC)
     assert bound_end == datetime(2026, 7, 5, 10, 32, 0, tzinfo=UTC)

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,7 +1,7 @@
 """Tests for Garmin endpoints."""
 
 import dataclasses
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import fastapi
 import httpx
@@ -2156,3 +2156,137 @@ async def test_get_segment_efforts_not_found(client: AsyncClient, mock_db):
     response = await client.get("/api/v1/garmin/segments/999/efforts")
 
     assert response.status_code == 404
+
+
+def _effort_series_bin_row(index: int, bins: int = 100, speed: float | None = 18.4, hr: int | None = 132) -> dict:
+    return {
+        "index": index,
+        "fraction": (index + 0.5) / bins,
+        "speed_kmh": speed,
+        "heart_rate": hr,
+    }
+
+
+@pytest.mark.asyncio
+async def test_effort_series_returns_gap_filled_bins(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = [
+        _effort_series_bin_row(0),
+        _effort_series_bin_row(1, speed=None, hr=None),  # GPS gap bin survives as nulls
+        _effort_series_bin_row(2, speed=19.1, hr=140),
+    ]
+
+    response = await client.get(
+        "/api/v1/garmin/segments/5/effort-series"
+        "?activity_id=20932993811"
+        "&effort_start=2026-07-05T10:30:00"
+        "&effort_end=2026-07-05T10:32:00"
+        "&bins=100"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["activity_id"] == "20932993811"
+    assert body["bin_count"] == 100
+    assert [b["index"] for b in body["bins"]] == [0, 1, 2]
+    assert body["bins"][1]["speed_kmh"] is None
+    assert body["bins"][1]["heart_rate"] is None
+    assert body["bins"][2]["heart_rate"] == 140
+
+    series_query, *series_params = mock_db.fetch.await_args.args
+    assert "WIDTH_BUCKET" in series_query
+    assert "GENERATE_SERIES" in series_query
+    assert series_params == [
+        "20932993811",
+        datetime(2026, 7, 5, 10, 30, 0, tzinfo=UTC),
+        datetime(2026, 7, 5, 10, 32, 0, tzinfo=UTC),
+        100,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_effort_series_normalizes_timestamps_to_aware_utc(client: AsyncClient, mock_db):
+    """Effort boundaries must bind as timezone-aware UTC datetimes.
+
+    garmin_track_points.timestamp is TIMESTAMPTZ in the live database, and
+    asyncpg interprets naive datetimes against the server session timezone,
+    silently shifting the window. Naive inputs are UTC by convention;
+    offset-bearing inputs are converted.
+    """
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = []
+
+    response = await client.get(
+        "/api/v1/garmin/segments/5/effort-series"
+        "?activity_id=20932993811"
+        "&effort_start=2026-07-05T10:30:00"
+        "&effort_end=2026-07-05T06:32:00-04:00"
+    )
+
+    assert response.status_code == 200
+    _, _, bound_start, bound_end, _ = mock_db.fetch.await_args.args
+    assert bound_start == datetime(2026, 7, 5, 10, 30, 0, tzinfo=UTC)
+    assert bound_end == datetime(2026, 7, 5, 10, 32, 0, tzinfo=UTC)
+    assert bound_end.utcoffset() == timedelta(0)
+
+
+@pytest.mark.asyncio
+async def test_effort_series_distinguishes_laps_by_effort_start(client: AsyncClient, mock_db):
+    """Two efforts from one activity (loop laps) must produce distinct queries."""
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = []
+
+    for start, end in (
+        ("2026-07-05T10:30:00", "2026-07-05T10:32:00"),
+        ("2026-07-05T11:00:00", "2026-07-05T11:02:30"),
+    ):
+        response = await client.get(
+            f"/api/v1/garmin/segments/5/effort-series?activity_id=multi-lap-ride&effort_start={start}&effort_end={end}"
+        )
+        assert response.status_code == 200
+
+    first_args = mock_db.fetch.await_args_list[0].args
+    second_args = mock_db.fetch.await_args_list[1].args
+    assert first_args[1] == second_args[1] == "multi-lap-ride"
+    assert first_args[2] != second_args[2]
+    assert first_args[3] != second_args[3]
+
+
+@pytest.mark.asyncio
+async def test_effort_series_segment_not_found(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = None
+
+    response = await client.get(
+        "/api/v1/garmin/segments/999/effort-series"
+        "?activity_id=20932993811"
+        "&effort_start=2026-07-05T10:30:00"
+        "&effort_end=2026-07-05T10:32:00"
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_effort_series_rejects_invalid_windows_and_bins(client: AsyncClient, mock_db):
+    mock_db.fetchval.return_value = 1
+
+    reversed_window = await client.get(
+        "/api/v1/garmin/segments/5/effort-series"
+        "?activity_id=20932993811"
+        "&effort_start=2026-07-05T10:32:00"
+        "&effort_end=2026-07-05T10:30:00"
+    )
+    assert reversed_window.status_code == 422
+
+    bins_too_large = await client.get(
+        "/api/v1/garmin/segments/5/effort-series"
+        "?activity_id=20932993811"
+        "&effort_start=2026-07-05T10:30:00"
+        "&effort_end=2026-07-05T10:32:00&bins=1000"
+    )
+    assert bins_too_large.status_code == 422
+
+    missing_activity = await client.get(
+        "/api/v1/garmin/segments/5/effort-series?effort_start=2026-07-05T10:30:00&effort_end=2026-07-05T10:32:00"
+    )
+    assert missing_activity.status_code == 422


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/garmin/segments/{segment_id}/effort-series?activity_id=&effort_start=&effort_end=&bins=` — returns one effort's speed/HR binned by normalized-distance midpoints strictly within `(0, 1)` along the segment
- Normalized-fraction alignment lets efforts from different activities be compared at the same point on the course despite GPS odometer drift
- Bins are always gap-filled to exactly `bin_count` entries (nulls for GPS dropouts), so callers get O(1) index lookups
- First consumer: an otel-data-ui leaderboard feature showing each effort's live speed/HR as a playback cursor moves along the segment (companion PRs to follow in otel-data-gateway and otel-data-ui)

## Notes
- No DB migration needed — reuses existing `garmin_track_points` columns (`distance_from_start_km`, `speed_kmh`, `heart_rate`), same table the existing efforts endpoint already queries
- Binds effort boundary timestamps as timezone-aware UTC — the live DB's `garmin_track_points.timestamp` is `TIMESTAMPTZ` (confirmed against the dev DB), and asyncpg interprets naive datetimes against the session timezone, which would silently shift the query window

## Test plan
- [x] `pytest tests/test_garmin.py` — 99/99 passing, including 5 new tests (gap-filled bins, tz normalization, 404, 422 validation, multi-lap disambiguation)
- [x] `ruff check` / `mypy` / `pyright` clean
- [x] Verified against the live dev database: `curl .../segments/15/effort-series?...` returns 100 fully-populated bins with plausible speed/HR values for a real effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)