### PR TITLE
perf(geocoding): decouple mv_garmin_track_point_cells cache from /status TTL

### DIFF
--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -72,12 +72,41 @@ _GARMIN_CONFLICT = "ON CONFLICT (garmin_track_point_id) WHERE source = 'garmin'"
 # every dashboard poll.
 _STATUS_CACHE_TTL_SECONDS = 60.0
 
+# Cache TTL specifically for the mv_garmin_track_point_cells-derived metrics
+# below (dense_cells_total / dense_point_coverage_percent). That query is an
+# unfiltered aggregate over the full MV (~556k rows, ~0.6-3.5s per New Relic
+# span data) that the plain 60s _StatusCache TTL still forced dozens of times
+# a day. The MV itself only refreshes out-of-band on an hours-scale cadence
+# (migrations 000018/000021), and geocoded_point_cells (the live side of the
+# join) is background-job progress, not something a dashboard needs
+# sub-minute freshness on -- so this portion gets its own, much longer TTL,
+# independent of the rest of the response.
+_MV_METRICS_CACHE_TTL_SECONDS = 600.0
+
 
 @dataclass
 class _StatusCache:
     """Per-process cache holder for the geocoding /status response."""
 
     value: GeocodingStatus | None = None
+    expires_at: float = 0.0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+@dataclass
+class _MvMetrics:
+    """Raw counts from the mv_garmin_track_point_cells aggregate."""
+
+    dense_total_cells: int
+    total_track_points: int
+    covered_track_points: int
+
+
+@dataclass
+class _MvMetricsCache:
+    """Per-process cache holder for `_MvMetrics`, decoupled from `_StatusCache`."""
+
+    value: _MvMetrics | None = None
     expires_at: float = 0.0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
@@ -255,13 +284,62 @@ async def geocoding_status(request: Request) -> GeocodingStatus:
         # Re-check after acquiring the lock so only one request recomputes.
         if cache.value is not None and time.monotonic() < cache.expires_at:
             return cache.value
-        status = await _compute_geocoding_status(request.app.state.db)
+        mv_cache: _MvMetricsCache | None = getattr(request.app.state, "_mv_metrics_cache", None)
+        if mv_cache is None:
+            mv_cache = _MvMetricsCache()
+            request.app.state._mv_metrics_cache = mv_cache
+        mv_metrics = await _get_mv_metrics(request.app.state.db, mv_cache)
+        status = await _compute_geocoding_status(request.app.state.db, mv_metrics)
         cache.value = status
         cache.expires_at = time.monotonic() + _STATUS_CACHE_TTL_SECONDS
         return status
 
 
-async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
+async def _get_mv_metrics(db: Any, cache: _MvMetricsCache) -> _MvMetrics:
+    """Return mv_garmin_track_point_cells coverage metrics, cached for
+    `_MV_METRICS_CACHE_TTL_SECONDS` independently of the outer /status cache.
+    """
+    if cache.value is not None and time.monotonic() < cache.expires_at:
+        return cache.value
+
+    async with cache.lock:
+        if cache.value is not None and time.monotonic() < cache.expires_at:
+            return cache.value
+
+        # Derive all materialized-view metrics in a SINGLE query so
+        # dense_total_cells, total and covered come from one MV snapshot. The
+        # MV (migrations 18 + 21) is refreshed out-of-band, so computing these
+        # as separate statements could span a refresh and briefly skew the
+        # coverage percentage. The MV carries a per-cell point_count; a LEFT
+        # JOIN to geocoded_point_cells on the indexed (lat_4dp, lon_4dp) key
+        # yields covered points via FILTER — replacing the old ~5.2s COUNT(*)
+        # ... WHERE EXISTS(ROUND ...) Parallel Seq Scan over ~4.5M
+        # garmin_track_points rows (~0.9s now, per #167). Still an unfiltered
+        # ~556k-row aggregate though, so it gets its own longer-TTL cache
+        # rather than running on every 60s /status cache miss (see #<TBD>).
+        row = await db.fetchrow(
+            "SELECT COUNT(*)::BIGINT AS dense_total_cells, "
+            "COALESCE(SUM(m.point_count), 0)::BIGINT AS total_track_points, "
+            "COALESCE(SUM(m.point_count) FILTER (WHERE g.lat_4dp IS NOT NULL), 0)::BIGINT "
+            "AS covered_track_points "
+            "FROM public.mv_garmin_track_point_cells m "
+            "LEFT JOIN public.geocoded_point_cells g USING (lat_4dp, lon_4dp)"
+        )
+        metrics = (
+            _MvMetrics(
+                dense_total_cells=row["dense_total_cells"],
+                total_track_points=row["total_track_points"],
+                covered_track_points=row["covered_track_points"],
+            )
+            if row
+            else _MvMetrics(dense_total_cells=0, total_track_points=0, covered_track_points=0)
+        )
+        cache.value = metrics
+        cache.expires_at = time.monotonic() + _MV_METRICS_CACHE_TTL_SECONDS
+        return metrics
+
+
+async def _compute_geocoding_status(db: Any, mv_metrics: _MvMetrics) -> GeocodingStatus:
     """Compute geocoding coverage statistics (uncached)."""
     # Per-(source, status) counts for geocoded_addresses in a single GROUP BY
     # instead of eight separate COUNT(*) round-trips.
@@ -301,25 +379,12 @@ async def _compute_geocoding_status(db: Any) -> GeocodingStatus:
     dense_errors = cell.get("error", 0)
     dense_geocoded = dense_success + dense_pending + dense_no_coverage + dense_errors
 
-    # Derive all materialized-view metrics in a SINGLE query so dense_total_cells,
-    # total and covered come from one MV snapshot. The MV (migrations 18 + 21) is
-    # refreshed out-of-band, so computing these as separate statements could span a
-    # refresh and briefly skew the coverage percentage. The MV carries a per-cell
-    # point_count; a LEFT JOIN to geocoded_point_cells on the indexed (lat_4dp, lon_4dp)
-    # key yields covered points via FILTER — replacing the old ~5.2s COUNT(*) ...
-    # WHERE EXISTS(ROUND ...) Parallel Seq Scan over ~4.5M garmin_track_points rows
-    # (~0.9s now). Staleness of hours is acceptable (see migration 21).
-    mv_metrics = await db.fetchrow(
-        "SELECT COUNT(*)::BIGINT AS dense_total_cells, "
-        "COALESCE(SUM(m.point_count), 0)::BIGINT AS total_track_points, "
-        "COALESCE(SUM(m.point_count) FILTER (WHERE g.lat_4dp IS NOT NULL), 0)::BIGINT "
-        "AS covered_track_points "
-        "FROM public.mv_garmin_track_point_cells m "
-        "LEFT JOIN public.geocoded_point_cells g USING (lat_4dp, lon_4dp)"
-    )
-    dense_total_cells = mv_metrics["dense_total_cells"] if mv_metrics else 0
-    total_track_points = mv_metrics["total_track_points"] if mv_metrics else 0
-    covered_track_points = mv_metrics["covered_track_points"] if mv_metrics else 0
+    # mv_garmin_track_point_cells-derived metrics are resolved by the caller
+    # via `_get_mv_metrics`, cached separately with a much longer TTL than the
+    # rest of this response (see _MV_METRICS_CACHE_TTL_SECONDS).
+    dense_total_cells = mv_metrics.dense_total_cells
+    total_track_points = mv_metrics.total_track_points
+    covered_track_points = mv_metrics.covered_track_points
     dense_point_coverage_percent = (
         round((covered_track_points / total_track_points * 100), 2) if total_track_points else 0.0
     )

--- a/app/routers/geocoding.py
+++ b/app/routers/geocoding.py
@@ -316,7 +316,7 @@ async def _get_mv_metrics(db: Any, cache: _MvMetricsCache) -> _MvMetrics:
         # ... WHERE EXISTS(ROUND ...) Parallel Seq Scan over ~4.5M
         # garmin_track_points rows (~0.9s now, per #167). Still an unfiltered
         # ~556k-row aggregate though, so it gets its own longer-TTL cache
-        # rather than running on every 60s /status cache miss (see #<TBD>).
+        # rather than running on every 60s /status cache miss.
         row = await db.fetchrow(
             "SELECT COUNT(*)::BIGINT AS dense_total_cells, "
             "COALESCE(SUM(m.point_count), 0)::BIGINT AS total_track_points, "

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -467,6 +467,48 @@ async def test_geocoding_status_cache_expires(client: AsyncClient, mock_db: Asyn
 
 
 @pytest.mark.asyncio
+async def test_geocoding_status_mv_metrics_outlive_status_cache_expiry(client: AsyncClient, mock_db: AsyncMock):
+    """The mv_garmin_track_point_cells-derived metrics use a longer, separate
+    TTL (_MV_METRICS_CACHE_TTL_SECONDS) than the rest of /status
+    (_STATUS_CACHE_TTL_SECONDS). That aggregate is an unfiltered scan over the
+    full MV (~556k rows in prod, consistently >500ms per New Relic), so once
+    it's warm it should survive an outer-cache expiry that only invalidates
+    the cheaper, more dynamic parts of the response.
+    """
+    addr_rows = [{"source": "owntracks", "status": "success", "n": 100}]
+    cell_rows = [{"status": "success", "n": 200}]
+    # Two full outer-cache cycles' worth of fetch/fetchval side effects, but
+    # only ONE fetchrow value -- if the MV cache were bypassed on the second
+    # cycle, fetchrow would be awaited twice and this would still pass by
+    # returning stale data, so the await_count assertion below is what
+    # actually guards the regression.
+    mock_db.fetch.side_effect = [addr_rows, cell_rows, addr_rows, cell_rows]
+    mock_db.fetchval.side_effect = [1000, 10, 5] * 2
+    mock_db.fetchrow.return_value = {
+        "dense_total_cells": 300,
+        "total_track_points": 50000,
+        "covered_track_points": 35000,
+    }
+
+    now = [0.0]
+    with patch("app.routers.geocoding.time.monotonic", side_effect=lambda: now[0]):
+        await client.get("/api/v1/geocoding/status")
+        assert mock_db.fetchrow.await_count == 1
+
+        # Past the 60s outer /status TTL, but well within the 600s MV TTL.
+        now[0] = 120.0
+        second = await client.get("/api/v1/geocoding/status")
+
+    assert second.status_code == 200
+    assert second.json()["dense_point_coverage_percent"] == 70.0
+    # Outer response was recomputed (dynamic parts re-queried)...
+    assert mock_db.fetch.await_count == 4
+    assert mock_db.fetchval.await_count == 6
+    # ...but the MV aggregate was served from its own longer-lived cache.
+    assert mock_db.fetchrow.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_trigger_geocoding_no_pending(client: AsyncClient, mock_db: AsyncMock):
     mock_db.fetch.return_value = []
     mock_db.fetchval.return_value = 0

--- a/tests/test_query_performance.py
+++ b/tests/test_query_performance.py
@@ -160,14 +160,20 @@ async def test_garmin_track_points_full_fetch_baseline(live_db: DatabaseService)
 
 @pytest.mark.asyncio
 async def test_mv_garmin_track_point_cells_coverage_baseline(live_db: DatabaseService) -> None:
-    """Geocoding coverage aggregate: baseline only, not fixed here.
+    """Geocoding coverage aggregate: cold-cache baseline, not sped up here.
 
     Full-table aggregate over mv_garmin_track_point_cells with no WHERE
-    clause -- indexes can't speed up an unfiltered aggregate. New Relic
-    showed 100% of calls >500ms (avg 942ms). Caching this at the app layer
-    (invalidated on MV refresh) is the real fix and is a separate follow-up;
-    this test just records today's baseline. Query matches
-    app/routers/geocoding.py's coverage-stats handler.
+    clause -- indexes can't speed up an unfiltered aggregate (~556k rows).
+    New Relic showed 100% of raw calls >500ms (avg ~1s). The app-layer fix
+    (this test bypasses, since it hits the DB directly) is a longer,
+    dedicated cache TTL for just this portion of GET /status
+    (_MV_METRICS_CACHE_TTL_SECONDS = 600s in app/routers/geocoding.py,
+    decoupled from the 60s _STATUS_CACHE_TTL_SECONDS the rest of the
+    response uses), which cuts how often this query runs by ~10x without
+    touching the query itself. This test documents the unavoidable
+    cold-cache/cache-miss cost -- see test_geocoding.py's
+    test_geocoding_status_mv_metrics_outlive_status_cache_expiry for the
+    caching behavior itself.
     """
     row, duration_ms = await _timed(
         live_db.fetchrow(


### PR DESCRIPTION
## Summary
- Continuation of the New Relic slow-query cleanup (see #232 for the query catalog). This is the `mv_garmin_track_point_cells` coverage aggregate.
- Live NR span data over the last 2 days showed this query still runs **73x/day at 100% >500ms** (avg ~1s, max 3.5s) despite `GET /status` already caching its whole response for 60s (#153/#167) -- the query only changes on out-of-band MV refresh (hours-scale) or background geocoding progress, so sharing the 60s TTL with the rest of the response forced far more recomputation than the data's actual freshness needs.
- Splits it into its own cache (`_MvMetricsCache`, `_MV_METRICS_CACHE_TTL_SECONDS = 600s`), independent of `_StatusCache`'s 60s TTL, using the same double-checked-locking pattern already established for the outer cache. Pure app-layer change -- no schema/API changes, no new failure modes.
- No further speedup to the query itself (it's an unfiltered aggregate over ~556k rows; indexes don't help). `tests/test_query_performance.py`'s baseline test still documents that cold-cache cost.

## Test plan
- [x] New test `test_geocoding_status_mv_metrics_outlive_status_cache_expiry`: outer cache expires at 60s (dynamic parts re-queried) while the MV cache survives (fetchrow not re-awaited) -- passes
- [x] All existing `/status` cache tests still pass unmodified
- [x] Live smoke test against prod DB (local `uvicorn`): cold call (644ms mv query) → immediate repeat (12ms, cache hit) → call after 62s (outer cache expired, MV cache still warm) -- `mv_garmin_track_point_cells` query ran exactly once across all three, response stayed correct (`dense_point_coverage_percent: 99.97`)
- [x] `pytest --cov=app tests/`: 279 passed, 94.51% coverage (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)