### PR TITLE
perf(garmin): replace segment-crossing self-join with a window pass

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1139,7 +1139,7 @@ async def _fetch_segment_efforts(
         ),"""
         bearings_join = """
             LEFT JOIN start_bearings sb
-              ON sb.activity_id = s.activity_id AND sb.s_ts = s.c_ts"""
+              ON sb.activity_id = s.activity_id AND sb.s_ts = s.s_ts"""
         bearing_clause = f"""
             AND (
                 sb.bearing_deg IS NULL
@@ -1208,13 +1208,26 @@ async def _fetch_segment_efforts(
             FROM crossing_repr r
             JOIN crossing_flags f ON f.activity_id = r.activity_id AND f.crossing = r.crossing
         ),{start_bearings_cte}
+        -- For each crossing, the nearest later is_end crossing in the same
+        -- activity ("next matching row"). Computed as one ordered window pass
+        -- rather than a crossings-JOIN-crossings self-join: that self-join
+        -- has no index to drive it (crossings is a CTE), so it degenerated
+        -- into a full activity_id x activity_id nested loop -- quadratic in
+        -- the number of crossings, which dominates for segments crossed by
+        -- many activities/laps.
+        pairs_raw AS (
+            SELECT activity_id, c_ts AS s_ts, is_start,
+                   MIN(c_ts) FILTER (WHERE is_end) OVER (
+                       PARTITION BY activity_id ORDER BY c_ts
+                       ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING
+                   ) AS e_ts
+            FROM crossings
+        ),
         pairs AS (
-            SELECT s.activity_id, s.c_ts AS s_ts, MIN(e.c_ts) AS e_ts
-            FROM crossings s
-            JOIN crossings e ON e.activity_id = s.activity_id AND e.c_ts > s.c_ts AND e.is_end
+            SELECT s.activity_id, s.s_ts, s.e_ts
+            FROM pairs_raw s
             {bearings_join}
-            WHERE s.is_start{bearing_clause}
-            GROUP BY s.activity_id, s.c_ts
+            WHERE s.is_start AND s.e_ts IS NOT NULL{bearing_clause}
         ),
         metrics AS (
             SELECT b.activity_id, b.s_ts, b.e_ts,
@@ -1465,13 +1478,22 @@ _SEGMENT_ROUTE_LATERAL = """
             FROM crossing_repr r
             JOIN crossing_flags f ON f.crossing = r.crossing
         ),
+        -- Same "next matching row" rewrite as _fetch_segment_efforts' pairs
+        -- CTE: a single ordered window pass instead of a crossings-JOIN-
+        -- crossings self-join with no index to drive it.
+        proximity_bounds_raw AS (
+            SELECT c_ts AS s_ts, is_start,
+                   MIN(c_ts) FILTER (WHERE is_end) OVER (
+                       ORDER BY c_ts
+                       ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING
+                   ) AS e_ts
+            FROM crossings
+        ),
         proximity_bounds AS (
-            SELECT cs.c_ts AS s_ts, MIN(ce.c_ts) AS e_ts
-            FROM crossings cs
-            JOIN crossings ce ON ce.c_ts > cs.c_ts AND ce.is_end
-            WHERE cs.is_start
-            GROUP BY cs.c_ts
-            ORDER BY cs.c_ts ASC
+            SELECT s_ts, e_ts
+            FROM proximity_bounds_raw
+            WHERE is_start AND e_ts IS NOT NULL
+            ORDER BY s_ts ASC
             LIMIT 1
         ),
         chosen_bounds AS (

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1751,8 +1751,12 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
     query, *params = mock_db.fetch.await_args.args
     assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in query
     assert "ST_DWithin(t.geog, seg.end_pt, seg.tol)" in query
-    assert "e.c_ts > s.c_ts" in query  # same-direction enforcement
-    assert "AND e.is_end" in query
+    # same-direction enforcement: the nearest later is_end crossing is found via
+    # an ordered window pass (ROWS 1 FOLLOWING..UNBOUNDED, ORDER BY c_ts), not a
+    # crossings-JOIN-crossings self-join (no index to drive it -- quadratic in
+    # the number of crossings for segments crossed by many activities/laps)
+    assert "ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING" in query
+    assert "MIN(c_ts) FILTER (WHERE is_end)" in query
     assert "WHERE s.is_start" in query
     # a new crossing must start on a direct start-only -> end-only flip (and
     # the reverse), not just a >2min time gap -- otherwise a short/fast

--- a/tests/test_query_performance.py
+++ b/tests/test_query_performance.py
@@ -182,3 +182,58 @@ async def test_mv_garmin_track_point_cells_coverage_baseline(live_db: DatabaseSe
     assert duration_ms < 3000, (
         f"coverage aggregate took {duration_ms:.2f}ms -- unexpectedly slow even for an unfiltered scan"
     )
+
+
+@pytest.mark.asyncio
+async def test_segment_efforts_pairs_regression_guard(live_db: DatabaseService) -> None:
+    """Segment-crossing effort matching: partially fixed, this test guards the fix.
+
+    New Relic showed this as the single most expensive query pattern (avg
+    3.26s, max 11.25s, 50% of calls >500ms). The `pairs` CTE (matching each
+    start-crossing to its nearest later end-crossing) used a
+    crossings-JOIN-crossings self-join with no index to drive it -- a full
+    activity_id x activity_id nested loop, quadratic in the number of
+    crossings. Rewritten to a single ordered window pass
+    (`app.routers.garmin._fetch_segment_efforts`'s `pairs`/`pairs_raw` CTEs).
+    Verified against prod with wide parameters (200m tolerance, all sports)
+    around the busiest real track in the DB: identical results, ~25-30%
+    faster (785-823ms -> 547-647ms over 3 runs) at that scale, with the win
+    expected to grow for segments crossed by many more activities/laps since
+    the removed cost was O(n^2) in crossing count, not O(n log n).
+
+    The other major cost component here -- the crossing_hits/crossing_grouped
+    window-function pipeline over all candidate track points -- is a larger,
+    separate follow-up, not addressed by this test or the fix it guards.
+    """
+    row = await live_db.fetchrow(
+        "SELECT t.activity_id, "
+        "(SELECT longitude FROM public.garmin_track_points WHERE activity_id = t.activity_id ORDER BY timestamp ASC LIMIT 1) AS start_lon, "
+        "(SELECT latitude FROM public.garmin_track_points WHERE activity_id = t.activity_id ORDER BY timestamp ASC LIMIT 1) AS start_lat, "
+        "(SELECT longitude FROM public.garmin_track_points WHERE activity_id = t.activity_id ORDER BY timestamp DESC LIMIT 1) AS end_lon, "
+        "(SELECT latitude FROM public.garmin_track_points WHERE activity_id = t.activity_id ORDER BY timestamp DESC LIMIT 1) AS end_lat "
+        "FROM public.garmin_track_points t "
+        "GROUP BY t.activity_id ORDER BY COUNT(*) DESC LIMIT 1"
+    )
+    if row is None:
+        pytest.skip("no garmin_track_points to test against")
+    assert row is not None  # narrows for type checkers; skip() above never returns
+
+    from app.routers.garmin import _fetch_segment_efforts
+
+    _, duration_ms = await _timed(
+        _fetch_segment_efforts(
+            live_db,
+            start_lat=row["start_lat"],
+            start_lon=row["start_lon"],
+            end_lat=row["end_lat"],
+            end_lon=row["end_lon"],
+            tolerance_meters=200.0,
+            sport=None,
+            date_from=None,
+            date_to=None,
+            max_effort_seconds=7200,
+            limit=20,
+        )
+    )
+    print(f"\n[segment-efforts pairs] activity_id={row['activity_id']} took {duration_ms:.2f}ms")
+    assert duration_ms < 5000, f"segment-efforts took {duration_ms:.2f}ms -- possible regression in the pairs rewrite"


### PR DESCRIPTION
## Summary
- New Relic showed the segment-efforts \`seg\` query as the single most expensive slow-SQL pattern found in the original review (avg 3.26s, max 11.25s, 50% of calls >500ms).
- Root cause: the \`pairs\` CTE matched each start-crossing to its nearest later end-crossing via \`crossings s JOIN crossings e ON e.activity_id = s.activity_id AND e.c_ts > s.c_ts AND e.is_end\`. \`crossings\` is a CTE with no index to drive that join, so it degenerated into a full \`activity_id x activity_id\` nested loop -- quadratic in the number of crossings. Busy/frequently-ridden segments (exactly the case this feature exists for) produce the large crossing counts that blow this up.
- Fix: rewrite as a single ordered window pass -- \`MIN(c_ts) FILTER (WHERE is_end) OVER (PARTITION BY activity_id ORDER BY c_ts ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)\` -- computing the same "nearest later end crossing" in one pass instead of a quadratic self-join. Applied to both the shared \`_fetch_segment_efforts()\` query and the structurally identical (single-activity-scoped) \`proximity_bounds\` CTE used by segment route recovery.
- **Not fully fixed**: the \`crossing_hits\`/\`crossing_grouped\` window-function pipeline over all candidate track points is a larger remaining cost component (~60% of total time at the tested scale). Separate, more invasive follow-up -- not addressed here.

## Verification
- Byte-for-byte identical results vs. the old query, checked at both a narrow (50m/cycling) and wide (200m/all-sports) parameter set against prod, around the busiest real track in the DB (13,720 points).
- ~25-30% faster at that scale: 785-823ms -> 547-647ms over 3 \`EXPLAIN ANALYZE\` runs each. The win is expected to grow for segments crossed by more activities/laps since the removed cost was O(n^2) in crossing count, not O(n log n) -- my reproducible test case only reached ~830 crossings; real worst cases (11.25s) likely involve far more.

## Test plan
- [x] Updated \`test_segment_efforts_query_and_params\` to assert the new window-pass SQL shape instead of the removed self-join text
- [x] New live regression-guard test \`test_segment_efforts_pairs_regression_guard\` in \`tests/test_query_performance.py\` (passed at 686-773ms across runs, well under its 5s guard threshold)
- [x] All 25 existing segment-related tests pass unmodified
- [x] \`pytest --cov=app tests/\`: 279 passed, 94.51% coverage (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)