### PR TITLE
perf(garmin): disable JIT for segment-efforts, its overhead exceeds its benefit

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -109,6 +109,26 @@ class DatabaseService:
         self._log_query(query, args, (time.perf_counter() - start) * 1000.0, row_count=len(result))
         return result
 
+    async def fetch_no_jit(self, query: str, *args: Any) -> list[asyncpg.Record]:
+        """Execute a query with JIT disabled for this transaction only.
+
+        For some multi-CTE queries (window functions over a correlated
+        ST_DWithin candidate set, e.g. segment-efforts matching) the planner's
+        row-count misestimate inflates the query's apparent cost enough to
+        trigger Postgres's JIT compiler, whose fixed compilation overhead then
+        exceeds what it saves on a single execution over a few thousand rows.
+        Verified ~17% faster with JIT off for that query (interleaved timing,
+        no overlap between the two distributions). Scoped to a single
+        transaction via SET LOCAL so it doesn't affect other queries sharing
+        the pooled connection -- use `fetch()` for everything else.
+        """
+        start = time.perf_counter()
+        async with self.pool.acquire() as conn, conn.transaction():
+            await conn.execute("SET LOCAL jit = off")
+            result: list[asyncpg.Record] = await conn.fetch(query, *args)
+        self._log_query(query, args, (time.perf_counter() - start) * 1000.0, row_count=len(result))
+        return result
+
     async def fetchrow(self, query: str, *args: Any) -> asyncpg.Record | None:
         """Execute a query and return a single row."""
         start = time.perf_counter()

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1253,7 +1253,10 @@ async def _fetch_segment_efforts(
         LIMIT ${limit_idx}
     """
 
-    rows = await db.fetch(query, *params)
+    # fetch_no_jit: this query's planner cost estimate triggers JIT
+    # compilation whose overhead exceeds its benefit here -- see
+    # DatabaseService.fetch_no_jit's docstring.
+    rows = await db.fetch_no_jit(query, *params)
     return [SegmentEffort(rank=i + 1, **dict(row)) for i, row in enumerate(rows)]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ def mock_db() -> AsyncMock:
     db = AsyncMock(spec=DatabaseService)
     db.health_check = AsyncMock(return_value={"status": "connected", "pool_size": 2, "pool_free": 2})
     db.fetch = AsyncMock(return_value=[])
+    db.fetch_no_jit = AsyncMock(return_value=[])
     db.fetchrow = AsyncMock(return_value=None)
     db.fetchval = AsyncMock(return_value=0)
     db.execute = AsyncMock(return_value="OK")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,6 +9,34 @@ import pytest
 from app.database import DatabaseService, _parse_operation
 
 
+class FakeTransaction:
+    async def __aenter__(self) -> FakeTransaction:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.fetch = AsyncMock()
+        self.execute = AsyncMock()
+
+    def transaction(self) -> FakeTransaction:
+        return FakeTransaction()
+
+
+class FakeAcquireContext:
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._conn
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
 class FakePool:
     def __init__(self) -> None:
         self.fetch = AsyncMock()
@@ -18,6 +46,10 @@ class FakePool:
         self.closed = False
         self._size = 2
         self._idle = 1
+        self.conn = FakeConnection()
+
+    def acquire(self) -> FakeAcquireContext:
+        return FakeAcquireContext(self.conn)
 
     def get_size(self) -> int:
         return self._size
@@ -123,6 +155,25 @@ async def test_fetch_helpers_delegate_to_pool(monkeypatch: pytest.MonkeyPatch, c
 
     assert await db.execute("DELETE FROM table") == "OK"
     fake_pool.execute.assert_awaited_with("DELETE FROM table")
+
+
+@pytest.mark.asyncio
+async def test_fetch_no_jit_disables_jit_for_a_single_transaction(monkeypatch: pytest.MonkeyPatch, config):
+    fake_pool = FakePool()
+    fake_pool.conn.fetch.return_value = ["rows"]
+
+    monkeypatch.setattr("app.database.asyncpg.create_pool", AsyncMock(return_value=fake_pool))
+
+    db = DatabaseService(config)
+    await db.initialize()
+
+    assert await db.fetch_no_jit("SELECT * FROM table WHERE id=$1", 1) == ["rows"]
+    # runs on the SAME acquired connection, inside a transaction, so SET LOCAL
+    # scopes the JIT-off setting to just this query -- not the pool default,
+    # which other queries sharing the pooled connection must keep using.
+    fake_pool.conn.execute.assert_awaited_with("SET LOCAL jit = off")
+    fake_pool.conn.fetch.assert_awaited_with("SELECT * FROM table WHERE id=$1", 1)
+    fake_pool.fetch.assert_not_awaited()  # not the plain pool.fetch() path
 
 
 @pytest.mark.asyncio

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1671,7 +1671,7 @@ def _segment_effort_row(activity_id: str, elapsed: float) -> dict:
 
 @pytest.mark.asyncio
 async def test_segment_efforts_returns_ranked(client: AsyncClient, mock_db):
-    mock_db.fetch.return_value = [
+    mock_db.fetch_no_jit.return_value = [
         _segment_effort_row("a-fast", 89.0),
         _segment_effort_row("a-slow", 130.0),
     ]
@@ -1706,7 +1706,7 @@ async def test_segment_efforts_keeps_multiple_laps_from_one_activity(client: Asy
     GPS-ping bursts down to one row per real crossing while still returning
     every distinct lap.
     """
-    mock_db.fetch.return_value = [
+    mock_db.fetch_no_jit.return_value = [
         _segment_effort_row("multi-lap-ride", 1098.0),
         _segment_effort_row("multi-lap-ride", 1199.0),
     ]
@@ -1726,7 +1726,7 @@ async def test_segment_efforts_keeps_multiple_laps_from_one_activity(client: Asy
 
 @pytest.mark.asyncio
 async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
-    mock_db.fetch.return_value = []
+    mock_db.fetch_no_jit.return_value = []
 
     response = await client.get(
         "/api/v1/garmin/segment-efforts"
@@ -1748,7 +1748,7 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
         "items": [],
     }
 
-    query, *params = mock_db.fetch.await_args.args
+    query, *params = mock_db.fetch_no_jit.await_args.args
     assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in query
     assert "ST_DWithin(t.geog, seg.end_pt, seg.tol)" in query
     # same-direction enforcement: the nearest later is_end crossing is found via
@@ -1790,14 +1790,14 @@ async def test_segment_efforts_query_and_params(client: AsyncClient, mock_db):
 
 @pytest.mark.asyncio
 async def test_segment_efforts_all_sports_when_blank(client: AsyncClient, mock_db):
-    mock_db.fetch.return_value = []
+    mock_db.fetch_no_jit.return_value = []
 
     response = await client.get(
         "/api/v1/garmin/segment-efforts?start_lat=40.79&start_lon=-73.96&end_lat=40.79&end_lon=-73.964&sport="
     )
 
     assert response.status_code == 200
-    query, *params = mock_db.fetch.await_args.args
+    query, *params = mock_db.fetch_no_jit.await_args.args
     assert "a.sport =" not in query
     assert "cycling" not in params
 
@@ -2028,7 +2028,7 @@ async def test_get_segment_efforts_uses_saved_coords(client: AsyncClient, mock_d
         "source_activity_id": None,
         "distance_meters": None,
     }
-    mock_db.fetch.return_value = [
+    mock_db.fetch_no_jit.return_value = [
         _segment_effort_row("a-fast", 79.0),
         _segment_effort_row("a-slow", 130.0),
     ]
@@ -2039,7 +2039,7 @@ async def test_get_segment_efforts_uses_saved_coords(client: AsyncClient, mock_d
     body = response.json()
     assert body["segment"]["tolerance_meters"] == 40
     assert [e["rank"] for e in body["items"]] == [1, 2]
-    efforts_query, *efforts_params = mock_db.fetch.await_args.args
+    efforts_query, *efforts_params = mock_db.fetch_no_jit.await_args.args
     assert "ST_DWithin(t.geog, seg.start_pt, seg.tol)" in efforts_query
     # matching used the saved segment's coordinates and tolerance
     assert efforts_params[:5] == [-73.96104321, 40.79366846, -73.96422816, 40.79002409, 40.0]
@@ -2061,12 +2061,12 @@ async def test_get_segment_efforts_applies_min_distance_from_saved_segment(clien
         "source_activity_id": None,
         "distance_meters": 6070.0,
     }
-    mock_db.fetch.return_value = [_segment_effort_row("a-real-lap", 900.0)]
+    mock_db.fetch_no_jit.return_value = [_segment_effort_row("a-real-lap", 900.0)]
 
     response = await client.get("/api/v1/garmin/segments/5/efforts")
 
     assert response.status_code == 200
-    efforts_query, *efforts_params = mock_db.fetch.await_args.args
+    efforts_query, *efforts_params = mock_db.fetch_no_jit.await_args.args
     assert "m.distance_km >= " in efforts_query
     # 6070m * 0.7 (MIN_SEGMENT_DISTANCE_RATIO) = 4.249 km
     assert efforts_params[-2] == pytest.approx(4.249)
@@ -2086,12 +2086,12 @@ async def test_get_segment_efforts_skips_min_distance_without_recorded_distance(
         "source_activity_id": None,
         "distance_meters": None,
     }
-    mock_db.fetch.return_value = [_segment_effort_row("a-real-lap", 900.0)]
+    mock_db.fetch_no_jit.return_value = [_segment_effort_row("a-real-lap", 900.0)]
 
     response = await client.get("/api/v1/garmin/segments/5/efforts")
 
     assert response.status_code == 200
-    efforts_query, *_efforts_params = mock_db.fetch.await_args.args
+    efforts_query, *_efforts_params = mock_db.fetch_no_jit.await_args.args
     assert "m.distance_km >= " not in efforts_query
 
 
@@ -2116,7 +2116,7 @@ async def test_get_segment_efforts_rejects_reverse_direction(client: AsyncClient
         },
         {"bearing_deg": 197.5},
     ]
-    mock_db.fetch.return_value = []
+    mock_db.fetch_no_jit.return_value = []
 
     response = await client.get("/api/v1/garmin/segments/7/efforts")
 
@@ -2124,7 +2124,7 @@ async def test_get_segment_efforts_rejects_reverse_direction(client: AsyncClient
     bearing_query, *bearing_params = mock_db.fetchrow.await_args_list[1].args
     assert bearing_params[0] == "23541736805"
 
-    efforts_query, *efforts_params = mock_db.fetch.await_args.args
+    efforts_query, *efforts_params = mock_db.fetch_no_jit.await_args.args
     assert "start_bearings" in efforts_query
     assert "LEAST(" in efforts_query
     assert efforts_params[-1] == 197.5
@@ -2142,13 +2142,13 @@ async def test_get_segment_efforts_skips_bearing_lookup_without_source_activity(
         "source_activity_id": None,
         "distance_meters": None,
     }
-    mock_db.fetch.return_value = []
+    mock_db.fetch_no_jit.return_value = []
 
     response = await client.get("/api/v1/garmin/segments/5/efforts")
 
     assert response.status_code == 200
     assert mock_db.fetchrow.await_count == 1  # no reference-bearing lookup fired
-    efforts_query, *efforts_params = mock_db.fetch.await_args.args
+    efforts_query, *efforts_params = mock_db.fetch_no_jit.await_args.args
     # no reference bearing to compare against, so the CTE (and its per-start
     # LATERAL lookup) is omitted rather than computed and ignored
     assert "start_bearings" not in efforts_query

--- a/tests/test_query_performance.py
+++ b/tests/test_query_performance.py
@@ -192,24 +192,35 @@ async def test_mv_garmin_track_point_cells_coverage_baseline(live_db: DatabaseSe
 
 @pytest.mark.asyncio
 async def test_segment_efforts_pairs_regression_guard(live_db: DatabaseService) -> None:
-    """Segment-crossing effort matching: partially fixed, this test guards the fix.
+    """Segment-crossing effort matching: two fixes layered, this test guards both.
 
     New Relic showed this as the single most expensive query pattern (avg
-    3.26s, max 11.25s, 50% of calls >500ms). The `pairs` CTE (matching each
-    start-crossing to its nearest later end-crossing) used a
-    crossings-JOIN-crossings self-join with no index to drive it -- a full
-    activity_id x activity_id nested loop, quadratic in the number of
-    crossings. Rewritten to a single ordered window pass
-    (`app.routers.garmin._fetch_segment_efforts`'s `pairs`/`pairs_raw` CTEs).
-    Verified against prod with wide parameters (200m tolerance, all sports)
-    around the busiest real track in the DB: identical results, ~25-30%
-    faster (785-823ms -> 547-647ms over 3 runs) at that scale, with the win
-    expected to grow for segments crossed by many more activities/laps since
-    the removed cost was O(n^2) in crossing count, not O(n log n).
+    3.26s, max 11.25s, 50% of calls >500ms). Two independent fixes:
 
-    The other major cost component here -- the crossing_hits/crossing_grouped
-    window-function pipeline over all candidate track points -- is a larger,
-    separate follow-up, not addressed by this test or the fix it guards.
+    1. The `pairs` CTE (matching each start-crossing to its nearest later
+       end-crossing) used a crossings-JOIN-crossings self-join with no index
+       to drive it -- a full activity_id x activity_id nested loop, quadratic
+       in the number of crossings. Rewritten to a single ordered window pass
+       (`app.routers.garmin._fetch_segment_efforts`'s `pairs`/`pairs_raw`
+       CTEs). Verified against prod with wide parameters (200m tolerance, all
+       sports) around the busiest real track in the DB: identical results,
+       ~25-30% faster (785-823ms -> 547-647ms over 3 runs) at that scale, with
+       the win expected to grow for segments crossed by many more
+       activities/laps since the removed cost was O(n^2) in crossing count,
+       not O(n log n).
+    2. Separately, this query's planner cost estimate (row-count misestimate
+       across the CTE chain) triggers Postgres's JIT compiler, whose fixed
+       compilation overhead exceeds what it saves on a single execution over
+       a few thousand rows. `DatabaseService.fetch_no_jit` disables JIT for
+       just this query via `SET LOCAL jit = off` in its own transaction --
+       verified ~17% faster with interleaved timing (no overlap between the
+       JIT-on and JIT-off distributions across 8 runs each).
+
+    Not addressed here: the crossing_hits/crossing_grouped window-function
+    pipeline's own row-processing cost (deduplicating its redundant
+    ST_DWithin calls was tried and measured -- only ~5%, within noise, so not
+    worth the added complexity) is a larger, structurally different
+    follow-up if this query needs to get faster still.
     """
     row = await live_db.fetchrow(
         "SELECT t.activity_id, "


### PR DESCRIPTION
## Summary
Continuing the seg-query optimization from #235. That fix cut the algorithmic cost of the `pairs` CTE, but a large chunk of remaining time (~600ms of ~968ms at tested scale) sits in the `crossing_hits`/`crossing_grouped` window-function pipeline. Two things investigated there:

- **Dedup redundant `ST_DWithin` calls** (computed up to 3x per candidate row: once for `is_start`/`is_end`, again inside each `LAG()` argument). Measured -- only ~5% improvement, within normal run-to-run noise. **Not shipped** -- not worth the added query complexity for an unreliable win. (Tried it, kept the evidence in the PR history, decided against it.)
- **JIT compilation overhead**: this query's planner cost estimate (row-count misestimate across the CTE chain -- 913 estimated vs 28,549 actual in testing) crosses Postgres's `jit_above_cost` threshold, but the query only runs once over a few thousand rows, so JIT's fixed compilation cost (~180-210ms measured via `EXPLAIN ANALYZE`) exceeds what it saves. **Shipped.**

## Verification
- Interleaved timing against prod (alternating JIT on/off, 8 runs each, same session to control for external load drift): **~17% faster with JIT off, zero overlap** between the two distributions (JIT on: 765-989ms, JIT off: 641-797ms).
- Confirmed the mechanism works cleanly through asyncpg + PgBouncer, not just raw `psql`.
- Re-ran the live `test_segment_efforts_pairs_regression_guard` integration test through the real `_fetch_segment_efforts` code path: 615-621ms, down from the 686-772ms baseline established in #235.

## Implementation
Adds `DatabaseService.fetch_no_jit()`, which runs a query with `SET LOCAL jit = off` inside its own transaction -- scoped to that one query, not the pool default, so it doesn't affect other queries sharing the pooled connection. `_fetch_segment_efforts` now uses it instead of the plain `fetch()`.

## Test plan
- [x] New `test_fetch_no_jit_disables_jit_for_a_single_transaction` in `tests/test_database.py` -- confirms it acquires a connection, runs `SET LOCAL jit = off`, executes the query on that same connection (not the plain pool path)
- [x] Updated all 9 segment-efforts mocked tests to assert against `fetch_no_jit` instead of `fetch`
- [x] Live regression-guard test in `tests/test_query_performance.py` passes at 615-621ms
- [x] `pytest --cov=app tests/`: 280 passed, 94.52% coverage (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)