### PR TITLE
perf(locations): fence the geocoded_addresses join behind LIMIT

### DIFF
--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -107,7 +107,10 @@ async def list_locations(
     # every row with a non-null location_id per the table's CHECK constraint,
     # but stating it lets the planner use the existing partial unique index
     # (uniq_geocoded_addresses_owntracks_location) instead of a full scan.
-    bare_sort = qualified_sort.removeprefix("l.")
+    # `sort` (not qualified_sort) for the outer ORDER BY: it's already
+    # whitelist-validated above and names exactly the column `page` selects,
+    # so it doesn't depend on _SORT_COLUMN_MAP's values staying simple
+    # "l.<column>" strings the way string-stripping qualified_sort would.
     data_query = (
         f"WITH page AS MATERIALIZED ("
         f"  SELECT l.id, l.device_id, l.tid, l.latitude, l.longitude, l.accuracy, l.altitude, "
@@ -121,7 +124,7 @@ async def list_locations(
         f"SELECT page.*, ga.display_address "
         f"FROM page "
         f"LEFT JOIN public.geocoded_addresses ga ON ga.location_id = page.id AND ga.source = 'owntracks' "
-        f"ORDER BY page.{bare_sort} {order}"
+        f"ORDER BY page.{sort} {order}"
     )
     params.extend([limit, offset])
     rows = await db.fetch(data_query, *params)

--- a/app/routers/locations.py
+++ b/app/routers/locations.py
@@ -97,16 +97,31 @@ async def list_locations(
     count_query = f"SELECT COUNT(*) FROM public.locations {where}"
     total = await db.fetchval(count_query, *params)
 
+    # `page` selects and limits locations alone (index-driven top-N via
+    # idx_locations_created_at etc.) *before* joining geocoded_addresses --
+    # joining first and limiting after made the planner Seq Scan + hash-join
+    # the entire ~350k-row geocoded_addresses table merely to sort and throw
+    # away all but `limit` rows (2.4s at offset=0 in production). MATERIALIZED
+    # keeps Postgres from flattening the CTE back into that same bad plan.
+    # The join also needs an explicit `ga.source = 'owntracks'` -- true for
+    # every row with a non-null location_id per the table's CHECK constraint,
+    # but stating it lets the planner use the existing partial unique index
+    # (uniq_geocoded_addresses_owntracks_location) instead of a full scan.
+    bare_sort = qualified_sort.removeprefix("l.")
     data_query = (
-        f"SELECT l.id, l.device_id, l.tid, l.latitude, l.longitude, l.accuracy, l.altitude, "
-        f"l.velocity, l.battery, l.battery_status, l.connection_type, l.trigger, "
-        f"l.timestamp, l.created_at, "
-        f"ga.display_address "
-        f"FROM public.locations l "
-        f"LEFT JOIN public.geocoded_addresses ga ON ga.location_id = l.id "
-        f"{where} "
-        f"ORDER BY {qualified_sort} {order} "
-        f"LIMIT ${idx} OFFSET ${idx + 1}"
+        f"WITH page AS MATERIALIZED ("
+        f"  SELECT l.id, l.device_id, l.tid, l.latitude, l.longitude, l.accuracy, l.altitude, "
+        f"  l.velocity, l.battery, l.battery_status, l.connection_type, l.trigger, "
+        f"  l.timestamp, l.created_at "
+        f"  FROM public.locations l "
+        f"  {where} "
+        f"  ORDER BY {qualified_sort} {order} "
+        f"  LIMIT ${idx} OFFSET ${idx + 1}"
+        f") "
+        f"SELECT page.*, ga.display_address "
+        f"FROM page "
+        f"LEFT JOIN public.geocoded_addresses ga ON ga.location_id = page.id AND ga.source = 'owntracks' "
+        f"ORDER BY page.{bare_sort} {order}"
     )
     params.extend([limit, offset])
     rows = await db.fetch(data_query, *params)

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -65,7 +65,10 @@ async def test_list_locations_filters_and_invalid_sort_falls_back(client: AsyncC
     assert "created_at < ($3::date + INTERVAL '1 day')" in count_query
 
     data_query, *params = mock_db.fetch.await_args.args
-    assert "ORDER BY l.created_at asc" in data_query
+    assert "ORDER BY l.created_at asc" in data_query  # inner CTE: index-driven top-N on locations alone
+    assert "ORDER BY page.created_at asc" in data_query  # outer: final order after the join
+    assert "MATERIALIZED" in data_query  # keeps the join fenced behind the LIMIT, not merged above it
+    assert "ga.source = 'owntracks'" in data_query  # lets the planner use the partial unique index
     assert params == ["phone", date(2025, 1, 1), date(2025, 1, 2), 10, 5]
 
 

--- a/tests/test_query_performance.py
+++ b/tests/test_query_performance.py
@@ -194,6 +194,47 @@ async def test_chart_data_bins_is_fast(live_db: DatabaseService) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_locations_first_page_is_fast(live_db: DatabaseService) -> None:
+    """GET /api/v1/locations default (first) page: found via a fresh New Relic
+    re-scan after the other fixes shipped, not part of the original catalog.
+
+    The original query joined geocoded_addresses (~350k rows) *before*
+    applying ORDER BY/LIMIT, so the planner Seq Scanned and hash-joined the
+    entire table just to sort and discard all but 50 rows -- 2420ms measured
+    via EXPLAIN ANALYZE against prod even at offset=0, not just at deep
+    OFFSET pages. Fixed by selecting/limiting locations alone in a
+    MATERIALIZED CTE first, then joining only those rows -- plus adding an
+    explicit `ga.source = 'owntracks'` predicate (always true for
+    location_id-joined rows per the table's CHECK constraint) so the planner
+    can use the existing partial unique index for the join instead of
+    another full scan. Verified against prod: identical results, 2420ms ->
+    10.6ms (EXPLAIN ANALYZE) / ~22ms (this test's full asyncpg round trip).
+    app/routers/locations.py's list_locations handler, default params
+    (sort=created_at, order=desc, limit=50, offset=0).
+    """
+    _, duration_ms = await _timed(
+        live_db.fetch(
+            "WITH page AS MATERIALIZED ("
+            "  SELECT l.id, l.device_id, l.tid, l.latitude, l.longitude, l.accuracy, l.altitude, "
+            "  l.velocity, l.battery, l.battery_status, l.connection_type, l.trigger, "
+            "  l.timestamp, l.created_at "
+            "  FROM public.locations l "
+            "  ORDER BY l.created_at desc "
+            "  LIMIT $1 OFFSET $2"
+            ") "
+            "SELECT page.*, ga.display_address "
+            "FROM page "
+            "LEFT JOIN public.geocoded_addresses ga ON ga.location_id = page.id AND ga.source = 'owntracks' "
+            "ORDER BY page.created_at desc",
+            50,
+            0,
+        )
+    )
+    print(f"\n[locations first page] took {duration_ms:.2f}ms")
+    assert duration_ms < 500, f"locations first page took {duration_ms:.2f}ms -- possible regression in the CTE fencing"
+
+
+@pytest.mark.asyncio
 async def test_mv_garmin_track_point_cells_coverage_baseline(live_db: DatabaseService) -> None:
     """Geocoding coverage aggregate: cold-cache baseline, not sped up here.
 


### PR DESCRIPTION
## Summary
Found via a fresh New Relic re-scan after the recently-shipped fixes -- not part of the original catalog. Requested this scan specifically to check for anything new now that the top offenders are fixed.

`GET /api/v1/locations` (default first page, no filters) measured **2420ms** via `EXPLAIN ANALYZE` against prod. Root cause, and it's not what it looks like at first glance: the planner **Seq Scanned and hash-joined the entire ~350k-row `geocoded_addresses` table** before applying `ORDER BY`/`LIMIT`, just to sort the joined result and discard all but 50 rows. `idx_locations_created_at` was never used. This happened even at `offset=0` -- it's not primarily an OFFSET-pagination problem, despite `LIMIT ... OFFSET` being right there in the query.

## Fix
- Select and limit `locations` alone in a `MATERIALIZED` CTE first. This forces the planner into an index-driven top-N scan (`idx_locations_created_at` etc.) and, critically, the `MATERIALIZED` hint stops Postgres from flattening the CTE back into the same bad join-before-limit plan.
- Join `geocoded_addresses` only against those already-limited rows.
- Added an explicit `ga.source = 'owntracks'` predicate to the join. This is always true for `location_id`-joined rows per the table's own `CHECK` constraint, but *stating* it lets the planner use the existing partial unique index (`uniq_geocoded_addresses_owntracks_location`) for the join instead of yet another full scan.

## Verification
Against prod, identical results:
- offset=0 (the common case): **2420ms -> 10.6ms** (`EXPLAIN ANALYZE`) / ~22-45ms (full asyncpg round trip through the real `DatabaseService`)
- offset=200000 (deep page): 2386ms -> 222ms -- still improved, though the residual cost there is the inherent O(offset) cost of skipping rows via an index; true keyset pagination would be a separate, smaller follow-up if very deep pages turn out to matter in practice.

## Test plan
- [x] Updated `test_list_locations_filters_and_invalid_sort_falls_back` to assert the new CTE structure (inner index-driven ORDER BY, outer post-join ORDER BY, `MATERIALIZED`, the `source = 'owntracks'` predicate)
- [x] New live test `test_list_locations_first_page_is_fast`: passes at 45ms against prod
- [x] `pytest --cov=app tests/`: 282 passed, 94.54% coverage (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)