### PR TITLE
perf(garmin): cache the unbinned chart-data series per activity

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import time
 import uuid
+from collections import OrderedDict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from typing import Annotated, Any, Literal
 
@@ -626,6 +629,46 @@ async def list_track_points(
     return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
+# Full-resolution chart-data cache. Deliberately unbounded resolution (see
+# get_chart_data's caller in otel-data-ui: "Full-resolution points for
+# accurate time-series charts" -- downsampling via `bins` already exists but
+# is opt-in, not a default, so it isn't a substitute here) -- returning every
+# raw point for a long activity is what made this NR's slowest recurring
+# query (up to ~3.9s). garmin_track_points rows are never mutated once
+# synced (writes only come from the separate garmin-sync service, and only
+# ever insert new activities), so a short-TTL cache carries no staleness
+# risk beyond that window; bounded to a max entry count so it can't grow
+# unboundedly across many distinct activities.
+_CHART_DATA_CACHE_TTL_SECONDS = 900.0
+_CHART_DATA_CACHE_MAX_ENTRIES = 64
+
+
+@dataclass
+class _ChartDataCacheEntry:
+    points: list[GarminChartPoint]
+    expires_at: float
+
+
+class _ChartDataCache:
+    def __init__(self) -> None:
+        self._entries: OrderedDict[str, _ChartDataCacheEntry] = OrderedDict()
+
+    def get(self, activity_id: str) -> list[GarminChartPoint] | None:
+        entry = self._entries.get(activity_id)
+        if entry is None or time.monotonic() >= entry.expires_at:
+            return None
+        self._entries.move_to_end(activity_id)
+        return entry.points
+
+    def set(self, activity_id: str, points: list[GarminChartPoint]) -> None:
+        self._entries[activity_id] = _ChartDataCacheEntry(
+            points=points, expires_at=time.monotonic() + _CHART_DATA_CACHE_TTL_SECONDS
+        )
+        self._entries.move_to_end(activity_id)
+        while len(self._entries) > _CHART_DATA_CACHE_MAX_ENTRIES:
+            self._entries.popitem(last=False)
+
+
 # Bins by time (not distance, unlike SEGMENT_EFFORT_SERIES_SQL) since
 # chart-data's contract is a full activity time series, not a single
 # distance-bounded effort. No GENERATE_SERIES grid: unlike the fixed-fraction
@@ -712,6 +755,15 @@ async def get_chart_data(
         rows = await db.fetch(CHART_DATA_BINNED_SQL, activity_id, bins)
         return [GarminChartPoint(**dict(row)) for row in rows]
 
+    cache: _ChartDataCache | None = getattr(request.app.state, "_chart_data_cache", None)
+    if cache is None:
+        cache = _ChartDataCache()
+        request.app.state._chart_data_cache = cache
+
+    cached = cache.get(activity_id)
+    if cached is not None:
+        return cached
+
     rows = await db.fetch(
         "SELECT latitude, longitude, timestamp, altitude, "
         "distance_from_start_km, speed_kmh, heart_rate, hr_zone, respiration_rate, "
@@ -720,7 +772,9 @@ async def get_chart_data(
         activity_id,
     )
 
-    return [GarminChartPoint(**dict(row)) for row in rows]
+    points = [GarminChartPoint(**dict(row)) for row in rows]
+    cache.set(activity_id, points)
+    return points
 
 
 @router.get(

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -655,7 +655,14 @@ class _ChartDataCache:
 
     def get(self, activity_id: str) -> list[GarminChartPoint] | None:
         entry = self._entries.get(activity_id)
-        if entry is None or time.monotonic() >= entry.expires_at:
+        if entry is None:
+            return None
+        if time.monotonic() >= entry.expires_at:
+            # Prune rather than leave it occupying a slot: an expired entry
+            # nobody re-requests would otherwise sit in the bounded cache
+            # until aged out by insertion order, at the expense of a
+            # still-valid entry getting LRU-evicted early.
+            del self._entries[activity_id]
             return None
         self._entries.move_to_end(activity_id)
         return entry.points

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1,6 +1,7 @@
 """Tests for Garmin endpoints."""
 
 import dataclasses
+import time
 from datetime import UTC, date, datetime, timedelta
 
 import fastapi
@@ -783,6 +784,18 @@ def test_chart_data_cache_evicts_oldest_beyond_max_entries():
 
     assert cache.get("activity-0") is None  # oldest entry evicted
     assert cache.get(f"activity-{_CHART_DATA_CACHE_MAX_ENTRIES}") == []  # newest still present
+
+
+def test_chart_data_cache_prunes_expired_entries_on_get():
+    """An expired entry must not keep occupying a slot in the bounded
+    cache -- otherwise it can cause a still-valid entry to get LRU-evicted
+    early instead."""
+    cache = _ChartDataCache()
+    cache.set("activity-stale", [])
+    cache._entries["activity-stale"].expires_at = time.monotonic() - 1  # force expiry
+
+    assert cache.get("activity-stale") is None
+    assert "activity-stale" not in cache._entries
 
 
 @pytest.mark.asyncio

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -14,6 +14,7 @@ from app import create_app
 from app.auth import require_auth
 from app.config import Config
 from app.models.garmin import SegmentEffortSeriesBin, SegmentEffortSeriesResponse
+from app.routers.garmin import _CHART_DATA_CACHE_MAX_ENTRIES, _ChartDataCache
 
 
 def _activity_row(activity_id: str = "20932993811") -> dict:
@@ -744,6 +745,44 @@ async def test_get_chart_data_omits_bins_by_default(client: AsyncClient, mock_db
     query = mock_db.fetch.await_args.args[0]
     assert "WIDTH_BUCKET" not in query
     assert "ORDER BY timestamp ASC" in query
+
+
+@pytest.mark.asyncio
+async def test_get_chart_data_caches_unbinned_series(client: AsyncClient, mock_db):
+    """The unbinned path is cached per activity_id -- garmin_track_points
+    rows are never mutated once synced, so a repeat request for the same
+    activity shouldn't pay for the full scan+fetch again (New Relic: this
+    was otel-data-api's slowest recurring query, up to ~3.9s).
+    """
+    mock_db.fetchval.return_value = 1
+    mock_db.fetch.return_value = [_chart_row()]
+
+    first = await client.get("/api/v1/garmin/activities/20932993811/chart-data")
+    second = await client.get("/api/v1/garmin/activities/20932993811/chart-data")
+
+    assert first.status_code == second.status_code == 200
+    assert first.json() == second.json()
+    assert mock_db.fetch.await_count == 1
+
+    # A different activity still triggers its own fetch (not a cache hit).
+    await client.get("/api/v1/garmin/activities/99999999999/chart-data")
+    assert mock_db.fetch.await_count == 2
+
+    # bins requests bypass the unbinned cache entirely -- always fresh.
+    await client.get("/api/v1/garmin/activities/20932993811/chart-data?bins=500")
+    assert mock_db.fetch.await_count == 3
+
+
+def test_chart_data_cache_evicts_oldest_beyond_max_entries():
+    """Bounded so many distinct activities viewed over time can't grow the
+    per-process cache unboundedly."""
+    cache = _ChartDataCache()
+
+    for i in range(_CHART_DATA_CACHE_MAX_ENTRIES + 1):
+        cache.set(f"activity-{i}", [])
+
+    assert cache.get("activity-0") is None  # oldest entry evicted
+    assert cache.get(f"activity-{_CHART_DATA_CACHE_MAX_ENTRIES}") == []  # newest still present
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a per-process, TTL + bounded-size cache for the unbinned `/activities/{id}/chart-data` response, keyed by `activity_id`

## Why
New Relic slow-query analysis (investigating `service.name:"otel-data-api"` slow SQL) found this was the most consistently slow query — avg 251ms but p95 1.0s and max 3.9s across 72 calls/24h — and the only one of the four patterns investigated that's genuinely user-facing (activity detail page chart rendering) rather than a background job.

The existing `bins` downsampling param isn't a fix here: `otel-data-ui` deliberately requests the full, unbinned series for chart accuracy (see the comment at the call site: "Full-resolution points for accurate time-series charts"), so trading resolution for speed isn't on the table without revisiting that decision.

`garmin_track_points` rows are never mutated once synced — grep confirms no `INSERT`/`UPDATE`/`DELETE` against that table anywhere in this service; writes only come from the separate `garmin-sync` service, and only ever insert new activities. A short-TTL (15 min), bounded-size (64 entries, LRU-evicted) cache carries no meaningful staleness risk while eliminating the repeat full-table-scan + row-to-Pydantic construction cost for popular/recently-viewed activities. Follows this codebase's existing cache conventions (`_StatusCache`/`_MvMetricsCache` in `geocoding.py`).

## Test plan
- [x] New tests: cache hit avoids a second `db.fetch`, a different activity still fetches fresh, `bins` requests bypass the cache, LRU eviction at max size
- [x] Full suite: 284 passed, 2 skipped (unrelated), 97.6% coverage on the changed file
- [x] `ruff`, `mypy`, `pyright`, pre-commit all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)