### PR TITLE
ci(renovate): match opentelemetry group by explicit names, not regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,10 +48,15 @@
       "groupSlug": "pydantic"
     },
     {
-      "description": "Group ALL OpenTelemetry packages (core + instrumentation) into one PR. They must move in lockstep: opentelemetry-sdk and the instrumentation packages each pin a matching opentelemetry-semantic-conventions, so bumping them in separate PRs causes pip ResolutionImpossible.",
+      "description": "Group ALL OpenTelemetry packages (core + instrumentation) into one PR. They must move in lockstep: opentelemetry-sdk and the instrumentation packages each pin a matching opentelemetry-semantic-conventions, so bumping them in separate PRs causes pip ResolutionImpossible. Explicit names (not a /^opentelemetry-/ regex) to match every other group in this file, and because the regex form silently failed to keep instrumentation-asyncpg/fastapi/httpx grouped with core across two release cycles (see otel-data-api#173) -- if a new opentelemetry-* package is added to requirements.txt, add it here too.",
       "matchManagers": ["pip_requirements"],
       "matchPackageNames": [
-        "/^opentelemetry-/"
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "opentelemetry-exporter-otlp-proto-grpc",
+        "opentelemetry-instrumentation-asyncpg",
+        "opentelemetry-instrumentation-fastapi",
+        "opentelemetry-instrumentation-httpx"
       ],
       "groupName": "opentelemetry",
       "groupSlug": "opentelemetry"


### PR DESCRIPTION
## Summary
- Replace the `/^opentelemetry-/` regex in the `opentelemetry` packageRule with an explicit `matchPackageNames` list

## Why
Every other group in `renovate.json` (fastapi-stack, pydantic, database-drivers, auth, aws-sdk, test-tooling, lint-tooling, observability) uses an explicit list — `opentelemetry` was the one exception using a regex.

That regex silently failed to keep the instrumentation packages grouped with core across two release cycles: PR #173 got stuck for over a month because `opentelemetry-sdk` kept bumping (1.42.1 → 1.43.0 → 1.44.0) in the PR while `opentelemetry-instrumentation-asyncpg/fastapi/httpx` never did, even though PyPI shows the upstream project releasing these in exact lockstep pairs (same timestamp, both 2026-06-24 and again 2026-07-16). The group rule was specifically added in #151 for this exact lockstep-versioning problem, so this is a real regression in the safeguard, not a one-off.

Switching to explicit names removes any doubt about whether the regex is matching as intended.

## Test plan
- [x] `renovate-config-validator renovate.json` passes
- [x] Valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)