### PR TITLE
ci: skip lint/test/build/docker jobs on draft PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,11 @@ on:
         type: boolean
   pull_request:
     branches: [master, develop]
+    # Explicit types (GitHub's default omits ready_for_review): without
+    # this, marking a draft "ready for review" wouldn't re-trigger the
+    # workflow unless a new commit was also pushed, leaving the required
+    # checks in their draft-skipped (passing) state through a merge.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   IMAGE_NAME: stuartshay/otel-data-api
@@ -27,6 +32,7 @@ jobs:
   build:
     name: Build and Push
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,17 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
+    # Explicit types (GitHub's default omits ready_for_review): without
+    # this, marking a draft "ready for review" wouldn't re-trigger the
+    # workflow unless a new commit was also pushed, leaving the required
+    # checks in their draft-skipped (passing) state through a merge.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   pre-commit:
     name: Pre-commit Checks
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -39,6 +45,7 @@ jobs:
   test:
     name: Python Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     services:
       postgres:
         image: postgres:18-alpine
@@ -119,6 +126,7 @@ jobs:
   docker-lint:
     name: Dockerfile Lint
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -132,6 +140,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Skip Pre-commit Checks, Python Tests, Dockerfile Lint, Security Scan, and Docker build-and-push when the triggering PR is a draft
- Add `ready_for_review` to both workflows' `pull_request` trigger types

## Why
Same pattern as [otel-data-gateway#240](https://github.com/stuartshay/otel-data-gateway/pull/240): Renovate opens major-version bump PRs as drafts when they need manual review, and every rebase push re-ran the full pipeline (including the Docker buildx job) for a result that can't change until the underlying blocker is resolved.

## Is this safe for required status checks?
Branch protection requires `Pre-commit Checks`, `Python Tests`, and `Build and Push`. GitHub doesn't block merging on a *conditionally-skipped* required check, and a draft PR can't be merged at all regardless. `ready_for_review` is added explicitly to both workflows' trigger types since GitHub's default (`[opened, synchronize, reopened]`) omits it — without that, marking a draft ready without also pushing a new commit would leave the required checks in their draft-skipped (passing) state through a merge (caught by Copilot review on the gateway PR this mirrors).

## Test plan
- [x] YAML validated, `pre-commit` (including the actionlint-style workflow lint hook) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)