### PR TITLE
fix(garmin): pick shortest crossing pairing for segment route recovery

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1620,10 +1620,18 @@ _SEGMENT_ROUTE_LATERAL = """
             FROM crossings
         ),
         proximity_bounds AS (
+            -- Shortest (not first-chronological) start/end pairing: an
+            -- activity that passes near the start/end points more than once
+            -- (e.g. the segment ridden once mid-ride, plus an incidental
+            -- pass-by elsewhere in a long route) pairs its first start with
+            -- whichever end comes next overall, which can be a crossing
+            -- hours later from a completely different part of the ride.
+            -- The shortest pairing is the one actually bounded by the
+            -- corridor tolerance on both ends, so it's the plausible match.
             SELECT s_ts, e_ts
             FROM proximity_bounds_raw
             WHERE is_start AND e_ts IS NOT NULL
-            ORDER BY s_ts ASC
+            ORDER BY (e_ts - s_ts) ASC
             LIMIT 1
         ),
         chosen_bounds AS (

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1631,7 +1631,7 @@ _SEGMENT_ROUTE_LATERAL = """
             SELECT s_ts, e_ts
             FROM proximity_bounds_raw
             WHERE is_start AND e_ts IS NOT NULL
-            ORDER BY (e_ts - s_ts) ASC
+            ORDER BY (e_ts - s_ts) ASC, s_ts ASC
             LIMIT 1
         ),
         chosen_bounds AS (

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -2035,6 +2035,28 @@ async def test_segment_route_lateral_prefers_lap_boundaries(client: AsyncClient,
 
 
 @pytest.mark.asyncio
+async def test_segment_route_proximity_prefers_shortest_pairing(client: AsyncClient, mock_db):
+    """The proximity fallback must pick the shortest start/end pairing.
+
+    An activity that passes near a point-to-point segment's start and end
+    coordinates more than once (e.g. an incidental pass-by elsewhere in a
+    long ride, plus the actual short traversal) produces multiple start
+    crossings. Pairing the chronologically-first start with whichever end
+    crossing follows it can grab an end from a much later, unrelated pass --
+    a route spanning hours of the ride instead of the real few-minute
+    traversal. Ordering candidate pairings by duration instead of by start
+    time picks the plausible (shortest) one.
+    """
+    mock_db.fetch.return_value = [_segment_row(1)]
+
+    response = await client.get("/api/v1/garmin/segments")
+
+    assert response.status_code == 200
+    query, *_ = mock_db.fetch.await_args.args
+    assert "ORDER BY (e_ts - s_ts) ASC" in query
+
+
+@pytest.mark.asyncio
 async def test_list_segments_null_route(client: AsyncClient, mock_db):
     mock_db.fetch.return_value = [_segment_row(1, route=None)]
 

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -2053,7 +2053,12 @@ async def test_segment_route_proximity_prefers_shortest_pairing(client: AsyncCli
 
     assert response.status_code == 200
     query, *_ = mock_db.fetch.await_args.args
-    assert "ORDER BY (e_ts - s_ts) ASC" in query
+    # Duration first, then start time as a tie-breaker so two candidate
+    # pairings of equal duration still resolve deterministically.
+    assert "ORDER BY (e_ts - s_ts) ASC, s_ts ASC" in query
+    # Guard against the old chronological-first selection being
+    # reintroduced elsewhere in the query.
+    assert "ORDER BY s_ts ASC" not in query
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The segments-listing page's map thumbnail for "42nd Street to Pier 57" rendered zoomed way out (Teaneck, NJ through NYC) instead of the actual ~1.35mi Manhattan segment. The segment detail page's map rendered correctly for the same segment.
- Root cause: this segment has no `source_lap_index`, so `_SEGMENT_ROUTE_LATERAL`'s route recovery falls back to proximity-based GPS crossing detection. Its source activity passed near the segment's start and end coordinates **twice** during one long ride — once for the real ~7 minute traversal, once incidentally elsewhere in the route. The `proximity_bounds` CTE paired the chronologically-first start crossing with the next later end crossing regardless of which pass it came from, producing a bogus 4.5-hour (16123s) time window that pulled in GPS points from across the whole ride instead of the real ~408s traversal.
- The detail page is unaffected only because it derives its route independently (nearest-point slicing over the raw track, `getSegmentRoutePoints` in `otel-data-ui`), not because the underlying data bug doesn't apply to it.

## Fix
One-line change in `proximity_bounds`: order candidate start/end pairings by duration instead of by start time, so the shortest (most plausible) pairing wins:

```sql
-- was: ORDER BY s_ts ASC
ORDER BY (e_ts - s_ts) ASC
```

## Verified against production data
- Manually ran the full `_SEGMENT_ROUTE_LATERAL` query (old vs. new `ORDER BY`) against the real DB for segment 18: old picks the 16123s bogus window (bounding box spans NJ to NYC), new picks the 408s real window (bounding box tightly matches the segment's actual start/end coordinates: lat 40.7445–40.7620, lon -74.0087 to -74.0012).
- Checked all 16 segments in the DB: of the 10 using this proximity fallback (no lap/climb index), only segment 18 has more than one candidate start/end pairing. The other 9 have exactly one candidate each, so this change is a no-op for them (verified old-pick == new-pick, identical duration, for every one) — it only changes behavior for the genuinely ambiguous case.

## Test plan
- [x] Added `test_segment_route_proximity_prefers_shortest_pairing` asserting the new `ORDER BY` clause
- [x] `pytest tests/test_garmin.py` — 115/115 passed
- [x] `pre-commit run` — passed
- [x] Verified query output directly against production data (see above) — both the buggy old behavior and the fixed new behavior were reproduced and compared