### PR TITLE
fix(garmin): compute segment distance_meters server-side from GPS

### DIFF
--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1738,10 +1738,18 @@ async def create_segment(
         body.source_activity_id,
         body.source_lap_index,
     )
+    if computed is None:
+        # The query above always yields exactly one row (a single-row `s`
+        # CTE, LEFT JOINed) -- a missing row means something is
+        # unexpectedly wrong with the DB, not that GPS data is merely
+        # unavailable. Treat it as a server error rather than silently
+        # falling back to the client-supplied distance_meters, which would
+        # defeat the point of computing it server-side.
+        raise HTTPException(status_code=500, detail="Failed to compute segment distance")
     distance_meters = (
         computed["route_length_meters"]
-        if computed and computed["route_length_meters"] is not None
-        else (computed["straight_line_meters"] if computed else body.distance_meters)
+        if computed["route_length_meters"] is not None
+        else computed["straight_line_meters"]
     )
 
     row = await db.fetchrow(

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -1531,9 +1531,13 @@ _SEGMENT_SELECT_COLUMNS = (
 )
 
 # Recover each segment's real path from its source activity GPS track and
-# return a PostGIS-simplified array of ordered [latitude, longitude] pairs.
-# Yields NULL route when the segment has no source activity or no matchable
-# slice, in which case the client falls back to a straight start->end line.
+# return a PostGIS-simplified array of ordered [latitude, longitude] pairs,
+# plus the route's real length in meters before simplification (route_length_meters)
+# -- used by create_segment to compute distance_meters server-side instead
+# of trusting the client. Yields NULL route/length when the segment has no
+# source activity or no matchable slice, in which case the client falls
+# back to a straight start->end line (and create_segment falls back to the
+# straight-line ST_Distance between the two points).
 #
 # When the segment was saved from a recorded lap (source_lap_index), that
 # lap's own start_time/duration_seconds give the exact slice boundaries --
@@ -1641,10 +1645,7 @@ _SEGMENT_ROUTE_LATERAL = """
             FULL OUTER JOIN proximity_bounds ON TRUE
         ),
         line AS (
-            SELECT ST_Simplify(
-                       ST_MakeLine(ST_MakePoint(t.longitude, t.latitude) ORDER BY t.timestamp ASC),
-                       0.00005
-                   ) AS geom
+            SELECT ST_MakeLine(ST_MakePoint(t.longitude, t.latitude) ORDER BY t.timestamp ASC) AS geom
             FROM public.garmin_track_points t, chosen_bounds
             WHERE t.activity_id = s.source_activity_id
               AND t.latitude IS NOT NULL
@@ -1652,15 +1653,23 @@ _SEGMENT_ROUTE_LATERAL = """
               AND chosen_bounds.s_ts IS NOT NULL
               AND chosen_bounds.e_ts IS NOT NULL
               AND t.timestamp BETWEEN chosen_bounds.s_ts AND chosen_bounds.e_ts
+        ),
+        -- Simplified only for the point array returned for map rendering;
+        -- route_length_meters below is measured on the line before simplification so
+        -- corner-cutting from ST_Simplify doesn't shrink the reported
+        -- distance.
+        simplified_line AS (
+            SELECT ST_Simplify(geom, 0.00005) AS geom FROM line
         )
         SELECT array_agg(
                    ARRAY[ST_Y((dp).geom), ST_X((dp).geom)]
                    ORDER BY (dp).path
-               ) AS route
-        FROM line
-        CROSS JOIN LATERAL ST_DumpPoints(line.geom) AS dp
-        WHERE line.geom IS NOT NULL
-          AND ST_NPoints(line.geom) >= 2
+               ) AS route,
+               (SELECT ST_Length(geom::geography) FROM line) AS route_length_meters
+        FROM simplified_line AS sl
+        CROSS JOIN LATERAL ST_DumpPoints(sl.geom) AS dp
+        WHERE sl.geom IS NOT NULL
+          AND ST_NPoints(sl.geom) >= 2
     ) r ON s.source_activity_id IS NOT NULL
 """
 
@@ -1695,8 +1704,46 @@ async def create_segment(
     body: GarminSegmentCreate,
     _user: Annotated[dict, Depends(require_auth)],
 ) -> GarminSegment:
-    """Save a new segment (path) from a climb, lap, or manual selection (auth required)."""
+    """Save a new segment (path) from a climb, lap, or manual selection (auth required).
+
+    distance_meters is computed server-side from GPS data rather than
+    trusting the client -- Garmin devices can report a lap's own recorded
+    distance (garmin_activity_laps.distance_meters) that disagrees sharply
+    with that same lap's actual track points (e.g. GPS degradation near
+    large structures during an auto-lap-by-distance trigger), and the
+    client (a "save this lap/climb as a segment" button) otherwise passes
+    that value straight through with no validation.
+    """
     db = request.app.state.db
+    computed = await db.fetchrow(
+        "WITH s AS ("
+        "    SELECT $1::double precision AS start_longitude, "
+        "           $2::double precision AS start_latitude, "
+        "           $3::double precision AS end_longitude, "
+        "           $4::double precision AS end_latitude, "
+        "           $5::double precision AS match_tolerance_meters, "
+        "           $6::varchar AS source_activity_id, "
+        "           $7::int AS source_lap_index"
+        ") "
+        "SELECT r.route_length_meters, "
+        "       ST_Distance("
+        "           ST_MakePoint($1, $2)::geography, ST_MakePoint($3, $4)::geography"
+        "       ) AS straight_line_meters "
+        f"FROM s {_SEGMENT_ROUTE_LATERAL}",
+        body.start_longitude,
+        body.start_latitude,
+        body.end_longitude,
+        body.end_latitude,
+        body.match_tolerance_meters,
+        body.source_activity_id,
+        body.source_lap_index,
+    )
+    distance_meters = (
+        computed["route_length_meters"]
+        if computed and computed["route_length_meters"] is not None
+        else (computed["straight_line_meters"] if computed else body.distance_meters)
+    )
+
     row = await db.fetchrow(
         "INSERT INTO public.garmin_segments "
         "(name, sport, start_latitude, start_longitude, end_latitude, end_longitude, "
@@ -1709,7 +1756,7 @@ async def create_segment(
         body.start_longitude,
         body.end_latitude,
         body.end_longitude,
-        body.distance_meters,
+        distance_meters,
         body.match_tolerance_meters,
         body.source_activity_id,
         body.source_lap_index,

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -1936,7 +1936,17 @@ def _segment_row(segment_id: int = 1, route: list[list[float]] | None = None) ->
 
 @pytest.mark.asyncio
 async def test_create_segment(client: AsyncClient, mock_db):
-    mock_db.fetchrow.return_value = _segment_row(7)
+    """distance_meters comes from the server-computed GPS route length.
+
+    Not from whatever the client sends -- Garmin devices can report a lap's
+    own distance_meters wildly wrong (e.g. GPS degradation near large
+    structures during an auto-lap trigger), and the client's "save this
+    lap as a segment" button passes that value through with no validation.
+    """
+    mock_db.fetchrow.side_effect = [
+        {"route_length_meters": 550.25, "straight_line_meters": 480.0},
+        _segment_row(7),
+    ]
 
     response = await client.post(
         "/api/v1/garmin/segments",
@@ -1946,6 +1956,7 @@ async def test_create_segment(client: AsyncClient, mock_db):
             "start_longitude": -73.96104321,
             "end_latitude": 40.79002409,
             "end_longitude": -73.96422816,
+            "distance_meters": 8046.72,
             "source_activity_id": "23493313338",
             "source_climb_index": 0,
         },
@@ -1956,9 +1967,38 @@ async def test_create_segment(client: AsyncClient, mock_db):
     assert body["id"] == 7
     assert body["name"] == "Harlem Hill"
     assert body["match_tolerance_meters"] == 35.0
-    query, *params = mock_db.fetchrow.await_args.args
-    assert "INSERT INTO public.garmin_segments" in query
-    assert params[0] == "Harlem Hill"
+    assert mock_db.fetchrow.await_count == 2
+    compute_query, *_ = mock_db.fetchrow.await_args_list[0].args
+    assert "LEFT JOIN LATERAL" in compute_query
+    assert "route_length_meters" in compute_query
+    insert_query, *insert_params = mock_db.fetchrow.await_args_list[1].args
+    assert "INSERT INTO public.garmin_segments" in insert_query
+    assert insert_params[0] == "Harlem Hill"
+    assert insert_params[6] == 550.25
+
+
+@pytest.mark.asyncio
+async def test_create_segment_falls_back_to_straight_line(client: AsyncClient, mock_db):
+    """When no route can be recovered, fall back to the straight-line distance."""
+    mock_db.fetchrow.side_effect = [
+        {"route_length_meters": None, "straight_line_meters": 480.0},
+        _segment_row(7),
+    ]
+
+    response = await client.post(
+        "/api/v1/garmin/segments",
+        json={
+            "name": "Manual Range",
+            "start_latitude": 40.79366846,
+            "start_longitude": -73.96104321,
+            "end_latitude": 40.79002409,
+            "end_longitude": -73.96422816,
+        },
+    )
+
+    assert response.status_code == 201
+    insert_query, *insert_params = mock_db.fetchrow.await_args_list[1].args
+    assert insert_params[6] == 480.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -2002,6 +2002,33 @@ async def test_create_segment_falls_back_to_straight_line(client: AsyncClient, m
 
 
 @pytest.mark.asyncio
+async def test_create_segment_errors_when_distance_computation_returns_no_row(client: AsyncClient, mock_db):
+    """A missing row from the distance-computation query is a server error.
+
+    Not a reason to fall back to the client-supplied distance_meters --
+    that would defeat the point of computing it server-side. The query
+    always yields exactly one row (a single-row `s` CTE, LEFT JOINed), so
+    None here means something is unexpectedly wrong with the DB.
+    """
+    mock_db.fetchrow.side_effect = [None]
+
+    response = await client.post(
+        "/api/v1/garmin/segments",
+        json={
+            "name": "Harlem Hill",
+            "start_latitude": 40.79366846,
+            "start_longitude": -73.96104321,
+            "end_latitude": 40.79002409,
+            "end_longitude": -73.96422816,
+            "distance_meters": 8046.72,
+        },
+    )
+
+    assert response.status_code == 500
+    assert mock_db.fetchrow.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_list_segments(client: AsyncClient, mock_db):
     mock_db.fetch.return_value = [_segment_row(1), _segment_row(2)]
 


### PR DESCRIPTION
## Summary

`POST /segments` accepted `distance_meters` directly from the client with zero server-side validation. The client (`otel-data-ui`'s "save this lap/climb as a segment" button, `ActivityLapsTable.tsx:146`) passes the source lap's own recorded `distance_meters` straight through unmodified.

**That field can't be trusted.** Confirmed on segment 5 ("Yankee Stadium", `source_lap_index=3`): the lap's recorded `distance_meters` was `8046.72` (exactly 5.00mi) for **6 consecutive laps** in that ride. This is genuine native Garmin FIT lap data, not a bug in our own `derive_activity_laps` fallback (`raw_payload->>'source'` is empty — the synthetic-lap path always sets it to `'derived_track_points'`). But the same time window's actual GPS track (verified two independent ways — odometer delta from `garmin_track_points.distance`, and `ST_Length` of the recovered route) shows only **~1.5km** traveled. Likely GPS degradation near a large structure (Yankee Stadium itself) during an auto-lap-by-distance trigger.

**Consequence beyond the wrong display value**: the inflated `distance_meters` fed `get_segment_efforts`'s `min_distance_km` sanity filter (`distance_meters * 0.7 = 5.6km`), which silently required 5.6km of real traversal for what's actually a ~1.5km segment. `GET /segments/5/efforts` returned **0 results** before this fix — every real ride across this segment was being filtered out.

## Fix
`create_segment` now computes `distance_meters` itself, using the same `_SEGMENT_ROUTE_LATERAL` machinery already used to serve the `route` field (extended to also return `route_length_meters`, measured **before** `ST_Simplify` so corner-cutting doesn't shrink the reported distance), falling back to the straight-line `ST_Distance` between the two points when no route can be recovered — matching the existing `route` field's own null-route fallback behavior.

## Verified
- Ran the new query directly against production for segment 5's parameters: computed `1531.15m`, matching my independent manual calculation exactly.
- Verified the straight-line fallback path (no `source_activity_id`) returns `NULL` route length as expected.
- **Manually corrected the two affected segments in production** after this fix (Yankee Stadium: `8046.72m` → `1531.15m`; Central Park 2: `8046.72m` → `6513.82m`) — verified against GPS data before applying. Confirmed the other 14 segments shift by only a few meters under the same computation (GPS/simplification noise), i.e. this was isolated to these two, not systemic.
- **Before/after on the actual bug report**: `GET /segments/5/efforts` went from `0` results to `10`, all with realistic ~1.4-1.5km distances and ~8-9 minute durations.

## Test plan
- [x] Updated `test_create_segment` to assert `distance_meters` comes from the computed route length, not the client-supplied value
- [x] Added `test_create_segment_falls_back_to_straight_line` for the no-route-recoverable case
- [x] `pytest tests/test_garmin.py` — 116/116 passed
- [x] `pre-commit run` — clean
- [x] Verified the new SQL directly against production (both the route-length and straight-line-fallback code paths)
- [x] Verified `/segments/5/efforts` and `/segments/6/efforts` now return real results