### PR TITLE
perf(ci): build arm64-only, drop wasted amd64 Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,7 +126,11 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # k8s-pi5-cluster (the only deployment target) is arm64-only --
+          # confirmed via `kubectl get nodes -o jsonpath='{.status.nodeInfo.architecture}'`
+          # across all 4 nodes. Building amd64 here was pure waste (an image
+          # half that's never pulled), so only arm64 is built via QEMU.
+          platforms: linux/arm64
           push: ${{ steps.push.outputs.should_push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,7 +127,8 @@ jobs:
         with:
           context: .
           # k8s-pi5-cluster (the only deployment target) is arm64-only --
-          # confirmed via `kubectl get nodes -o jsonpath='{.status.nodeInfo.architecture}'`
+          # confirmed via
+          # `kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.architecture}'`
           # across all 4 nodes. Building amd64 here was pure waste (an image
           # half that's never pulled), so only arm64 is built via QEMU.
           platforms: linux/arm64


### PR DESCRIPTION
## Summary
- k8s-pi5-cluster (the only deployment target) is arm64-only — confirmed via `kubectl get nodes`, all 4 nodes (`k8s-pi5-master-01`, `k8s-pi5-node-01/02/03`) report `arm64`
- Every multi-arch Docker build here has been building `linux/amd64,linux/arm64`, but the amd64 half is never pulled by anything — pure wasted CI runner-minutes
- Drops to `linux/arm64` only; QEMU is still needed (GitHub-hosted runners are amd64) but the workflow no longer does double the build+push work

## Expected impact
Roughly halves this workflow's `Build and Push` step, since it no longer builds+pushes an image that's never deployed.

## Test plan
- [x] YAML syntax validated
- [x] Pre-commit hooks passed
- [ ] Confirm the next master build only produces/pushes an arm64 manifest and that Argo CD/k8s can still pull it (should be a no-op change from the cluster's perspective, since it only ever consumed the arm64 layer anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)