### PR TITLE
feat(garmin): add activity trim endpoint

### DIFF
--- a/app/models/garmin.py
+++ b/app/models/garmin.py
@@ -85,6 +85,16 @@ class GarminActivity(BaseModel):
     uploaded_at: datetime | None = Field(default=None, description="UTC timestamp when the FIT file was uploaded")
     track_point_count: int | None = Field(default=None, description="Number of GPS track points in this activity")
     device: GarminDevice | None = Field(default=None, description="Recording device metadata")
+    is_modified: bool = Field(
+        default=False, description="True once this activity has been edited (e.g. trimmed) from Garmin's original"
+    )
+    modified_at: datetime | None = Field(default=None, description="UTC timestamp of the first modification, if any")
+    trim_status: str | None = Field(
+        default=None,
+        description="NULL under normal operation; trim_pending while Garmin Connect sync is in flight; "
+        "trim_failed if the last attempt errored (see trim_error)",
+    )
+    trim_error: str | None = Field(default=None, description="Error from the last failed Garmin Connect trim attempt")
 
     @classmethod
     def from_row(cls, row: Mapping[str, Any]) -> GarminActivity:
@@ -602,6 +612,17 @@ class GarminActivityManualUpdate(BaseModel):
                 }
             ]
         },
+    }
+
+
+class GarminActivityTrimRequest(BaseModel):
+    """Request body to trim trailing track points from a Garmin activity."""
+
+    cutoff_timestamp: datetime = Field(description="UTC timestamp; track points at or after this instant are removed")
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {"examples": [{"cutoff_timestamp": "2026-08-02T23:28:00+00:00"}]},
     }
 
 

--- a/app/routers/garmin.py
+++ b/app/routers/garmin.py
@@ -26,6 +26,7 @@ from app.models.garmin import (
     GarminActivityManualUpdate,
     GarminActivitySensor,
     GarminActivityTotal,
+    GarminActivityTrimRequest,
     GarminActivityWeather,
     GarminActivityWeatherHourly,
     GarminChartPoint,
@@ -94,6 +95,7 @@ ACTIVITY_BY_ID_SELECT = (
     "a.total_descent_m, a.total_distance, a.avg_pace, a.device_manufacturer, "
     "a.avg_temperature_c, a.min_temperature_c, a.max_temperature_c, "
     "a.total_elapsed_time, a.total_timer_time, a.created_at, a.uploaded_at, "
+    "a.is_modified, a.modified_at, a.trim_status, a.trim_error, "
     "a.device_id, d.manufacturer AS dev_manufacturer, "
     "d.garmin_product AS dev_garmin_product, d.model AS dev_model, "
     "d.software_version AS dev_software_version, "
@@ -323,6 +325,7 @@ async def list_activities(
         f"a.device_manufacturer, a.avg_temperature_c, a.min_temperature_c, "
         f"a.max_temperature_c, a.total_elapsed_time, a.total_timer_time, "
         f"a.created_at, a.uploaded_at, "
+        f"a.is_modified, a.modified_at, a.trim_status, a.trim_error, "
         f"a.device_id, d.manufacturer AS dev_manufacturer, "
         f"d.garmin_product AS dev_garmin_product, d.model AS dev_model, "
         f"d.software_version AS dev_software_version, "
@@ -496,6 +499,103 @@ async def patch_activity(
     )
     if not updated:
         raise HTTPException(status_code=404, detail=ACTIVITY_NOT_FOUND)
+
+    row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
+    if not row:
+        raise HTTPException(status_code=404, detail=ACTIVITY_NOT_FOUND)
+    return GarminActivity.from_row(row)
+
+
+@router.post(
+    "/activities/{activity_id}/trim",
+    responses={
+        **AUTH_RESPONSES,
+        400: {"description": "Cutoff timestamp out of range"},
+        404: {"description": ACTIVITY_NOT_FOUND},
+    },
+)
+async def trim_activity(
+    request: Request,
+    body: Annotated[GarminActivityTrimRequest, fastapi.Body()],
+    activity_id: Annotated[str, fastapi.Path(description=DESC_ACTIVITY_ID, examples=["20932993811"])],
+    _user: Annotated[dict, Depends(require_auth)],
+) -> GarminActivity:
+    """Delete trailing track points at/after a cutoff (auth required).
+
+    Removes local ``garmin_track_points`` at or after ``cutoff_timestamp``,
+    shrinks the activity's totals to match the kept range, and marks
+    ``trim_status = 'trim_pending'`` so the garmin-sync agent deletes and
+    re-uploads a trimmed FIT file on Garmin Connect asynchronously (mirrors
+    the ``delete_segment`` hand-off pattern). ``is_modified``/``modified_at``
+    are set permanently on first trim, independent of that async status.
+    """
+    db = request.app.state.db
+
+    activity_row = await db.fetchrow(
+        "SELECT start_time, end_time, modified_at FROM public.garmin_activities WHERE activity_id = $1",
+        activity_id,
+    )
+    if activity_row is None:
+        raise HTTPException(status_code=404, detail=ACTIVITY_NOT_FOUND)
+
+    start_time = activity_row["start_time"]
+    end_time = activity_row["end_time"]
+    cutoff = body.cutoff_timestamp
+    if (start_time is not None and cutoff <= start_time) or (end_time is not None and cutoff >= end_time):
+        raise HTTPException(status_code=400, detail="cutoff_timestamp must fall strictly within the activity")
+
+    async with db.pool.acquire() as conn, conn.transaction():
+        await conn.execute(
+            "DELETE FROM public.garmin_track_points WHERE activity_id = $1 AND timestamp >= $2",
+            activity_id,
+            cutoff,
+        )
+        totals = await conn.fetchrow(
+            "SELECT MAX(timestamp) AS end_time, MAX(distance) AS total_distance, "
+            "MAX(speed) AS max_speed, AVG(speed) AS avg_speed "
+            "FROM public.garmin_track_points WHERE activity_id = $1",
+            activity_id,
+        )
+
+        def _as_float(value: Any) -> float | None:
+            return float(value) if value is not None else None
+
+        new_end_time = totals["end_time"] if totals else None
+        new_total_distance = _as_float(totals["total_distance"]) if totals else None
+        new_max_speed = _as_float(totals["max_speed"]) if totals else None
+        new_avg_speed = _as_float(totals["avg_speed"]) if totals else None
+        new_elapsed = (new_end_time - start_time).total_seconds() if new_end_time and start_time else None
+
+        await conn.execute(
+            "UPDATE public.garmin_activities SET "
+            "end_time = $2, total_distance = $3, distance_km = $4, "
+            "total_elapsed_time = $5, duration_seconds = $6, "
+            "max_speed = $7, max_speed_kmh = $8, avg_speed = $9, avg_speed_kmh = $10, "
+            "trim_status = 'trim_pending', trim_cutoff_timestamp = $11, trim_error = NULL, "
+            "is_modified = TRUE, modified_at = COALESCE(modified_at, NOW()) "
+            "WHERE activity_id = $1",
+            activity_id,
+            new_end_time,
+            new_total_distance,
+            (new_total_distance / 1000.0) if new_total_distance is not None else None,
+            new_elapsed,
+            int(new_elapsed) if new_elapsed is not None else None,
+            new_max_speed,
+            (new_max_speed * 3.6) if new_max_speed is not None else None,
+            new_avg_speed,
+            (new_avg_speed * 3.6) if new_avg_speed is not None else None,
+            cutoff,
+        )
+
+    config = request.app.state.config
+    base_url = config.garmin_sync_base_url.rstrip("/")
+    try:
+        async with httpx.AsyncClient(base_url=base_url, timeout=config.garmin_sync_timeout_seconds) as client:
+            await client.post(f"/internal/trim/trigger?activity_id={activity_id}")
+    except httpx.HTTPError:
+        # Non-fatal: the scheduled poll loop in garmin-sync will pick up
+        # trim_pending activities as a safety net if this trigger fails.
+        logger.warning("garmin_trim_trigger_failed", garmin_activity_id=activity_id)
 
     row = await db.fetchrow(ACTIVITY_BY_ID_SELECT, activity_id)
     if not row:


### PR DESCRIPTION
## Summary
- Adds `POST /garmin/activities/{activity_id}/trim`: deletes trailing GPS track points at/after a cutoff timestamp, recomputes activity totals for the kept range, and marks `trim_status=trim_pending` so garmin-sync can asynchronously delete and re-upload the shortened FIT file on Garmin Connect.
- Sets `is_modified`/`modified_at` as a permanent record that the activity has been edited.
- Adds the new fields to `GarminActivity`'s read model (`ACTIVITY_BY_ID_SELECT` and the list-activities query).

## Stack (deploy in this order)
1. [homelab-database-migrations: add trim status and modified-flag columns](https://github.com/stuartshay/homelab-database-migrations/pull/71) — schema (required before this PR)
2. **This PR** — otel-data-api
3. [otel-data-gateway: add trimGarminActivity mutation](https://github.com/stuartshay/otel-data-gateway/pull/256)
4. [otel-agents: trim activities on Garmin Connect](https://github.com/stuartshay/otel-agents/pull/171)

(GitHub's stacked-PR feature is single-repo only, so this isn't a literal GitHub stack — just 4 PRs across 4 repos that must merge/deploy in this order since each depends on the previous one's schema/API surface.)

## Test plan
- [x] Ran locally against `owntracks_dev` (uvicorn + dev DB): out-of-range cutoff rejected (400), valid trim shrinks points/totals correctly, `is_modified`/`modified_at` set on first trim and stable on repeat trims
- [x] `ruff check` clean
- [ ] Requires migration 000039 applied before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)